### PR TITLE
Updated hosts files, removed metrics, logging exports from NFS server

### DIFF
--- a/ansible/configs/ocp-ha-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-lab/env_vars.yml
@@ -101,11 +101,8 @@ nfs_pvs: /dev/xvdb
 nfs_export_path: /srv/nfs
 
 nfs_shares:
-  - logging
-  - metrics
   - jenkins
   - nexus
-  - justanother
 
 ################################################################################
 #### CLOUD PROVIDER: AWS SPECIFIC VARIABLES

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.j2
@@ -11,12 +11,13 @@ ansible_ssh_user={{ansible_ssh_user}}
 ###########################################################################
 ### OpenShift Basic Vars
 ###########################################################################
-openshift_metrics_image_version=v{{ repo_version }}
-#openshift_image_tag=v{{ repo_version }}
-openshift_release={{ osrelease }}
-#docker_version="{{docker_version}}"
+
 deployment_type=openshift-enterprise
 containerized=false
+# openshift_metrics_image_version=v{{ repo_version }}
+# openshift_image_tag=v{{ repo_version }}
+# openshift_release={{ osrelease }}
+# docker_version="{{docker_version}}"
 
 # default project node selector
 osm_default_node_selector='env=users'
@@ -25,7 +26,6 @@ osm_default_node_selector='env=users'
 ###########################################################################
 ### OpenShift Optional Vars
 ###########################################################################
-
 
 # Enable cockpit
 osm_use_cockpit=true
@@ -44,10 +44,7 @@ openshift_master_cluster_public_hostname={{master_lb_dns}}
 openshift_master_default_subdomain={{cloudapps_suffix}}
 openshift_master_overwrite_named_certificates={{openshift_master_overwrite_named_certificates}}
 
-openshift_set_hostname=True
-
-
-
+openshift_set_hostname=true
 
 ###########################################################################
 ### OpenShift Network Vars
@@ -55,7 +52,6 @@ openshift_set_hostname=True
 
 osm_cluster_network_cidr=10.1.0.0/16
 openshift_portal_net=172.30.0.0/16
-
 
 #os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 {{multi_tenant_setting}}
@@ -65,11 +61,9 @@ openshift_portal_net=172.30.0.0/16
 ### OpenShift Authentication Vars
 ###########################################################################
 
-
-
 {% if install_idm == "ldap" %}
 
-openshift_master_identity_providers=[{'name': 'ldap', 'challenge': 'true', 'login': 'true', 'kind': 'LDAPPasswordIdentityProvider','attributes': {'id': ['dn'], 'email': ['mail'], 'name': ['cn'], 'preferredUsername': ['uid']}, 'bindDN': 'uid=ose-mwl-auth,cn=users,cn=accounts,dc=opentlc,dc=com', 'bindPassword': '{{bindPassword}}', 'ca': 'ipa-ca.crt','insecure': 'false', 'url': 'ldaps://ipa1.opentlc.com:636/cn=users,cn=accounts,dc=opentlc,dc=com?uid'}]
+openshift_master_identity_providers=[{'name': 'ldap', 'challenge': 'true', 'login': 'true', 'kind': 'LDAPPasswordIdentityProvider','attributes': {'id': ['dn'], 'email': ['mail'], 'name': ['cn'], 'preferredUsername': ['uid']}, 'bindDN': 'uid=admin,cn=users,cn=accounts,dc=shared,dc=example,dc=opentlc,dc=com', 'bindPassword': '{{bindPassword}}', 'ca': 'ipa-ca.crt','insecure': 'false', 'url': 'ldaps://ipa.shared.example.opentlc.com:636/cn=users,cn=accounts,dc=shared,dc=example,dc=opentlc,dc=com?uid?sub?(memberOf=cn=ocp-users,cn=groups,cn=accounts,dc=shared,dc=example,dc=opentlc,dc=com)'}]
 {{openshift_master_ldap_ca_file}}
 
 {% endif %}
@@ -84,42 +78,45 @@ openshift_master_identity_providers=[{'name': 'allow_all', 'login': 'true', 'cha
 # htpasswd auth
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 # Defining htpasswd users
-#openshift_master_htpasswd_users={'user1': '<pre-hashed password>', 'user2': '<pre-hashed password>'}
+# openshift_master_htpasswd_users={'user1': '<pre-hashed password>', 'user2': '<pre-hashed password>'}
 # or
 openshift_master_htpasswd_file=/root/htpasswd.openshift
 
 {% endif %}
 
 ###########################################################################
-### OpenShift Metrics and Logging Vars
+### OpenShift Metrics Vars
 ###########################################################################
 
-# Enable cluster metrics
 openshift_hosted_metrics_deploy={{install_metrics}}
+
 openshift_hosted_metrics_storage_kind=nfs
 openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
-openshift_hosted_metrics_storage_host=support1.{{guid}}.internal
 openshift_hosted_metrics_storage_nfs_directory=/srv/nfs
 openshift_hosted_metrics_storage_nfs_options='*(rw,root_squash)'
 openshift_hosted_metrics_storage_volume_name=metrics
 openshift_hosted_metrics_storage_volume_size=10Gi
+
 openshift_hosted_metrics_public_url=https://hawkular-metrics.{{cloudapps_suffix}}/hawkular/metrics
 
-# Enable cluster logging
+###########################################################################
+#### OpenShift Logging Vars
+############################################################################
+
 openshift_hosted_logging_deploy={{install_logging}}
+
 openshift_hosted_logging_storage_kind=nfs
 openshift_hosted_logging_storage_access_modes=['ReadWriteOnce']
-openshift_hosted_logging_storage_host=support1.{{guid}}.internal
 openshift_hosted_logging_storage_nfs_directory=/srv/nfs
 openshift_hosted_logging_storage_nfs_options='*(rw,root_squash)'
 openshift_hosted_logging_storage_volume_name=logging
 openshift_hosted_logging_storage_volume_size=10Gi
+
 openshift_hosted_logging_hostname=kibana.{{cloudapps_suffix}}
 openshift_hosted_logging_elasticsearch_cluster_size=1
 openshift_master_logging_public_url=https://kibana.{{cloudapps_suffix}}
 
-
-openshift_hosted_logging_deployer_version=v{{repo_version}}
+# openshift_hosted_logging_deployer_version=v{{repo_version}}
 # This one is wrong (down arrow)
 #openshift_hosted_logging_image_version=v{{repo_version}}
 #openshift_logging_image_version=v{{repo_version}}
@@ -129,9 +126,7 @@ openshift_hosted_logging_deployer_version=v{{repo_version}}
 ###########################################################################
 
 # Configure additional projects
-openshift_additional_projects={'my-infra-project-test': {'default_node_selector': 'env=infra'}}
-
-
+# openshift_additional_projects={'my-infra-project-test': {'default_node_selector': 'env=infra'}}
 
 ###########################################################################
 ### OpenShift Router and Registry Vars
@@ -139,18 +134,20 @@ openshift_additional_projects={'my-infra-project-test': {'default_node_selector'
 
 openshift_hosted_router_selector='env=infra'
 openshift_hosted_router_replicas={{infranode_instance_count}}
-#openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
+# openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
 
 openshift_hosted_registry_selector='env=infra'
 openshift_hosted_registry_replicas={{infranode_instance_count}}
 openshift_hosted_registry_storage_kind=nfs
 openshift_hosted_registry_storage_access_modes=['ReadWriteMany']
-openshift_hosted_registry_storage_host=support1.{{guid}}.internal
 openshift_hosted_registry_storage_nfs_directory=/srv/nfs
+openshift_hosted_registry_storage_nfs_options='*(rw,root_squash)'
 openshift_hosted_registry_storage_volume_name=registry
-openshift_hosted_registry_storage_volume_size=5Gi
+openshift_hosted_registry_storage_volume_size=10Gi
 
-
+###########################################################################
+#### OpenShift Host Vars
+############################################################################
 
 [OSEv3:children]
 masters
@@ -161,24 +158,23 @@ lb
 
 [lb]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_loadbalancer') | replace('-', '_') ] %}
-loadbalancer{{loop.index}}.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+loadbalancer{{loop.index}}.{{chomped_zone_internal_dns}} host_zone={{hostvars[host]['ec2_placement']}}
 {% endfor %}
 
 [masters]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_master') | replace('-', '_') ] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+master{{loop.index}}.{{chomped_zone_internal_dns}} host_zone={{hostvars[host]['ec2_placement']}}
 {% endfor %}
 
 [etcd]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_master') | replace('-', '_') ] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+master{{loop.index}}.{{chomped_zone_internal_dns}} host_zone={{hostvars[host]['ec2_placement']}}
 {% endfor %}
-
 
 [nodes]
 ## These are the masters
 {% for host in groups[('tag_' + env_type + '-' + guid + '_master') | replace('-', '_') ] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}   ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['ec2_placement']}}'}"
+master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['ec2_placement']}}'}"
 {% endfor %}
 
 ## These are infranodes

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.j2
@@ -1,4 +1,4 @@
-[OCPlabs:vars]
+[OSEv3:vars]
 
 ###########################################################################
 ### Ansible Vars
@@ -9,14 +9,6 @@ ansible_ssh_user={{ansible_ssh_user}}
 
 
 
-[OCPlabs:children]
-masters
-etcd
-nodes
-lb
-nfs
-
-
 [OSEv3:children]
 lb
 masters
@@ -24,27 +16,25 @@ etcd
 nodes
 nfs
 
-
 [lb]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_loadbalancer') | replace('-', '_') ] %}
-loadbalancer{{loop.index}}.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+loadbalancer{{loop.index}}.{{chomped_zone_internal_dns}} host_zone={{hostvars[host]['ec2_placement']}}
 {% endfor %}
 
 [masters]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_master') | replace('-', '_') ] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+master{{loop.index}}.{{chomped_zone_internal_dns}} host_zone={{hostvars[host]['ec2_placement']}}
 {% endfor %}
 
 [etcd]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_master') | replace('-', '_') ] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+master{{loop.index}}.{{chomped_zone_internal_dns}} host_zone={{hostvars[host]['ec2_placement']}}
 {% endfor %}
-
 
 [nodes]
 ## These are the masters
 {% for host in groups[('tag_' + env_type + '-' + guid + '_master') | replace('-', '_') ] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}   ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['ec2_placement']}}'}"
+master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['ec2_placement']}}'}"
 {% endfor %}
 
 ## These are infranodes


### PR DESCRIPTION
Figured I'd send you a Pull Request rather than contributing it directly.

I removed the NFS Shares for metrics and logging (and justanother) from the ansible deployer script. The way that metrics/logging is now set up in the hosts file OpenShift ansible creates the exports itself. So we ended up with duplicate exports.

Actually for HA we could remove >all< the default exports including jenkins and nexus - except I wasn't sure we could have an empty section there. So I left jenkins and nexus.

I tested the hosts file on a new environment (where I had manually "fixed" the NFS server) and it ran through perfectly.