### PR TITLE
switch to using ssh config file (for bu-workshop)

### DIFF
--- a/ansible/configs/bu-workshop/cleanup.yml
+++ b/ansible/configs/bu-workshop/cleanup.yml
@@ -24,3 +24,31 @@
         region: "{{ aws_region }}"
       tags:
         - remove_cf
+
+    - name: Remove SSH config
+      file:
+        dest: "{{ inventory_dir }}/../workdir/{{ env_type }}_{{ guid }}_ssh_conf"
+        state: absent
+      tags:
+        - remove_ssh_config
+
+    - name: Remove SSH bastion config
+      file:
+        dest: "{{ inventory_dir }}/../workdir/ssh-config-{{ env_type }}-{{ guid }}"
+        state: absent
+      tags:
+        - remove_hosts_file
+
+    - name: Remove cloud template
+      file:
+        dest: "{{ inventory_dir }}/../workdir/{{ cloud_provider }}_cloud_template.{{ env_type }}.{{ guid }}.json"
+        state: absent
+      tags:
+        - remove_cloud_template
+
+    - name: Remove hosts file
+      file:
+        dest: "{{ inventory_dir }}/../workdir/hosts-{{ env_type }}-{{ guid }}"
+        state: absent
+      tags:
+        - remove_hosts_file

--- a/ansible/configs/bu-workshop/ssh_vars.yml
+++ b/ansible/configs/bu-workshop/ssh_vars.yml
@@ -1,5 +1,1 @@
-ansible_ssh_extra_args: >
-  -o User={{ ansible_ssh_user }}
-  -o StrictHostKeyChecking=no
-  -i ~/.ssh/{{ key_name }}.pem
-  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -i ~/.ssh/'{{ key_name }}'.pem -o User='{{ ansible_ssh_user }}' -W %h:%p {{ hostvars[ groups[ ('tag_' ~ env_type ~ '_' ~ guid ~ '_bastion') | replace('-', '_') ].0 ]['ec2_public_dns_name'] }}"
+ansible_ssh_extra_args: "-F {{ inventory_dir }}/../workdir/{{ env_type }}_{{ guid }}_ssh_conf"

--- a/ansible/main.yml
+++ b/ansible/main.yml
@@ -59,6 +59,59 @@
       tags:
         - refresh_inventory
 
+- name: Generate SSH config file for use with ssh_vars
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars_files:
+    - "{{ playbook_dir }}/configs/{{ env_type }}/env_vars.yml"
+    - "{{ playbook_dir }}/configs/{{ env_type }}/env_secret_vars.yml"
+  tags:
+    - generate_ssh_config_file
+  tasks:
+    - name: Store bastion hostname as a fact
+      set_fact:
+        bastion_hostname: "{{ hostvars[ groups[ ('tag_' ~ env_type ~ '_' ~ guid ~ '_bastion') | replace('-', '_') ].0 ]['ec2_public_dns_name'] }}"
+    
+    - name: Create empty local ssh config in /tmp
+      file:
+        dest: "{{ playbook_dir }}/workdir/{{ env_type }}_{{ guid }}_ssh_conf"
+        state: touch
+
+    - name: Add bastion proxy config to workdir ssh config file
+      blockinfile:
+        dest: "{{ playbook_dir }}/workdir/{{ env_type }}_{{ guid }}_ssh_conf"
+        marker: "##### {mark} ADDED BASTION PROXY HOST {{ env_type }}-{{ guid }} ######"
+        content: |
+            Host {{ bastion_hostname }}
+              Hostname {{ bastion_hostname }}
+              IdentityFile ~/.ssh/{{ key_name }}.pem
+              IdentitiesOnly yes
+              User {{ remote_user }}
+              ControlMaster auto
+              ControlPath /tmp/%h-%r
+              ControlPersist 5m
+              StrictHostKeyChecking no
+      tags:
+        - bastion_proxy_config_main
+
+    - name: Add all hosts to workdir ssh config file
+      blockinfile:
+        dest: "{{ playbook_dir }}/workdir/{{ env_type }}_{{ guid }}_ssh_conf"
+        marker: "##### {mark} ADDED Node Proxy Config  {{ item }} {{ env_type }}-{{ guid }} ######"
+        block: |
+            Host {{ item }}
+              Hostname {{ item }}
+              User {{ remote_user }}
+              IdentityFile ~/.ssh/{{ key_name }}.pem
+              ProxyCommand ssh {{ remote_user }}@{{ bastion_hostname }} -W %h:%p
+              StrictHostKeyChecking no
+      with_items:
+        - "{{ groups[('tag_Project_' ~ env_type ~ '_' ~ guid) | replace('-', '_')] }}"
+      tags:
+        - bastion_proxy_config_hosts
+
 - name: Wait for environment Readiness
   hosts:
     - "{{ ('tag_Project_' ~ env_type ~ '_' ~ guid) | replace('-', '_') }}"


### PR DESCRIPTION
This brings back using an SSH config file for accessing hosts through the bastion. However, it creates the file in `workdir` and then (at least for the bu-workshop) references the file as part of the `ssh_extra_args`.

Generating the file will happen in all runs and for all env types. However, currently only the bu-workshop env type actually uses this file in its SSH config.

The generated config file does not rely on a template, so it should not cause any errors when running the playbook. However, the ControlPath is set to `/tmp/%h-%r` which might have issues on MacOS.

It also makes the bu-workshop cleanup playbook more thorough, deleting all of the generated files out of the workdir.