### PR TITLE
ocp-ha-lab, README: fix destroy command

### DIFF
--- a/ansible/configs/ocp-ha-lab/README.adoc
+++ b/ansible/configs/ocp-ha-lab/README.adoc
@@ -85,8 +85,10 @@ ansible-playbook -i ${DEPLOYER_REPO_PATH}/inventory/${CLOUDPROVIDER}.py ${DEPLOY
 ----
 
 #To Destroy an Env
-ansible-playbook  ./configs/${ENVTYPE}/destroy_env.yml \
- -e "guid=${GUID}" -e "env_type=${ENVTYPE}"  -e "cloud_provider=${CLOUDPROVIDER}" -e "aws_region=${REGION}"  \
- -e "HostedZoneId=${HOSTZONEID}"  -e "key_name=${KEYNAME}"  -e "subdomain_base_suffix=${BASESUFFIX}"
-
+ansible-playbook -i ${DEPLOYER_REPO_PATH}/inventory/${CLOUDPROVIDER}.py \
+                        ${DEPLOYER_REPO_PATH}/configs/${ENVTYPE}/destroy_env.yml \
+                        -e "guid=${GUID}" -e "env_type=${ENVTYPE}" \
+                        -e "cloud_provider=${CLOUDPROVIDER}" -e "aws_region=${REGION}"  -e "HostedZoneId=${HOSTZONEID}" \
+                        -e "ANSIBLE_REPO_PATH=${DEPLOYER_REPO_PATH}" \
+                        -e "key_name=${KEYNAME}"  -e "subdomain_base_suffix=${BASESUFFIX}"
 ----


### PR DESCRIPTION
- Add inventory like the previous command
- add ANSIBLE_REPO_PATH, fix error because of undefined variable:

    fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'ANSIBLE_REPO_PATH' is undefined\n\nThe error appears to have been in '/home/user/Git/ansible_agnostic_deployer/ansible/configs/ocp-ha-lab/destroy_env.yml': line 36, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Destroy cloudformation template\n      ^ here\n"}