### PR TITLE
 Preparing_your_workstation.adoc: fix  ~/.ssh/config mode

### DIFF
--- a/Preparing_your_workstation.adoc
+++ b/Preparing_your_workstation.adoc
@@ -64,6 +64,7 @@ openssl rsa -in ~/.ssh/${KEYNAME}.pem -pubout > ~/.ssh/${KEYNAME}.pub
 chmod 400 ~/.ssh/${KEYNAME}.pub
 chmod 400 ~/.ssh/${KEYNAME}.pem
 touch ~/.ssh/config
+chmod 600 ~/.ssh/config
 aws ec2 import-key-pair --key-name ${KEYNAME} --region=$REGION --output=text --public-key-material "`cat ~/.ssh/${KEYNAME}.pub | grep -v PUBLIC`"
 ----
 +


### PR DESCRIPTION
`touch ~/.ssh/config` is not enough. This error can occur in some playbooks during provisioning (depending on the user's umask of course):

    fatal: [ec2-35-158-247-170.eu-central-1.compute.amazonaws.com]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Bad owner or permissions on /home/user/.ssh/config\r\nCouldn't read packet: Connection reset by peer\r\n", "unreachable": true}

this commit sets mode for `~/.ssh/config` to `600`