### PR TITLE
change garbage collection threshold

### DIFF
--- a/ansible/configs/ocp-workshop/files/hosts_template.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.j2
@@ -22,7 +22,7 @@ containerized=false
 osm_default_node_selector='env=users'
 
 # Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
-openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['90'], 'image-gc-low-threshold': ['80']}
+openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['75']}
 
 # Configure logrotate scripts
 # See: https://github.com/nickhammond/ansible-logrotate


### PR DESCRIPTION
zabbix alerts are currently set to trigger above 90%. The current setting (90-80%)
results in false-positive. Lower those values.