### PR TITLE
make ec2_infrastructure_deployment agnostic

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -72,6 +72,7 @@
 
 - name: Configure local ssh config for bastion proxy use
   include: "{{ ANSIBLE_REPO_PATH }}/cloud_providers/{{cloud_provider}}_ssh_config_setup.yml"
+  when: ('tag_' ~ env_type ~ '_' ~ guid ~ '_bastion') | replace('-', '_') in groups
 
 
 - name: Wait for environment Readiness


### PR DESCRIPTION
The play 'Configure local ssh config for bastion proxy use' is specific to OCP
environments. If there is no bastion host, the playbook fails with the message:

```
TASK [Store bastion hostname as a fact] ***************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute u'tag_ansible_provisioner_gucoretest_bastion'\n\nThe error appears to have been in '/home/user/Git/ansible_agnostic_deployer/ansible/cloud_providers/ec2_ssh_config_setup.yml': line 14, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n     var: \"{{hostvars}}\"\n  - name: Store bastion hostname as a fact\n    ^ here\n"}
```

Fix:
- add conditional to include based on the presence of bastion host