### PR TITLE
ocp-workshop: generate report

### DIFF
--- a/ansible/configs/ocp-workshop/files/ocp_report.adoc.j2
+++ b/ansible/configs/ocp-workshop/files/ocp_report.adoc.j2
@@ -42,7 +42,7 @@ Unknown
 [width="100%",options="header",cols=",,,,asciidoc"]
 |=========================================================
 |Host Name |  Instance Size  | CPU | RAM | Storage
-{% for host in hostvars -%}
+{% for host in env_all_hosts -%}
 | {{ hostvars[host].ansible_hostname }}
 | {{ hostvars[host].ec2_instance_type }} 
 | {{ hostvars[host].ansible_processor_cores }} x {{ hostvars[host].ansible_processor[1] }} 
@@ -59,7 +59,7 @@ Unknown
 |=========================================================
 |Internal Name |Public Name  | EIP | Access Key
 
-{% for host in hostvars -%}
+{% for host in env_all_hosts -%}
 | {{ hostvars[host].ec2_tag_internaldns }}
 | {{ hostvars[host].ec2_public_dns_name }} 
 | {{ hostvars[host].ec2_ip_address }}

--- a/ansible/configs/ocp-workshop/files/ocp_report.adoc.j2
+++ b/ansible/configs/ocp-workshop/files/ocp_report.adoc.j2
@@ -1,0 +1,93 @@
+= OPENTLC Shared Labs Environment "{{ guid }}"
+
+== Overview
+
+* The OpenShift Shared Environment is used to provide "developer" level access to
+ participants enrolled in OPEN courses by GPTE.
+
+== Installed Software
+
+.Installed Software versions
+[width="100%",cols="1,1,3,10",options="header"]
+|=========================================================
+|Software |Version  |Source |Notes
+
+| OpenShift
+| {{ osrelease }}
+| {% if repo_method == 'file' -%}
+{{ own_repo_path }}
+{% elif repo_method == 'satellite' %}
+Satellite
+{% else %}
+Unknown
+{% endif %}
+| OpenShift Container Platform is installed and configured.
+
+| Nexus
+| v2
+| Container based deployment
+| A Nexus pod is configured and loaded with X repositories
+
+| Zabbix
+| 3.1
+| admin based repos
+| Zabbix Client is installed, configured and enabled
+|=========================================================
+
+== Architecture
+
+* AWS region: {{ aws_region }}
+
+.Environment Size
+[width="100%",options="header",cols=",,,,asciidoc"]
+|=========================================================
+|Host Name |  Instance Size  | CPU | RAM | Storage
+{% for host in hostvars -%}
+| {{ hostvars[host].ansible_hostname }}
+| {{ hostvars[host].ec2_instance_type }} 
+| {{ hostvars[host].ansible_processor_cores }} x {{ hostvars[host].ansible_processor[1] }} 
+| {{ '%0.2f'| format(hostvars[host].ansible_memtotal_mb|int / 1024) }} GB RAM
+| {% for dev in hostvars[host].ansible_devices %}
+- {{ dev }}: {{ hostvars[host].ansible_devices[dev].size }}
+{% endfor %}
+
+{% endfor %}
+|=========================================================
+
+.Host Networking
+[width="100%",options="header"]
+|=========================================================
+|Internal Name |Public Name  | EIP | Access Key
+
+{% for host in hostvars -%}
+| {{ hostvars[host].ec2_tag_internaldns }}
+| {{ hostvars[host].ec2_public_dns_name }} 
+| {{ hostvars[host].ec2_ip_address }}
+| {{ hostvars[host].key_name }}
+{% endfor %}
+|=========================================================
+
+.Access Points
+[width="100%",options="header"]
+|=========================================================
+|Access Point | URI | Method | Notes
+| Bastion Shell
+| `ssh ec2-user@bastion.{{ subdomain_base }}`
+| SSH
+| Admin Only
+
+| OpenShift Web Console
+| https://master.{{ subdomain_base }}:{{master_api_port}}
+| Browser
+| Using OPENTLC Credentials
+
+| Cockpit Console
+| https://master.{{ subdomain_base }}:9090
+| Browser
+| Admin Only
+
+|Nexus Repository
+| http://nexus-opentlc-shared.{{ cloudapps_suffix }}
+| Browser
+| Admin Only
+|=========================================================

--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -274,6 +274,8 @@
     - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
   tags:
     - ocp_report
+  vars:
+    env_all_hosts: "{{ groups[('tag_Project_' ~ env_type ~ '_' ~ guid) | replace('-', '_')] }}"
   tasks:
     - name: Gather ec2 facts
       ec2_remote_facts:

--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -265,3 +265,21 @@
   tasks:
     - debug:
         msg: "Post-Software checks completed successfully"
+
+- name: Generate reports
+  hosts: localhost
+  connection: local
+  vars_files:
+    - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_vars.yml"
+    - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
+  tags:
+    - ocp_report
+  tasks:
+    - name: Gather ec2 facts
+      ec2_remote_facts:
+        region: "{{ aws_region }}"
+
+    - name: Generate report
+      template:
+        src: "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/files/ocp_report.adoc.j2"
+        dest: "{{ ANSIBLE_REPO_PATH }}/workdir/{{ env_type }}_ocp_report.adoc"


### PR DESCRIPTION
Generate asciidoc report at the end of post_software playbook.

export report to `workdir/`