### PR TITLE
Update provisioner

### DIFF
--- a/ansible/configs/ansible-provisioner/README.adoc
+++ b/ansible/configs/ansible-provisioner/README.adoc
@@ -1,15 +1,27 @@
 = Ansible Provisioner Env_Type
 
-In this directory we keep the files for a "Generic Example" environment type.
+In this directory we keep the files for an "Ansible Provisioner" environment type.
 
-we create folders, yml files, and other items we want to over ride default variables.
+This set of playbooks will:
 
-For example, we will include things such as ec2 instance names, secret
-variables such as private/public key pair information, passwords, etc.
+- setup users
+* AWS credentials
+* authorized_keys to access by SSH
+* symlinks (for Cloudform integration)
+* copy private key
+- download repositories (ansible_agnostic_deployer, private OPEN_Admin)
+- installed dependencies to run ansible_agnostic_deployer
 
-Eventually, all sensitive information will be encypted via Ansible Vault. The
-inclusion as well as instructions on doing this will be included in a later
-release.
+// 
+// we create folders, yml files, and other items we want to over ride default variables.
+// 
+// For example, we will include things such as ec2 instance names, secret
+// variables such as private/public key pair information, passwords, etc.
+// 
+// Eventually, all sensitive information will be encypted via Ansible Vault. The
+// inclusion as well as instructions on doing this will be included in a later
+// release.
+
 
 == Set up your "Secret" variables
 
@@ -17,9 +29,10 @@ release.
 * you can set these for each "Standard Config" in it's directory or have a
  global variables file that will overwrite any "Config" specific variable file.
 
-* Create a file called env_secret_vars.yml in the "environment type" directory
+* Create a file called `env_secret_vars.yml` in the "environment type" directory
 
 .Example contents of "Secret" Vars file
+[source,yaml]
 ----
 # ## Logon credentials for Red Hat Network
 # ## Required if using the subscription component
@@ -38,6 +51,59 @@ admin_user_password: ""
 aws_access_key_id: ""
 aws_secret_access_key: ""
 ----
+
+
+For managing users on the ansible provisioner, you can override the `mgr_users` variable. The default is the following:
+
+.managing users ("Secret" Vars file or Env Vars file)
+[source,yaml]
+----
+mgr_users:
+  - name: opentlc-mgr
+    home: /home/opentlc-mgr
+    private_key: ocpkey
+    authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
+    aws_access_key_id: "{{aws_access_key_id}}"
+    aws_secret_access_key: "{{aws_secret_access_key}}"
+    symlinks:
+      - src: OPEN_Admin/OPENTLC-OCP3/provision_workshop_env.sh
+        path: bin/provision_workshop_env.sh
+      - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
+        path: bin/provision-ose-projects.sh
+      - src: OPEN_Admin/OPENTLC-OCP3/deploy_scripts
+        path: bin/deploy_scripts
+----
+
+You can, for example, want to add another user:
+
+.managing users ("Secret" Vars file or Env Vars file)
+[source,yaml]
+----
+mgr_users:
+  - name: opentlc-mgr
+    home: /home/opentlc-mgr
+    private_key: ocpkey
+    authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
+    aws_access_key_id: "{{aws_access_key_id}}"
+    aws_secret_access_key: "{{aws_secret_access_key}}"
+    symlinks:
+      - src: OPEN_Admin/OPENTLC-OCP3/provision_workshop_env.sh
+        path: bin/provision_workshop_env.sh
+      - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
+        path: bin/provision-ose-projects.sh
+      - src: OPEN_Admin/OPENTLC-OCP3/deploy_scripts
+        path: bin/deploy_scripts
+  - name: fridim
+    home: /home/fridim
+    authorized_keys:
+      - https://github.com/fridim.keys
+    aws_access_key_id: "{{fridim_aws_access_key_id}}"
+    aws_secret_access_key: "{{fridim_aws_secret_access_key}}"
+    symlinks: []
+----
+
 
 == Review the Env_Type variable file
 
@@ -61,15 +127,19 @@ CLOUDPROVIDER=ec2
 HOSTZONEID='Z3IHLWJZOU9SRT'
 
 time ansible-playbook -i inventory/ ./main.yml \
--e "guid=${GUID}" -e "env_type=${ENVTYPE}"  -e "cloud_provider=${CLOUDPROVIDER}" -e "aws_region=${REGION}"  \
--e "HostedZoneId=${HOSTZONEID}"  -e "key_name=${KEYNAME}"  -e "subdomain_base_suffix=.example.opentlc.com"  \
+-e "guid=${GUID}" \
+-e "env_type=${ENVTYPE}"  \
+-e "cloud_provider=${CLOUDPROVIDER}" \
+-e "aws_region=${REGION}"  \
+-e "HostedZoneId=${HOSTZONEID}"  \
+-e "key_name=${KEYNAME}"  \
+-e "subdomain_base_suffix=.example.opentlc.com"  \
 -e "software_to_deploy=none"
-
-
-
-. To Delete an environment
 ----
 
+. To Delete an environment
+[source,bash]
+----
 REGION=ap-southeast-2
 KEYNAME=osesharedkey
 GUID=ocptestha4
@@ -78,8 +148,11 @@ CLOUDPROVIDER=ec2
 HOSTZONEID='Z3IHLWJZOU9SRT'
 #To Destroy an Env
 ansible-playbook -i inventory/ ./configs/${ENVTYPE}/destroy_env.yml \
- -e "guid=${GUID}" -e "env_type=${ENVTYPE}"  -e "cloud_provider=${CLOUDPROVIDER}" -e "aws_region=${REGION}"  \
- -e "HostedZoneId=${HOSTZONEID}"  -e "key_name=${KEYNAME}"  -e "subdomain_base_suffix=.example.opentlc.com"
-
-
+ -e "guid=${GUID}" \
+ -e "env_type=${ENVTYPE}"  \
+ -e "cloud_provider=${CLOUDPROVIDER}" \
+ -e "aws_region=${REGION}"  \
+ -e "HostedZoneId=${HOSTZONEID}"  \
+ -e "key_name=${KEYNAME}"  \
+ -e "subdomain_base_suffix=.example.opentlc.com"
 ----

--- a/ansible/configs/ansible-provisioner/README.adoc
+++ b/ansible/configs/ansible-provisioner/README.adoc
@@ -7,7 +7,7 @@ This set of playbooks will:
 - setup users
 * AWS credentials
 * authorized_keys to access by SSH
-* symlinks (for Cloudform integration)
+* symlinks (for Cloudform integration with OPEN_Admin repository)
 * copy private key
 - download repositories (ansible_agnostic_deployer, private OPEN_Admin)
 - installed dependencies to run ansible_agnostic_deployer
@@ -61,6 +61,7 @@ For managing users on the ansible provisioner, you can override the `mgr_users` 
 mgr_users:
   - name: opentlc-mgr
     home: /home/opentlc-mgr
+    open_admin: yes
     private_key: ocpkey
     authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
@@ -75,7 +76,24 @@ mgr_users:
         path: bin/deploy_scripts
 ----
 
-You can, for example, want to add another user:
+Note the `open_admin` key that will be checked to know if the OPEN_Admin private repository needs to be fetched. If yes, there is 2 ways:
+
+- pull it manually and create `OPEN_Admin.tar.gz` archive on your workstation. The file will be uploaded and unarchive to the user's home.
+- set github.user and github.password for user. For example:
++
+[source,yaml]
+----
+mgr_users:
+  - name: opentlc-mgr
+    home: /home/opentlc-mgr
+    open_admin: yes
+    private_key: ocpkey
+    github:
+      user: fridim
+      password: MYPASSWORD
+----
+
+Here a complete example if you want, for example, add another user:
 
 .managing users ("Secret" Vars file or Env Vars file)
 [source,yaml]
@@ -83,6 +101,7 @@ You can, for example, want to add another user:
 mgr_users:
   - name: opentlc-mgr
     home: /home/opentlc-mgr
+    open_admin: yes
     private_key: ocpkey
     authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
@@ -101,7 +120,6 @@ mgr_users:
       - https://github.com/fridim.keys
     aws_access_key_id: "{{fridim_aws_access_key_id}}"
     aws_secret_access_key: "{{fridim_aws_secret_access_key}}"
-    symlinks: []
 ----
 
 

--- a/ansible/configs/ansible-provisioner/files/hosts_template.j2
+++ b/ansible/configs/ansible-provisioner/files/hosts_template.j2
@@ -13,4 +13,6 @@ ansible_ssh_user={{ansible_ssh_user}}
 provisioner
 
 [provisioner]
+{% for host in groups[('tag_' + env_type + '-' + guid + '_provisioner') | replace('-', '_') ] %}
 provisioner.{{chomped_zone_internal_dns}}  host_zone={{hostvars[host]['ec2_placement']}}
+{% endfor %}

--- a/ansible/configs/ansible-provisioner/post_software.yml
+++ b/ansible/configs/ansible-provisioner/post_software.yml
@@ -19,11 +19,11 @@
   gather_facts: False
   vars:
     symlinks:
-      - src: /opt/OPEN_Admin/OPENTLC-OCP3/provision_workshop_env.sh
+      - src: /home/opentlc-mgr/OPEN_Admin/OPENTLC-OCP3/provision_workshop_env.sh
         path: /home/opentlc-mgr/bin/provision_workshop_env.sh
-      - src: /opt/OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
+      - src: /home/opentlc-mgr/OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
         path: /home/opentlc-mgr/bin/provision-ose-projects.sh
-      - src: /opt/OPEN_Admin/OPENTLC-OCP3/deploy_scripts
+      - src: /home/opentlc-mgr/OPEN_Admin/OPENTLC-OCP3/deploy_scripts
         path: /home/opentlc-mgr/bin/deploy_scripts
   roles:
     - role: "{{ ANSIBLE_REPO_PATH }}/roles/opentlc-integration"

--- a/ansible/configs/ansible-provisioner/post_software.yml
+++ b/ansible/configs/ansible-provisioner/post_software.yml
@@ -22,6 +22,7 @@
     mgr_users:
       - name: opentlc-mgr
         home: /home/opentlc-mgr
+        open_admin: yes
         private_key: ocpkey
         authorized_keys:
           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com

--- a/ansible/configs/ansible-provisioner/post_software.yml
+++ b/ansible/configs/ansible-provisioner/post_software.yml
@@ -18,13 +18,22 @@
   become: yes
   gather_facts: False
   vars:
-    symlinks:
-      - src: /home/opentlc-mgr/OPEN_Admin/OPENTLC-OCP3/provision_workshop_env.sh
-        path: /home/opentlc-mgr/bin/provision_workshop_env.sh
-      - src: /home/opentlc-mgr/OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
-        path: /home/opentlc-mgr/bin/provision-ose-projects.sh
-      - src: /home/opentlc-mgr/OPEN_Admin/OPENTLC-OCP3/deploy_scripts
-        path: /home/opentlc-mgr/bin/deploy_scripts
+    # to add more users, override this variable in env_vars or env_secret_vars
+    mgr_users:
+      - name: opentlc-mgr
+        home: /home/opentlc-mgr
+        private_key: ocpkey
+        authorized_keys:
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
+        aws_access_key_id: "{{aws_access_key_id}}"
+        aws_secret_access_key: "{{aws_secret_access_key}}"
+        symlinks:
+          - src: OPEN_Admin/OPENTLC-OCP3/provision_workshop_env.sh
+            path: bin/provision_workshop_env.sh
+          - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
+            path: bin/provision-ose-projects.sh
+          - src: OPEN_Admin/OPENTLC-OCP3/deploy_scripts
+            path: bin/deploy_scripts
   roles:
     - role: "{{ ANSIBLE_REPO_PATH }}/roles/opentlc-integration"
       when: install_opentlc_integration == true
@@ -33,18 +42,30 @@
     - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
   tags: [ env-specific, cf_integration ]
   tasks:
-    - name: Copy ssh key to provisioner
-      copy:
-        src: "~/.ssh/{{ key_name }}.pem"
-        dest: "/home/opentlc-mgr/.ssh/{{ key_name }}.pem"
+    - name: Install vim
+      yum:
+        name: vim
 
-    - name: Install EPEL (for jq)
+    - name: Copy SSH private key to provisioner for users
+      copy:
+        src: "~/.ssh/{{ item.private_key }}.pem"
+        dest: "{{ item.home }}/.ssh/{{ item.private_key }}.pem"
+        mode: 0400
+        owner: "{{ item.name }}"
+      when: item.private_key is defined
+      with_items: "{{ mgr_users }}"
+
+    - name: Install EPEL (for python-pip and ansible)
       package:
         name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm"
         use: yum
         state: installed
 
     - name: install python-pip
+      yum:
+        name: python2-pip
+
+    - name: install ansible
       yum:
         name: python2-pip
 
@@ -55,22 +76,29 @@
     - name: test awscli
       command: aws --version
 
-    - name: create ~opentlc-mgr/.aws 
+    - name: Create ~/.aws for users
       file:
-        path: /home/opentlc-mgr/.aws
-        owner: opentlc-mgr
-        group: opentlc-mgr
+        path: "{{ item.home }}/.aws"
+        owner: "{{ item.name }}"
+        group: "{{ item.name }}"
+        mode: 0700
         state: directory
+      when: item.aws_access_key_id is defined
+      with_items: "{{ mgr_users }}"
 
     - name: Insert awscli credentials
       copy:
-        dest: /home/opentlc-mgr/.aws/credentials
-        owner: opentlc-mgr
-        group: opentlc-mgr
+        dest: "{{ item.home }}/.aws/credentials"
+        owner: "{{ item.name }}"
+        group: "{{ item.name }}"
         content: |
           [default]
-          aws_access_key_id = {{aws_access_key_id}}
-          aws_secret_access_key = {{aws_secret_access_key}}
+          aws_access_key_id = {{ item.aws_access_key_id }}
+          aws_secret_access_key = {{ item.aws_secret_access_key }}
+      when:
+        - item.aws_access_key_id is defined
+        - item.aws_secret_access_key is defined
+      with_items: "{{ mgr_users }}"
 
     - name: Copy boto.cfg file to /etc
       copy:

--- a/ansible/configs/ocp-workshop/README.adoc
+++ b/ansible/configs/ocp-workshop/README.adoc
@@ -41,6 +41,40 @@ zabbix_auto_registration_pass: "XXXXX"
  need to define to control the deployment of your environment.
 
 
+=== Add new users on the bastion
+
+For managing users on the bastion, you can override the `mgr_users` variable. The default is the following:
+
+.managing users ("Secret" Vars file or Env Vars file)
+[source,yaml]
+----
+mgr_users:
+  - name: opentlc-mgr
+    home: /home/opentlc-mgr
+    open_admin: false
+    authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
+----
+
+You can, for example, want to add another user:
+
+.managing users ("Secret" Vars file or Env Vars file)
+[source,yaml]
+----
+mgr_users:
+  - name: opentlc-mgr
+    home: /home/opentlc-mgr
+    open_admin: false
+    authorized_keys:
+      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
+  - name: fridim
+    home: /home/fridim
+    authorized_keys:
+      - https://github.com/fridim.keys
+    aws_access_key_id: "{{fridim_aws_access_key_id}}"
+    aws_secret_access_key: "{{fridim_aws_secret_access_key}}"
+----
+
 == Running Ansible Playbook
 
 You can run the playbook with the following arguments to overwrite the default variable values:

--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -65,11 +65,20 @@
     - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_vars.yml"
     - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
   vars:
-    symlinks:
-      - src: /opt/OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
-        path: /home/opentlc-mgr/bin/provision-accounts.sh
-      - src: /opt/OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
-        path: /home/opentlc-mgr/bin/provision-ose-projects.sh
+    # to update or add more users, override this variable in env_vars or env_secret_vars
+    mgr_users:
+      - name: opentlc-mgr
+        home: /home/opentlc-mgr
+        private_key: ocpkey
+        authorized_keys:
+          - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
+        aws_access_key_id: "{{aws_access_key_id}}"
+        aws_secret_access_key: "{{aws_secret_access_key}}"
+        symlinks:
+          - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
+            path: bin/provision-accounts.sh
+          - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
+            path: bin/provision-ose-projects.sh
   tags:
     - env-specific
     - cf_integration

--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -69,16 +69,9 @@
     mgr_users:
       - name: opentlc-mgr
         home: /home/opentlc-mgr
-        private_key: ocpkey
+        open_admin: false
         authorized_keys:
           - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
-        aws_access_key_id: "{{aws_access_key_id}}"
-        aws_secret_access_key: "{{aws_secret_access_key}}"
-        symlinks:
-          - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
-            path: bin/provision-accounts.sh
-          - src: OPEN_Admin/OPENTLC-OCP3/provision-ose-projects.sh
-            path: bin/provision-ose-projects.sh
   tags:
     - env-specific
     - cf_integration

--- a/ansible/roles/opentlc-integration/defaults/main.yml
+++ b/ansible/roles/opentlc-integration/defaults/main.yml
@@ -1,2 +1,1 @@
 ---
-# defaults file for bastion

--- a/ansible/roles/opentlc-integration/tasks/main.yml
+++ b/ansible/roles/opentlc-integration/tasks/main.yml
@@ -1,81 +1,98 @@
 # vim: set ft=ansible:
 ---
-- name: Add opentlc-mgr user
+- name: Create users
   user:
-    name: opentlc-mgr
-    home: /home/opentlc-mgr
+    name: "{{ item.name }}"
+    home: "{{ item.home }}"
+  with_items: "{{ mgr_users }}"
 
-- name: Install git
+- name: Install packages
   yum:
-    name: git
+    name: "{{ item }}"
+  with_items:
+    - git
+    - python-boto
 
 - name: Get updated files from git repository github.com/sborenst/ansible_agnostic_deployer
   git:
     repo: "https://github.com/sborenst/ansible_agnostic_deployer.git"
-    dest: /home/opentlc-mgr/ansible_agnostic_deployer
+    dest: "{{ item.home }}/ansible_agnostic_deployer"
     force: yes
+  with_items: "{{ mgr_users }}"
 
 - name: Check if OPEN_Admin.tar.gz repo exists in the current dir (manual upload)
   delegate_to: localhost
   stat:
     path: "{{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz"
   register: openadmin_archive
-
-- name: Check if file exists remotely.
-  stat:
-    path: /home/opentlc-mgr/OPEN_Admin
-  register: remote_openadmin
+  become: false
 
 - name: Copy and unarchive OPEN_Admin.tar.gz repo from local. Do not copy if already present remotely.
   unarchive:
     src: "{{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz"
-    dest: /home/opentlc-mgr/
+    dest: "{{ item.home }}/"
+    creates: "{{ item.home }}/OPEN_Admin"
   when:
     - openadmin_archive.stat.exists
-    - not remote_openadmin.stat.exists
+  with_items: "{{ mgr_users }}"
 
 - name: Get updated files from git repository github.com/redhat-gpe/OPEN_Admin.git
   git:
     repo: "https://{{ githubuser }}:{{ githubpassword }}@github.com/redhat-gpe/OPEN_Admin.git"
-    dest: /home/opentlc-mgr/OPEN_Admin
+    dest: "{{ item.home }}/OPEN_Admin"
     force: yes
   when:
     - githubuser is defined
     - githubpassword is defined
     - not openadmin_archive.stat.exists
+  with_items: "{{ mgr_users }}"
+
+- name: No OPEN_Admin repo available
+  fail:
+    msg: "You need to either provide githubuser/githubpassword to fetch OPEN_Admin repo from the provisioner or provide {{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz to be uploaded (recommended). Caution: github credentials will be readable on the provisioner if you choose the first option."
+  when:
+    - not openadmin_archive.stat.exists
+    - githubpassword is not defined
 
 - name: Set permissions for directories OPEN_Admin and ansible_agnostic_deployer
   file:
-    path: "/home/opentlc-mgr/{{ item }}"
+    path: "{{ item[0].home }}/{{ item[1] }}"
     state: directory
-    owner: opentlc-mgr
+    owner: "{{ item[0].name }}"
     recurse: yes
-    group: opentlc-mgr
+    group: "{{ item[0].name }}"
     mode: 0770
-  with_items:
-    - OPEN_Admin
-    - ansible_agnostic_deployer
+  with_nested:
+    - "{{ mgr_users }}"
+    - [ "OPEN_Admin", "ansible_agnostic_deployer" ]
 
-- name: Create ~opentlc-mgr/bin
+- name: Create ~/bin
   file:
-    path: /home/opentlc-mgr/bin
+    path: "{{ item.home }}/bin"
     state: directory
+  with_items: "{{ mgr_users }}"
 
 # these symlinks are usually specific (bastion, ansible-provisionner, etc)
-- name: Create symlinks to ~opentlc-mgr/bin
+- name: Create symlinks to ~/bin
   file:
-    path: "{{ item.path }}"
-    src: "{{ item.src }}"
+    path: "{{item.0.home }}/{{ item.1.path }}"
+    src: "{{item.0.home }}/{{ item.1.src }}"
     state: link
-  with_items: "{{ symlinks }}"
+  with_subelements:
+    - "{{ mgr_users }}"
+    - symlinks
 
-- name: add CF key
+- name: add authorized_keys
   authorized_key:
-    key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4OojwKH74UWVOY92y87Tb/b56CMJoWbz2gyEYsr3geOc2z/n1pXMwPfiC2KT7rALZFHofc+x6vfUi6px5uTm06jXa78S7UB3MX56U3RUd8XF3svkpDzql1gLRbPIgL1h0C7sWHfr0K2LG479i0nPt/X+tjfsAmT3nWj5PVMqSLFfKrOs6B7dzsqAcQPInYIM+Pqm/pXk+Tjc7cfExur2oMdzx1DnF9mJaj1XTnMsR81h5ciR2ogXUuns0r6+HmsHzdr1I1sDUtd/sEVu3STXUPR8oDbXBsb41O5ek6E9iacBJ327G3/1SWwuLoJsjZM0ize+iq3HpT1NqtOW6YBLR opentlc-mgr@inf00-mwl.opentlc.com
-    user: opentlc-mgr
+    user: "{{ item.0.name }}"
+    key: "{{ item.1 }}"
+  with_subelements:
+    - "{{ mgr_users }}"
+    - authorized_keys
 
 - file:
-    path: /home/opentlc-mgr/deployer_logs
+    path: "{{ item.home }}/deployer_logs"
     state: directory
-    owner: opentlc-mgr
+    owner: "{{ item.name }}"
     recurse: yes
+  with_items: "{{ mgr_users }}"

--- a/ansible/roles/opentlc-integration/tasks/main.yml
+++ b/ansible/roles/opentlc-integration/tasks/main.yml
@@ -12,18 +12,18 @@
 - name: Get updated files from git repository github.com/sborenst/ansible_agnostic_deployer
   git:
     repo: "https://{{ githubuser }}:{{ githubpassword }}@github.com/sborenst/ansible_agnostic_deployer.git"
-    dest: /opt/ansible_agnostic_deployer
+    dest: /home/opentlc-mgr/ansible_agnostic_deployer
     force: yes
 
 - name: Get updated files from git repository github.com/redhat-gpe/OPEN_Admin.git
   git:
     repo: "https://{{ githubuser }}:{{ githubpassword }}@github.com/redhat-gpe/OPEN_Admin.git"
-    dest: /opt/OPEN_Admin
+    dest: /home/opentlc-mgr/OPEN_Admin
     force: yes
 
 - name: Set permissions for directories OPEN_Admin and ansible_agnostic_deployer
   file:
-    path: "/opt/{{ item }}"
+    path: "/home/opentlc-mgr/{{ item }}"
     state: directory
     owner: opentlc-mgr
     recurse: yes
@@ -52,7 +52,7 @@
     user: opentlc-mgr
 
 - file:
-    path: /opt/deployer_logs
+    path: /home/opentlc-mgr/deployer_logs
     state: directory
     owner: opentlc-mgr
     recurse: yes

--- a/ansible/roles/opentlc-integration/tasks/main.yml
+++ b/ansible/roles/opentlc-integration/tasks/main.yml
@@ -5,21 +5,44 @@
     name: opentlc-mgr
     home: /home/opentlc-mgr
 
-- name: install git
+- name: Install git
   yum:
     name: git
 
 - name: Get updated files from git repository github.com/sborenst/ansible_agnostic_deployer
   git:
-    repo: "https://{{ githubuser }}:{{ githubpassword }}@github.com/sborenst/ansible_agnostic_deployer.git"
+    repo: "https://github.com/sborenst/ansible_agnostic_deployer.git"
     dest: /home/opentlc-mgr/ansible_agnostic_deployer
     force: yes
+
+- name: Check if OPEN_Admin.tar.gz repo exists in the current dir (manual upload)
+  delegate_to: localhost
+  stat:
+    path: "{{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz"
+  register: openadmin_archive
+
+- name: Check if file exists remotely.
+  stat:
+    path: /home/opentlc-mgr/OPEN_Admin
+  register: remote_openadmin
+
+- name: Copy and unarchive OPEN_Admin.tar.gz repo from local. Do not copy if already present remotely.
+  unarchive:
+    src: "{{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz"
+    dest: /home/opentlc-mgr/
+  when:
+    - openadmin_archive.stat.exists
+    - not remote_openadmin.stat.exists
 
 - name: Get updated files from git repository github.com/redhat-gpe/OPEN_Admin.git
   git:
     repo: "https://{{ githubuser }}:{{ githubpassword }}@github.com/redhat-gpe/OPEN_Admin.git"
     dest: /home/opentlc-mgr/OPEN_Admin
     force: yes
+  when:
+    - githubuser is defined
+    - githubpassword is defined
+    - not openadmin_archive.stat.exists
 
 - name: Set permissions for directories OPEN_Admin and ansible_agnostic_deployer
   file:

--- a/ansible/roles/opentlc-integration/tasks/main.yml
+++ b/ansible/roles/opentlc-integration/tasks/main.yml
@@ -34,37 +34,56 @@
     creates: "{{ item.home }}/OPEN_Admin"
   when:
     - openadmin_archive.stat.exists
+    - item.open_admin is defined
+    - item.open_admin == True
   with_items: "{{ mgr_users }}"
 
 - name: Get updated files from git repository github.com/redhat-gpe/OPEN_Admin.git
   git:
-    repo: "https://{{ githubuser }}:{{ githubpassword }}@github.com/redhat-gpe/OPEN_Admin.git"
+    repo: "https://{{ item.github.user }}:{{ item.github.password }}@github.com/redhat-gpe/OPEN_Admin.git"
     dest: "{{ item.home }}/OPEN_Admin"
     force: yes
   when:
-    - githubuser is defined
-    - githubpassword is defined
+    - item.github is defined
+    - item.github.user is defined
+    - item.github.password is defined
     - not openadmin_archive.stat.exists
+    - item.open_admin is defined
+    - item.open_admin == True
   with_items: "{{ mgr_users }}"
 
-- name: No OPEN_Admin repo available
+- name: No OPEN_Admin repo available for user
   fail:
-    msg: "You need to either provide githubuser/githubpassword to fetch OPEN_Admin repo from the provisioner or provide {{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz to be uploaded (recommended). Caution: github credentials will be readable on the provisioner if you choose the first option."
+    msg: "User {{ item.name }}: You need to either provide github.user/github.password to fetch OPEN_Admin repo from the provisioner or provide {{ ANSIBLE_REPO_PATH }}/OPEN_Admin.tar.gz to be uploaded (recommended). Caution: github credentials will be readable on the provisioner if you choose the first option."
   when:
     - not openadmin_archive.stat.exists
-    - githubpassword is not defined
+    - item.github is not defined
+    - item.open_admin is defined
+    - item.open_admin == True
+  with_items: "{{ mgr_users }}"
 
-- name: Set permissions for directories OPEN_Admin and ansible_agnostic_deployer
+- name: Set permissions for directories ansible_agnostic_deployer
   file:
-    path: "{{ item[0].home }}/{{ item[1] }}"
+    path: "{{ item.home }}/ansible_agnostic_deployer"
     state: directory
-    owner: "{{ item[0].name }}"
+    owner: "{{ item.name }}"
     recurse: yes
-    group: "{{ item[0].name }}"
+    group: "{{ item.name }}"
     mode: 0770
-  with_nested:
-    - "{{ mgr_users }}"
-    - [ "OPEN_Admin", "ansible_agnostic_deployer" ]
+  with_items: "{{ mgr_users }}"
+
+- name: Set permissions for directories OPEN_Admin
+  file:
+    path: "{{ item.home }}/OPEN_Admin"
+    state: directory
+    owner: "{{ item.name }}"
+    recurse: yes
+    group: "{{ item.name }}"
+    mode: 0770
+  when:
+    - item.open_admin is defined
+    - item.open_admin == True
+  with_items: "{{ mgr_users }}"
 
 - name: Create ~/bin
   file:
@@ -81,6 +100,7 @@
   with_subelements:
     - "{{ mgr_users }}"
     - symlinks
+  ignore_errors: yes
 
 - name: add authorized_keys
   authorized_key:

--- a/ansible/roles/opentlc-integration/vars/main.yml
+++ b/ansible/roles/opentlc-integration/vars/main.yml
@@ -1,2 +1,1 @@
 ---
-# vars file for bastion


### PR DESCRIPTION
update provisioner                                                                                                                                                                        
- fix template                                                                                                                                                                            
- move repos to /home instead of /opt   

fix repo credential                                                                                                                                                                       

- do not use credential for agnostic_ansible_deployer, it is public                                                                                                                       
- OPEN_Admin:                                                                                                                                                                             
- use githubuser and githubpassword variables only when needed                                                                                                                          
- upload and unarchive OPEN_Admin.tar.gz if present (and absent remotely)  

factorize user creation                                                                                                                                                                 

introduce the variable mgr_users that will be used to create the different users                                                                                                          
on the ansible provisioner (or bastion).                                                                                                                                                  

Update README.adoc      

add mgr_users[].open_admin variable to define if user has access to OPEN_Admin                                                                                                            

- introduce open_admin to mgr_users                                                                                                                                                       
- make mgr_users.[].symlinks optional                                                                                                                                                     
- update defaults mgr_users values                                                                                                                                                        
- update READMEs 
