### PR TITLE
Fix aws credentials for ocp_report play

### DIFF
--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -325,6 +325,8 @@
   tasks:
     - name: Gather ec2 facts
       ec2_remote_facts:
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
         region: "{{ aws_region }}"
 
     - name: Generate report


### PR DESCRIPTION
Let's use the aws_* variables set in env_secret_vars.yml instead of
~/.aws/credentials