### PR TITLE
ocp-workshop 3.6 + ansible-provisioner scripts

### DIFF
--- a/ansible/configs/ansible-provisioner/post_software.yml
+++ b/ansible/configs/ansible-provisioner/post_software.yml
@@ -138,3 +138,16 @@
 
     - shell: "mkdir -p {{ storage_mount_path }} &&  mount {{ storage_mount_path }}"
       ignore_errors: true
+
+- name: Zabbix
+  hosts: "{{ ('tag_' ~ env_type ~ '_' ~ guid ~ '_provisioner') | replace('-', '_') }}"
+  gather_facts: true
+  become: yes
+  vars_files:
+    - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_vars.yml"
+    - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
+  roles:
+    - { role: "{{ ANSIBLE_REPO_PATH }}/roles/zabbix-client" }
+  tags:
+    - env-specific
+    - install_zabbix

--- a/ansible/configs/ocp-workshop/files/hosts_template.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.j2
@@ -13,10 +13,11 @@ ansible_ssh_user={{ansible_ssh_user}}
 ###########################################################################
 openshift_metrics_image_version=v{{ repo_version }}
 #openshift_image_tag=v{{ repo_version }}
-openshift_release={{ osrelease }}
+#openshift_release={{ osrelease }}
 #docker_version="{{docker_version}}"
 deployment_type=openshift-enterprise
 containerized=false
+openshift_disable_check="disk_availability,memory_availability"
 
 # default project node selector
 osm_default_node_selector='env=users'

--- a/ansible/roles/zabbix-client/defaults/main.yml
+++ b/ansible/roles/zabbix-client/defaults/main.yml
@@ -3,4 +3,5 @@
 # will be authorized to auto-register
 zabbix_auto_registration_keyword: OCP Host
 # hostname that appears in Zabbix.
-zabbix_hostname: "OCP {{ repo_version }} {{ guid }} - {{ ansible_hostname }}"
+zabbix_hostname: "{% if repo_version is defined %} OCP {{ repo_version }} {% endif %}{{ guid }} - {{ ansible_hostname }}"
+zabbix_host: 23.246.247.58

--- a/scripts/README.adoc
+++ b/scripts/README.adoc
@@ -1,0 +1,40 @@
+= Wrapper script
+
+This script is a wrapper for end-users, to run ansible_agnostic_deployer playbooks.
+
+All the configuration regarding an environment can be set in a .rc file (bash syntax). The script takes the file as first arg. Here is an example:
+
+.ocp-example.rc
+----
+GUID=testocp35
+REGION=eu-central-1
+KEYNAME=gucore
+ENVTYPE=ocp-workshop
+SOFTWARE_TO_DEPLOY=openshift
+HOSTZONEID=Z3IHLWJZOU9SRT
+ENVTYPE_ARGS=(
+-e osrelease=3.5.5.31
+-e "bastion_instance_type=t2.large"
+-e "master_instance_type=c4.xlarge" 
+-e "infranode_instance_type=c4.4xlarge"
+-e "node_instance_type=c4.4xlarge"
+-e "nfs_instance_type=m3.large"
+-e "subdomain_base_suffix=.example.opentlc.com"
+-e "node_instance_count=1"
+-e own_repo_path=http://admin.example.com/repos/ocp/3.5
+-e repo_version=3.5
+)
+----
+
+It has several possible actions as second arg:
+
+. provision
+. destroy
+. stop
+. start
+
+.Example run
+----
+$ cd scripts
+$ ./wrapper.sh ocp-workshop-3.5.rc provision
+----

--- a/scripts/ansible-provisioner.rc.example
+++ b/scripts/ansible-provisioner.rc.example
@@ -1,0 +1,6 @@
+GUID=testprovisioner
+REGION=eu-central-1
+KEYNAME=gucore
+HOSTZONEID=Z3IHLWJZOU9SRT
+ENVTYPE=ansible-provisioner
+ENVTYPE_ARGS=()

--- a/scripts/ocp-workshop-3.5.rc.example
+++ b/scripts/ocp-workshop-3.5.rc.example
@@ -1,0 +1,18 @@
+GUID=testocp35
+REGION=eu-central-1
+KEYNAME=gucore
+ENVTYPE=ocp-workshop
+SOFTWARE_TO_DEPLOY=openshift
+HOSTZONEID=Z3IHLWJZOU9SRT
+ENVTYPE_ARGS=(
+-e osrelease=3.5.5.31
+-e "bastion_instance_type=t2.large"
+-e "master_instance_type=c4.xlarge" 
+-e "infranode_instance_type=c4.4xlarge"
+-e "node_instance_type=c4.4xlarge"
+-e "nfs_instance_type=m3.large"
+-e "subdomain_base_suffix=.example.opentlc.com"
+-e "node_instance_count=1"
+-e own_repo_path=http://admin.example.com/repos/ocp/3.5
+-e repo_version=3.5
+)

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# wapper script to agnostic_ansible_deployer playbooks
+
+if [ $# != 2 ]; then
+    echo "2 args needed" >&2
+    echo
+    echo 'wapper script to agnostic_ansible_deployer playbooks'
+    echo "./$0 RCFILE ACTION"
+    echo 'args'
+    echo '- RCFILE: to be sourced, containing needed env variables (especially envtype_args array)'
+    echo '- ACTION: provision|destroy|stop|start'
+    exit 2
+fi
+
+set -xe -o pipefail
+
+. "$1"
+
+if [ -z "${GUID}" ]; then
+    echo "GUID is mandatory"
+    exit 2
+fi
+
+REGION=${REGION:-us-east-1}
+KEYNAME=${KEYNAME:-ocpkey}
+ENVTYPE=${ENVTYPE:-generic-example}
+CLOUDPROVIDER=${CLOUDPROVIDER:-ec2}
+if [ "$CLOUDPROVIDER" = "ec2" ]; then
+    if [ -z "${HOSTZONEID}" ]; then
+        echo "HOSTZONEID vars are mandatory"
+        exit 2
+    fi
+fi
+
+INSTALL_IPA_CLIENT=${INSTALL_IPA_CLIENT:-false}
+REPO_METHOD=${REPO_METHOD:-file}
+SOFTWARE_TO_DEPLOY=${SOFTWARE_TO_DEPLOY:-none}
+
+STACK_NAME=${ENVTYPE}-${GUID}
+ORIG=$(cd $(dirname $0); cd ..; pwd)
+DEPLOYER_REPO_PATH="${ORIG}/ansible"
+
+case $2 in
+    provision)
+        ansible-playbook \
+            ${DEPLOYER_REPO_PATH}/main.yml  \
+            -i ${DEPLOYER_REPO_PATH}/inventory/${CLOUDPROVIDER}.py \
+            -e "ANSIBLE_REPO_PATH=${DEPLOYER_REPO_PATH}" \
+            -e "guid=${GUID}" \
+            -e "env_type=${ENVTYPE}" \
+            -e "key_name=${KEYNAME}" \
+            -e "cloud_provider=${CLOUDPROVIDER}" \
+            -e "aws_region=${REGION}" \
+            -e "HostedZoneId=${HOSTZONEID}" \
+            -e "install_ipa_client=${INSTALL_IPA_CLIENT}" \
+            -e "software_to_deploy=${SOFTWARE_TO_DEPLOY}" \
+            -e "repo_method=${REPO_METHOD}" \
+            ${ENVTYPE_ARGS[@]}
+        ;;
+    destroy)
+        ansible-playbook \
+            ${DEPLOYER_REPO_PATH}/configs/${ENVTYPE}/destroy_env.yml \
+            -i ${DEPLOYER_REPO_PATH}/inventory/${CLOUDPROVIDER}.py \
+            -e "ANSIBLE_REPO_PATH=${DEPLOYER_REPO_PATH}" \
+            -e "guid=${GUID}" \
+            -e "env_type=${ENVTYPE}"  \
+            -e "cloud_provider=${CLOUDPROVIDER}" \
+            -e "aws_region=${REGION}"  \
+            -e "HostedZoneId=${HOSTZONEID}"  \
+            -e "key_name=${KEYNAME}"  \
+        ;;
+    stop)
+        aws ec2 stop-instances --region $REGION --instance-ids $(aws ec2 describe-instances --filters "Name=tag:aws:cloudformation:stack-name,Values=${STACK_NAME}" --query Reservations[*].Instances[*].InstanceId --region $REGION --output text)
+        ;;
+    start)
+        aws ec2 start-instances --region $REGION --instance-ids `aws ec2 describe-instances --filters "Name=tag:aws:cloudformation:stack-name,Values=${STACK_NAME}" --query Reservations[*].Instances[*].InstanceId --region $REGION --output text`
+        ;;
+esac


### PR DESCRIPTION
- tested ocp-workshop deployment with ocp 3.6
- validate ocp-workshop deployment with ocp 3.5 is still working
- add role zabbix-client to ansible-provisioner
- add wrapper.sh script in `scripts/` directory
  - end-user script to facilitate deployments
  - add README.adoc
  - add 2 examples of RC files