### PR TITLE
ocp-ha-lab: disable checks

### DIFF
--- a/ansible/configs/ocp-ha-lab/files/hosts_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.j2
@@ -18,6 +18,7 @@ containerized=false
 # openshift_image_tag=v{{ repo_version }}
 # openshift_release={{ osrelease }}
 # docker_version="{{docker_version}}"
+openshift_disable_check="disk_availability,memory_availability"
 
 # default project node selector
 osm_default_node_selector='env=app'


### PR DESCRIPTION
tested opc-ha-lab config with 3.6.

host inventory file needs this var in our case, because we usually use small VM and do not follow requirements/recommandations