### PR TITLE
use variables for root fs size in ec2 templates + add one for bastion as well

### DIFF
--- a/ansible/configs/ocp-ha-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-lab/env_vars.yml
@@ -206,3 +206,9 @@ vpcid_name_tag: "{{subdomain_base}}"
 # rtb_private_name_tag: "{{subdomain_base}}-private"
 #
 # cf_template_description: "{{ env_type }}-{{ guid }} template"
+
+rootfs_size_node: 50
+rootfs_size_infranode: 50
+rootfs_size_master: 50
+rootfs_size_bastion: 20
+rootfs_size_support: 20

--- a/ansible/configs/ocp-ha-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-lab/env_vars.yml
@@ -105,6 +105,7 @@ rhn_pool_id_string: OpenShift Container Platform
 nfs_vg: nfsvg
 nfs_pvs: /dev/xvdb
 nfs_export_path: /srv/nfs
+nfs_size: 50
 
 nfs_shares:
   - jenkins

--- a/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -331,6 +331,14 @@
             "Key": "{{ project_tag }}",
             "Value": "bastion"
           }
+        ],
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "VolumeSize": {{ rootfs_size_bastion }}
+            }
+          }
         ]
       }
     },
@@ -487,7 +495,7 @@
             {
               "DeviceName": "/dev/sda1",
               "Ebs": {
-                "VolumeSize": 50
+                "VolumeSize": {{ rootfs_size_master }}
               }
             },
             {
@@ -574,7 +582,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": 50
+              "VolumeSize": {{ rootfs_size_node }}
             }
           },
           {
@@ -665,7 +673,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": 50
+              "VolumeSize": {{ rootfs_size_infranode }}
             }
           },
           {
@@ -762,7 +770,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": 50
+              "VolumeSize": {{ rootfs_size_support }}
             }
           },
           {

--- a/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -499,7 +499,7 @@
               }
             },
             {
-              "DeviceName": "/dev/xvdb",
+              "DeviceName": "{{ docker_device }}",
               "Ebs": {
                 "VolumeType": "gp2",
                 "VolumeSize": 20
@@ -586,7 +586,7 @@
             }
           },
           {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "{{ docker_device }}",
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 100
@@ -677,7 +677,7 @@
             }
           },
           {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "{{ docker_device }}",
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 50
@@ -774,10 +774,10 @@
             }
           },
           {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "{{ nfs_pvs }}",
             "Ebs": {
               "VolumeType": "gp2",
-              "VolumeSize": 50
+              "VolumeSize": {{ nfs_size }}
             }
           }
         ]

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -232,3 +232,9 @@ rtb_private_name_tag: "{{subdomain_base}}-private"
 
 
 cf_template_description: "{{ env_type }}-{{ guid }} template "
+
+rootfs_size_node: 50
+rootfs_size_infranode: 50
+rootfs_size_master: 50
+rootfs_size_bastion: 20
+rootfs_size_support: 20

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -159,6 +159,7 @@ rhel_repos:
 nfs_vg: nfsvg
 nfs_pvs: /dev/xvdb
 nfs_export_path: /srv/nfs
+nfs_size: 50
 
 nfs_shares:
   - es-storage

--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -429,7 +429,7 @@
                 }
               },
               {
-                "DeviceName": "/dev/xvdb",
+                "DeviceName": "{{ docker_device }}",
                 "Ebs": {
                   "VolumeType": "gp2",
                   "VolumeSize": 20
@@ -537,7 +537,7 @@
             }
           },
           {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "{{ docker_device }}",
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 100
@@ -632,7 +632,7 @@
             }
           },
           {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "{{ docker_device }}",
             "Ebs": {
               "VolumeType": "gp2",
               "VolumeSize": 50
@@ -733,10 +733,10 @@
             }
           },
           {
-            "DeviceName": "/dev/xvdb",
+            "DeviceName": "{{ nfs_pvs }}",
             "Ebs": {
               "VolumeType": "gp2",
-              "VolumeSize": 50
+              "VolumeSize": {{ nfs_size }}
             }
           }
         ]

--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -330,6 +330,14 @@
             "Key": "internaldns",
             "Value": "bastion.{{chomped_zone_internal_dns}}"
           }
+        ],
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/sda1",
+            "Ebs": {
+              "VolumeSize": {{ rootfs_size_bastion }}
+            }
+          }
         ]
       }
     },
@@ -417,7 +425,7 @@
               {
                 "DeviceName": "/dev/sda1",
                 "Ebs": {
-                  "VolumeSize": 50
+                  "VolumeSize": {{ rootfs_size_master }}
                 }
               },
               {
@@ -525,7 +533,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": 50
+              "VolumeSize": {{ rootfs_size_node }}
             }
           },
           {
@@ -620,7 +628,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": 50
+              "VolumeSize": {{ rootfs_size_infranode }}
             }
           },
           {
@@ -721,7 +729,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "VolumeSize": 50
+              "VolumeSize": {{ rootfs_size_support }}
             }
           },
           {


### PR DESCRIPTION
Use variables to be able to simply change size of the device attached for rootfs.
* ocp-workshop
* ocp-ha-lab