### PR TITLE
add do-until loop for cloudformation destroy

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -37,6 +37,15 @@
       - aws_infrastructure_deployment
       - provision_cf_template
     register: cloudformation_out
+    until: cloudformation_out|succeeded
+    retries: 5
+    delay: 60
+    ignore_errors: yes
+
+  - name: report Cloudformation error
+    fail:
+      msg: "FAIL {{ project_tag }} Create Cloudformation"
+    when: not cloudformation_out|succeeded
 
   - debug:
      var: cloudformation_out.stack_outputs

--- a/ansible/configs/ans-tower-lab/destroy_env.yml
+++ b/ansible/configs/ans-tower-lab/destroy_env.yml
@@ -18,3 +18,13 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded

--- a/ansible/configs/ansible-provisioner/destroy_env.yml
+++ b/ansible/configs/ansible-provisioner/destroy_env.yml
@@ -18,4 +18,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/generic-example/destroy_env.yml
+++ b/ansible/configs/generic-example/destroy_env.yml
@@ -18,3 +18,13 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded

--- a/ansible/configs/ocp-demo-lab/destroy_env.yml
+++ b/ansible/configs/ocp-demo-lab/destroy_env.yml
@@ -45,6 +45,16 @@
         region: "{{ aws_region }}"
       tags:
         - remove_s3
+      register: s3_result
+      until: s3_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report s3 error
+      fail:
+        msg: "FAIL {{ project_tag }} delete s3"
+      when: not s3_result|succeeded
 
     - name: Destroy cloudformation template
       cloudformation:
@@ -56,4 +66,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/ocp-ha-lab/destroy_env.yml
+++ b/ansible/configs/ocp-ha-lab/destroy_env.yml
@@ -43,4 +43,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/ocp-implementation-lab/destroy_env.yml
+++ b/ansible/configs/ocp-implementation-lab/destroy_env.yml
@@ -43,4 +43,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/ocp-workshop/destroy_env.yml
+++ b/ansible/configs/ocp-workshop/destroy_env.yml
@@ -65,6 +65,16 @@
         region: "{{ aws_region }}"
       tags:
         - remove_s3
+      register: s3_result
+      until: s3_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report s3 error
+      fail:
+        msg: "FAIL {{ project_tag }} delete s3"
+      when: not s3_result|succeeded
 
     - name: Destroy cloudformation template
       cloudformation:
@@ -76,4 +86,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/opentlc-shared/destroy_env.yml
+++ b/ansible/configs/opentlc-shared/destroy_env.yml
@@ -51,4 +51,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/single-ipa/destroy_env.yml
+++ b/ansible/configs/single-ipa/destroy_env.yml
@@ -43,4 +43,14 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded
 ## we need to add something to delete the env specific key.

--- a/ansible/configs/three-tier-app/destroy_env.yml
+++ b/ansible/configs/three-tier-app/destroy_env.yml
@@ -18,3 +18,13 @@
         tags:
           Stack: "project {{env_type}}-{{ guid }}"
       tags: [ destroying, destroy_cf_deployment ]
+      register: cloudformation_result
+      until: cloudformation_result|succeeded
+      retries: 5
+      delay: 60
+      ignore_errors: yes
+
+    - name: report Cloudformation error
+      fail:
+        msg: "FAIL {{ project_tag }} Destroy Cloudformation"
+      when: not cloudformation_result|succeeded


### PR DESCRIPTION
When we trigger several destroy actions at the same time, it happens that the
cloudformation module fail because of AWS MaxRequest/s policy (Throttling).

This commit adds:
- retry 5 times
- wait 1 minute between retry

This should help ensure each stack is properly destroyed.