### PR TITLE
improvements from stress tests

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -37,18 +37,20 @@
       - aws_infrastructure_deployment
       - provision_cf_template
     register: cloudformation_out
-    until: cloudformation_out|succeeded
+    until:
+      - cloudformation_out|succeeded
+      - cloudformation_out.output in ["Stack CREATE complete", "Stack is already up-to-date."]
     retries: 5
     delay: 60
     ignore_errors: yes
+
+  - debug:
+     var: cloudformation_out
 
   - name: report Cloudformation error
     fail:
       msg: "FAIL {{ project_tag }} Create Cloudformation"
     when: not cloudformation_out|succeeded
-
-  - debug:
-     var: cloudformation_out.stack_outputs
 
   - name: Refresh cloud_provider cache
     environment:
@@ -60,11 +62,17 @@
     register: task_result
     until: task_result.rc == 0
     retries: 5
-    delay: 30
+    delay: 60
     ignore_errors: yes
+    changed_when: task_result.rc == 0
     tags:
       - refresh_inventory
       - refresh_inventory_script
+
+  - name: report Cache refresh error
+    fail:
+      msg: "FAIL {{ project_tag }} Cache refresh error"
+    when: not task_result|succeeded
 
   - name: Refresh in-memory cloud_provider cache
     environment:

--- a/ansible/inventory/ec2.ini
+++ b/ansible/inventory/ec2.ini
@@ -72,7 +72,7 @@ elasticache = False
 
 # By default, only EC2 instances in the 'running' state are returned. Set
 # 'all_instances' to True to return all instances regardless of state.
-all_instances = False
+all_instances = True
 
 # By default, only EC2 instances in the 'running' state are returned. Specify
 # EC2 instance states to return as a comma-separated list. This
@@ -109,7 +109,7 @@ cache_path = ~/.ansible/tmp
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
 # To disable the cache, set this value to 0
-cache_max_age = 0
+cache_max_age = 120
 
 # Organize groups into a nested/hierarchy instead of a flat namespace.
 nested_groups = False

--- a/ansible/inventory/ec2.sh
+++ b/ansible/inventory/ec2.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# This script is a wrapper for ec2.py. The purpose is to avoid HTTP 400 from AWS as we run several
+# deployments simultaneously.
+# It follows the recommandations from: http://docs.aws.amazon.com/general/latest/gr/api-retries.html
+
+# There must be a way to configure boto and num_retries in some profile to avoid using a wrapper
+# if someone knows where to set it, please, let us know!
+
+# pseudo-code:
+#
+#DO
+# wait for (2^retries * 100) milliseconds
+# status = Get the result of the asynchronous operation.
+#
+#IF status = SUCCESS
+#retry = false
+#ELSE IF status = NOT_READY
+#retry = true
+#ELSE IF status = THROTTLED
+#retry = true
+#ELSE
+#Some other error occurred, so stop calling the API.
+#retry = false
+#END IF
+#
+#retries = retries + 1
+#
+#WHILE (retry AND (retries < MAX_RETRIES))
+
+# 10 * 90-150s ~ 20 minutes max
+MAX_RETRIES=10
+MAX_DELAY=$(( 90 + RANDOM % 60))
+retries=0
+
+ORIG=$(cd $(dirname $0); pwd)
+
+output=$(mktemp)
+errlog=$(mktemp)
+
+while [ $retries -le $MAX_RETRIES ]; do
+    duration=$(bc <<< "2^${retries} * 0.${RANDOM}")
+    if [ $(bc <<< "$duration > $MAX_DELAY") -eq 1 ]; then
+        duration=$MAX_DELAY
+    fi
+
+    sleep $duration
+
+    $ORIG/ec2.py "$@" > $output 2>$errlog
+    RET=$?
+    if [ "$RET" = "0" ]; then
+        cat $output
+        cat $errlog >&2
+        rm $output
+        rm $errlog
+        exit 0
+    fi
+    retries=$((retries + 1))
+done
+
+cat $output
+cat $errlog >&2
+rm $output
+rm $errlog
+exit 2

--- a/ansible/roles/opentlc-integration/tasks/packages.yml
+++ b/ansible/roles/opentlc-integration/tasks/packages.yml
@@ -5,3 +5,4 @@
   with_items:
     - git
     - python-boto
+    - bc


### PR DESCRIPTION
- ensure stack creation is complete: add a condition on output.

  Sometime stack creation fails, resulting in a non-complete stack (some VM
  created, other components missing). The cloudformation module does not register
  a failure in that case.

- debug complete register of cloudformation instead of only 'stack_outputs'
  which is not very informative.

- update ec2.ini to use cache: improves the overall performance a lot

  we are using refresh_inventory only in a few places like just after
  cloudformation stack creation.

- update ec2.ini to list non-running instances

  Sometime after Cloudformation stack creation, we directly update ec2.py cache.
  Some instances might not be ready and running.

- ec2.sh: add a wrapper to ec2.py.
  This wrapper implements recommandations from:
  http://docs.aws.amazon.com/general/latest/gr/api-retries.html
  Until we find a way to configure boto to do it properly this can be a
  solution.
  Also add 'bc' package to provisioner, needed by this script.