### PR TITLE
cloudformation templates: fix race condition

### DIFF
--- a/ansible/configs/ans-tower-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ans-tower-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -384,13 +384,13 @@
         ]
       }
     },
-    "BastionEIP" : {
- "Type" : "AWS::EC2::EIP",
- "DependsOn": [ "Bastion" ],
- "Properties" : {
-     "InstanceId" : { "Ref" : "Bastion" }
- }
-},
+      "BastionEIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "Bastion" }
+          }
+      },
     "BastionInternalDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -484,12 +484,12 @@
           }
 
         },
-        "tower{{loop.index}}EIP" : {
-       "Type" : "AWS::EC2::EIP",
-       "DependsOn": [ "tower{{loop.index}}" ],
-       "Properties" : {
-           "InstanceId" : { "Ref" : "tower{{loop.index}}" }
-       }
+      "tower{{loop.index}}EIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "tower{{loop.index}}" }
+          }
       },
         "tower{{loop.index}}DNS": {
           "Type": "AWS::Route53::RecordSetGroup",
@@ -880,12 +880,13 @@
       }
 
     },
-    "Windows{{loop.index}}EIP" : {
-    "Type" : "AWS::EC2::EIP",
-    "DependsOn": [ "windows{{loop.index}}" ],
-    "Properties" : {
-     "InstanceId" : { "Ref" : "windows{{loop.index}}" }
-    }},
+      "Windows{{loop.index}}EIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "windows{{loop.index}}" }
+          }
+      },
     "windows{{loop.index}}DNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {

--- a/ansible/configs/generic-example/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/generic-example/files/cloud_providers/ec2_cloud_template.j2
@@ -357,13 +357,13 @@
         ]
       }
     },
-    "BastionEIP" : {
- "Type" : "AWS::EC2::EIP",
- "DependsOn": [ "Bastion" ],
- "Properties" : {
-     "InstanceId" : { "Ref" : "Bastion" },
- }
-},
+      "BastionEIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "Bastion" }
+          }
+      },
     "BastionInternalDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -453,13 +453,12 @@
           }
 
         },
-        "publichost{{loop.index}}EIP" : {
-       "Type" : "AWS::EC2::EIP",
-       "DependsOn": [ "publichost{{loop.index}}" ],
-       "Properties" : {
-           "InstanceId" : { "Ref" : "publichost{{loop.index}}" },
-
-       }
+      "publichost{{loop.index}}EIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "publichost{{loop.index}}" }
+          }
       },
         "publichost{{loop.index}}DNS": {
           "Type": "AWS::Route53::RecordSetGroup",

--- a/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -121,17 +121,17 @@
       }
     },
     "VPCRouteInternetGateway": {
-      "DependsOn" : "VpcGA",
-  "Type": "AWS::EC2::Route",
-      "Properties": {
-        "GatewayId": {
-          "Ref": "VpcInternetGateway"
-        },
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "RouteTableId": {
-          "Ref": "VpcRouteTable"
+        "DependsOn" : "VpcGA",
+        "Type": "AWS::EC2::Route",
+        "Properties": {
+            "GatewayId": {
+                "Ref": "VpcInternetGateway"
+            },
+            "DestinationCidrBlock": "0.0.0.0/0",
+            "RouteTableId": {
+                "Ref": "VpcRouteTable"
+            }
         }
-      }
     },
     "PublicSubnet": {
       "Type": "AWS::EC2::Subnet",
@@ -347,12 +347,14 @@
       }
     },
     "BastionEIP" : {
- "Type" : "AWS::EC2::EIP",
- "DependsOn": [ "Bastion" ],
- "Properties" : {
-     "InstanceId" : { "Ref" : "Bastion" },
- }
-},
+        "Type" : "AWS::EC2::EIP",
+        "DependsOn": ["VpcGA"],
+        "Properties" : {
+            "InstanceId" : {
+                "Ref" : "Bastion"
+            }
+        }
+    },
     "BastionInternalDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -425,12 +427,12 @@
       }
     },
     "LoadBalancerEIP" : {
- "Type" : "AWS::EC2::EIP",
- "DependsOn": [ "LoadBalancer" ],
- "Properties" : {
-     "InstanceId" : { "Ref" : "LoadBalancer" },
- }
-},
+        "Type" : "AWS::EC2::EIP",
+        "DependsOn": [ "VpcGA" ],
+        "Properties" : {
+            "InstanceId" : { "Ref" : "LoadBalancer" }
+        }
+    },
     "LoadBalancerInternalDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -708,13 +710,12 @@
 
     },
     "infranode{{loop.index}}EIP" : {
-   "Type" : "AWS::EC2::EIP",
-   "DependsOn": [ "infranode{{loop.index}}" ],
-   "Properties" : {
-       "InstanceId" : { "Ref" : "infranode{{loop.index}}" },
-
-   }
-  },
+        "Type" : "AWS::EC2::EIP",
+        "DependsOn": [ "VpcGA" ],
+        "Properties" : {
+            "InstanceId" : { "Ref" : "infranode{{loop.index}}" }
+        }
+    },
     "infranode{{loop.index}}DNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {

--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -345,13 +345,13 @@
         ]
       }
     },
-    "BastionEIP" : {
- "Type" : "AWS::EC2::EIP",
- "DependsOn": [ "Bastion" ],
- "Properties" : {
-     "InstanceId" : { "Ref" : "Bastion" },
- }
-},
+      "BastionEIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "Bastion" }
+          }
+      },
     "BastionInternalDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -447,13 +447,12 @@
           }
 
         },
-        "master{{loop.index}}EIP" : {
-       "Type" : "AWS::EC2::EIP",
-       "DependsOn": [ "master{{loop.index}}" ],
-       "Properties" : {
-           "InstanceId" : { "Ref" : "master{{loop.index}}" },
-
-       }
+      "master{{loop.index}}EIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "master{{loop.index}}" }
+          }
       },
         "master{{loop.index}}DNS": {
           "Type": "AWS::Route53::RecordSetGroup",
@@ -658,14 +657,13 @@
       }
 
     },
-    "infranode{{loop.index}}EIP" : {
-   "Type" : "AWS::EC2::EIP",
-   "DependsOn": [ "infranode{{loop.index}}" ],
-   "Properties" : {
-       "InstanceId" : { "Ref" : "infranode{{loop.index}}" },
-
-   }
-  },
+      "infranode{{loop.index}}EIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "infranode{{loop.index}}" }
+          }
+      },
     "infranode{{loop.index}}DNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {

--- a/ansible/configs/three-tier-app/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/three-tier-app/files/cloud_providers/ec2_cloud_template.j2
@@ -361,13 +361,13 @@
         ]
       }
     },
-    "BastionEIP" : {
- "Type" : "AWS::EC2::EIP",
- "DependsOn": [ "Bastion" ],
- "Properties" : {
-     "InstanceId" : { "Ref" : "Bastion" }
- }
-},
+      "BastionEIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "Bastion" }
+          }
+      },
     "BastionInternalDNS": {
       "Type": "AWS::Route53::RecordSetGroup",
       "Properties": {
@@ -460,13 +460,13 @@
           }
 
         },
-        "frontend{{loop.index}}EIP" : {
-        "Type" : "AWS::EC2::EIP",
-        "DependsOn": [ "frontend{{loop.index}}" ],
-        "Properties" : {
-           "InstanceId" : { "Ref" : "frontend{{loop.index}}" }
-        }
-        },
+      "frontend{{loop.index}}EIP" : {
+          "Type" : "AWS::EC2::EIP",
+          "DependsOn": [ "VpcGA" ],
+          "Properties" : {
+              "InstanceId" : { "Ref" : "frontend{{loop.index}}" }
+          }
+      },
         "frontend{{loop.index}}DNS": {
           "Type": "AWS::Route53::RecordSetGroup",
           "Properties": {


### PR DESCRIPTION
The problem during the stress tests appears to be a race condition established
between the creation of the Elastic IP resource and the VPC Gateway Attachment
resource that connects the created VPC to the wider internet. For the EIP to be
created successfully, it needs to be created in a VPC with an established
network connection.

It appears that in most cases, the Gateway Attachment is created before the
EIPs, and the stack is therefore successful. The failures occur when the EIP
creation is attempted before the Gateway Attachment. To avoid this condition,
this commit makes the EIP resources dependent on the Gateway Attachment using a
DependsOn statement.