### PR TITLE
add tag 'owner' to CloudFormation stacks

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -33,6 +33,7 @@
       template: "{{ ANSIBLE_REPO_PATH }}/workdir/{{cloud_provider}}_cloud_template.{{ env_type }}.{{ guid }}.json"
       tags:
         Stack: "project {{ project_tag }}"
+        owner: "{{ email | default('unknown') }}"
     tags:
       - aws_infrastructure_deployment
       - provision_cf_template

--- a/ansible/configs/ans-tower-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ans-tower-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -385,10 +385,6 @@
           {
             "Key": "internaldns",
             "Value": "bastion.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ]
       }
@@ -469,10 +465,6 @@
               {
                 "Key": "internaldns",
                 "Value": "tower{{loop.index}}.{{chomped_zone_internal_dns}}"
-              },
-              {
-                "Key": "owner",
-                "Value": "{{ email | default('unknown')}}"
               }
             ],
             "BlockDeviceMappings": [
@@ -571,10 +563,6 @@
               {
                 "Key": "internaldns",
                 "Value": "frontend{{loop.index}}.{{chomped_zone_internal_dns}}"
-              },
-              {
-                "Key": "owner",
-                "Value": "{{ email | default('unknown')}}"
               }
             ],
             "BlockDeviceMappings": [
@@ -665,10 +653,6 @@
               {
                 "Key": "internaldns",
                 "Value": "app{{loop.index}}.{{chomped_zone_internal_dns}}"
-              },
-              {
-                "Key": "owner",
-                "Value": "{{ email | default('unknown')}}"
               }
             ],
             "BlockDeviceMappings": [
@@ -759,10 +743,6 @@
           {
             "Key": "internaldns",
             "Value": "appdb{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -865,10 +845,6 @@
           {
             "Key": "internaldns",
             "Value": "windows{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -965,10 +941,6 @@
           {
             "Key": "internaldns",
             "Value": "support{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [

--- a/ansible/configs/bu-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/bu-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -296,10 +296,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "master"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -376,10 +372,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "infranode"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -475,10 +467,6 @@
             "Key": "{{ project_tag }}",
             "Value": "node",
             "PropagateAtLaunch": true
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "VPCZoneIdentifier": [
@@ -529,10 +517,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "support"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -587,10 +571,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "bastion"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ]
       }
@@ -607,10 +587,6 @@
           {
             "Key": "Project",
             "Value": "{{ project_tag }}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ]
       }

--- a/ansible/configs/ocp-demo-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-demo-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -327,10 +327,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "bastion"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ]
       }
@@ -402,10 +398,6 @@
         {
           "Key": "{{ project_tag }}",
           "Value": "master"
-        },
-        {
-          "Key": "owner",
-          "Value": "{{ email | default('unknown')}}"
         }
       ],
       "BlockDeviceMappings": [
@@ -493,10 +485,6 @@
       {
         "Key": "{{ project_tag }}",
         "Value": "node"
-      },
-      {
-        "Key": "owner",
-        "Value": "{{ email | default('unknown')}}"
       }
     ],
     "BlockDeviceMappings": [
@@ -588,10 +576,6 @@
       {
         "Key": "{{ project_tag }}",
         "Value": "infranode"
-      },
-      {
-        "Key": "owner",
-        "Value": "{{ email | default('unknown')}}"
       }
     ],
     "BlockDeviceMappings": [
@@ -681,10 +665,6 @@
       {
         "Key": "{{ project_tag }}",
         "Value": "support"
-      },
-      {
-        "Key": "owner",
-        "Value": "{{ email | default('unknown')}}"
       }
     ],
     "BlockDeviceMappings": [
@@ -740,10 +720,6 @@
       {
         "Key": "Project",
         "Value": "{{project_tag}}"
-      },
-      {
-        "Key": "owner",
-        "Value": "{{ email | default('unknown')}}"
       }
     ]
   }

--- a/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -330,10 +330,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "bastion"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -418,10 +414,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "loadbalancer"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ]
       }
@@ -499,10 +491,6 @@
             {
               "Key": "{{ project_tag }}",
               "Value": "master"
-            },
-            {
-              "Key": "owner",
-              "Value": "{{ email | default('unknown')}}"
             }
           ],
           "BlockDeviceMappings": [
@@ -590,10 +578,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "node"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -685,10 +669,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "infranode"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -785,10 +765,6 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "support"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [

--- a/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-workshop/files/cloud_providers/ec2_cloud_template.j2
@@ -329,10 +329,6 @@
           {
             "Key": "internaldns",
             "Value": "bastion.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -423,10 +419,6 @@
               {
                 "Key": "internaldns",
                 "Value": "master{{loop.index}}.{{chomped_zone_internal_dns}}"
-              },
-              {
-                "Key": "owner",
-                "Value": "{{ email | default('unknown')}}"
               }
             ],
             "BlockDeviceMappings": [
@@ -534,10 +526,6 @@
           {
             "Key": "internaldns",
             "Value": "node{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -633,10 +621,6 @@
           {
             "Key": "internaldns",
             "Value": "infranode{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -737,10 +721,6 @@
           {
             "Key": "internaldns",
             "Value": "support{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -796,10 +776,6 @@
       {
         "Key": "Project",
         "Value": "{{project_tag}}"
-      },
-      {
-        "Key": "owner",
-        "Value": "{{ email | default('unknown')}}"
       }
     ]
   }

--- a/ansible/configs/three-tier-app/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/three-tier-app/files/cloud_providers/ec2_cloud_template.j2
@@ -362,10 +362,6 @@
           {
             "Key": "internaldns",
             "Value": "bastion.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ]
       }
@@ -445,10 +441,6 @@
               {
                 "Key": "internaldns",
                 "Value": "frontend{{loop.index}}.{{chomped_zone_internal_dns}}"
-              },
-              {
-                "Key": "owner",
-                "Value": "{{ email | default('unknown')}}"
               }
             ],
             "BlockDeviceMappings": [
@@ -545,10 +537,6 @@
               {
                 "Key": "internaldns",
                 "Value": "app{{loop.index}}.{{chomped_zone_internal_dns}}"
-              },
-              {
-                "Key": "owner",
-                "Value": "{{ email | default('unknown')}}"
               }
             ],
             "BlockDeviceMappings": [
@@ -639,10 +627,6 @@
           {
             "Key": "internaldns",
             "Value": "appdb{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [
@@ -733,10 +717,6 @@
           {
             "Key": "internaldns",
             "Value": "support{{loop.index}}.{{chomped_zone_internal_dns}}"
-          },
-          {
-            "Key": "owner",
-            "Value": "{{ email | default('unknown')}}"
           }
         ],
         "BlockDeviceMappings": [


### PR DESCRIPTION
Do the same as for instances.

Tags applied to stack are applied to all the resources of the stack:

Revert "add 'owner' tag on ec2 instances (cloudformation templates)"
This reverts commit d9abab9.
But keeps changes made on README.org(s)