### PR TITLE
Changed node selectors for metrics and logging

### DIFF
--- a/ansible/configs/ocp-workshop/files/hosts_template.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.j2
@@ -113,9 +113,10 @@ openshift_hosted_metrics_storage_nfs_options='*(rw,root_squash)'
 openshift_hosted_metrics_storage_volume_name=metrics
 openshift_hosted_metrics_storage_volume_size=10Gi
 openshift_hosted_metrics_public_url=https://hawkular-metrics.{{cloudapps_suffix}}/hawkular/metrics
-openshift_hosted_metrics_cassandra_nodeselector='env=infra'
-openshift_hosted_metrics_hawkular_nodeselector='env=infra'
-openshift_hosted_metrics_heapster_nodeselector='env=infra'
+openshift_metrics_cassandra_nodeselector={"env":"infra"}
+openshift_metrics_hawkular_nodeselector={"env":"infra"}
+openshift_metrics_heapster_nodeselector={"env":"infra"}
+
 # Enable cluster logging
 openshift_hosted_logging_deploy={{install_logging}}
 openshift_hosted_logging_storage_kind=nfs
@@ -126,10 +127,10 @@ openshift_hosted_logging_storage_volume_name=logging
 openshift_hosted_logging_storage_volume_size=10Gi
 openshift_hosted_logging_hostname=kibana.{{cloudapps_suffix}}
 openshift_hosted_logging_elasticsearch_cluster_size=1
-openshift_hosted_logging_elasticsearch_nodeselector='env=infra'
 openshift_master_logging_public_url=https://kibana.{{cloudapps_suffix}}
-openshift_hosted_logging_kibana_nodeselector='env=infra'
-
+openshift_logging_es_nodeselector={"env":"infra"}
+openshift_logging_kibana_nodeselector={"env":"infra"}
+openshift_logging_curator_nodeselector={"env":"infra"}
 
 openshift_hosted_logging_deployer_version=v{{repo_version}}
 # This one is wrong (down arrow)
@@ -152,7 +153,6 @@ openshift_additional_projects={'my-infra-project-test': {'default_node_selector'
 openshift_hosted_router_selector='env=infra'
 openshift_hosted_router_replicas={{infranode_instance_count}}
 #openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
-
 
 openshift_hosted_registry_selector='env=infra'
 openshift_hosted_registry_replicas=1


### PR DESCRIPTION
I changed the default node selectors for metrics and logging. This worked in an OCP-Workshop environment stood up for the OCP_Operations course. Should work elsewhere as well.