### PR TITLE
replacing markdown links with adocs links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,12 +19,12 @@ There are several prerequisites for using this repository, scripted and detailed
     file to your system. (command line instructions can be found in the
        link:./Preparing_your_workstation.adoc[Preparing Your Workstation] document.)
 * Software required on provisioning workstation:
-- [Python](https://www.python.org) version 2.7.x (3.x untested and may not work)
-- [Python Boto](http://docs.pythonboto.org) version 2.41 or greater
-- [Git](http://github.com) any version would do.
-- [Ansible](https://github.com/ansible/ansible) version 2.1.2 or greater
-- [awscli bundle](https://s3.amazonaws.com/aws-cli/awscli-bundle.zip) tested
- with version 1.11.32
+- https://www.python.org[Python] version 2.7.x (3.x untested and may not work)
+- http://docs.pythonboto.org[Python Boto] version 2.41 or greater
+- http://github.com[Git] any version would do.
+- https://github.com/ansible/ansible[Ansible] version 2.1.2 or greater
+- https://s3.amazonaws.com/aws-cli/awscli-bundle.zip[awscli bundle] tested
+  with version 1.11.32
 
 
 == Standard Configurations


### PR DESCRIPTION
Immediately recognized it, because I also do that all the time in adoc files. The links are written the other way around and without `()`.