### PR TITLE
ocp-ha-lab: fix hostname

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -80,14 +80,14 @@
       - must
   - add_host:
       name: "{{item['public_dns_name']}}"
-      shortname: "{{item['tags']['Name'] | default('default_value')}}"
+      shortname: "{{item['tags']['Name'] | default(item['private_dns_name'])}}"
       groups: "{{item['tags']['AnsibleGroup']}},tag_Project_{{env_type| replace('-', '_')}}_{{guid}},tag_{{env_type| replace('-', '_')}}_{{guid}}_{{item['tags'][project_tag] | default('unknowns')}},tag_{{env_type| replace('-', '_')}}_{{guid}}_ostype_{{item['tags'][project_tag_ostype] | default('unknown')}},{{item['tags']['ostype'] | default('unknowns')}},{{item['tags'][project_tag_ostype] | default('unknowns')}}"
       ansible_ssh_user: ec2-user
       remote_user: ec2-user
       ansible_ssh_private_key_file: "{{item['key_name']}}"
       key_name: "{{item['key_name']}}"
       state: "{{item['state']}}"
-      internaldns: "{{item['tags']['internaldns'] | default('default_value')}}"
+      internaldns: "{{item['tags']['internaldns'] | default(item['private_dns_name'])}}"
       region: "{{item['region']}}"
       public_dns_name: "{{item['public_dns_name']}}"
       private_dns_name: "{{item['private_dns_name']}}"

--- a/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/cloud_providers/ec2_cloud_template.j2
@@ -332,6 +332,10 @@
             "Value": "bastion"
           },
           {
+            "Key": "internaldns",
+            "Value": "bastion.{{chomped_zone_internal_dns}}"
+          },
+          {
             "Key": "owner",
             "Value": "{{ email | default('unknown')}}"
           }
@@ -420,6 +424,10 @@
             "Value": "loadbalancer"
           },
           {
+            "Key": "internaldns",
+            "Value": "loadbalancer1.{{chomped_zone_internal_dns}}"
+          },
+          {
             "Key": "owner",
             "Value": "{{ email | default('unknown')}}"
           }
@@ -499,6 +507,10 @@
             {
               "Key": "{{ project_tag }}",
               "Value": "master"
+            },
+            {
+              "Key": "internaldns",
+              "Value": "master{{loop.index}}.{{chomped_zone_internal_dns}}"
             },
             {
               "Key": "owner",
@@ -590,6 +602,10 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "node"
+          },
+          {
+            "Key": "internaldns",
+            "Value": "node{{loop.index}}.{{chomped_zone_internal_dns}}"
           },
           {
             "Key": "owner",
@@ -685,6 +701,10 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "infranode"
+          },
+          {
+            "Key": "internaldns",
+            "Value": "infranode{{loop.index}}.{{chomped_zone_internal_dns}}"
           },
           {
             "Key": "owner",
@@ -785,6 +805,10 @@
           {
             "Key": "{{ project_tag }}",
             "Value": "support"
+          },
+          {
+            "Key": "internaldns",
+            "Value": "support{{loop.index}}.{{chomped_zone_internal_dns}}"
           },
           {
             "Key": "owner",


### PR DESCRIPTION
internaldns tags were missing in the ocp-ha-lab Cloudformation template.

Also add better defaults in `ec2_infrastructure_deployment.yml` for shortname and internaldns vars:
default to `private_dns_name` if tags do not exist.