### PR TITLE
fix ssh key behavior

### DIFF
--- a/ansible/roles/bastion/defaults/main.yml
+++ b/ansible/roles/bastion/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for bastion
+# by default, do not copy over the user's private key
+use_own_key: true

--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -3,26 +3,25 @@
 # tasks file for bastion
 
 ######################### Setting up environment for post deployment administration
-
 - name: copy the environment .pem key
   become: true
   copy:
     src: "{{ ANSIBLE_REPO_PATH }}/workdir/{{ env_authorized_key }}"
-    dest: /root/.ssh/{{env_authorized_key}}
+    dest: /root/.ssh/{{env_authorized_key}}.pem
     owner: root
     group: root
     mode: 0400
-  when: 'use_own_key|bool == false'
+  when: use_own_key|bool
 
-- name: copy the environment .pem key
+- name: copy the user's SSH private key
   become: true
   copy:
     src: "~/.ssh/{{key_name}}.pem"
-    dest: /root/.ssh/{{env_authorized_key}}
+    dest: "/root/.ssh/{{key_name}}.pem"
     owner: root
     group: root
     mode: 0400
-  when: 'use_own_key|bool == true'
+  when: not use_own_key|bool
   tags:
     - copy_env_private_key
 
@@ -30,14 +29,14 @@
 - name: Generate host .ssh/config Template
   become: no
   local_action: template src={{ role_path }}/files/bastion_ssh_config.j2 dest={{ ANSIBLE_REPO_PATH }}/workdir/ssh-config-{{ env_type }}-{{ guid }}
-  when: 'use_own_key|bool == false'
+  when: not use_own_key|bool
   tags:
     - gen_sshconfig_file
 
 - name: Generate host .ssh/config Template
   become: no
   local_action: template src={{ role_path }}/files/bastion_ssh_config_ownkey.j2 dest={{ ANSIBLE_REPO_PATH }}/workdir/ssh-config-{{ env_type }}-{{ guid }}
-  when: 'use_own_key|bool == true'
+  when: use_own_key|bool
   tags:
     - gen_sshconfig_file
 

--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -7,12 +7,12 @@
     owner: root
     group: root
     mode: 0400
+  when: set_env_authorized_key|bool
 
 - name: Set authorized key from file
   authorized_key:
     user: "{{ansible_ssh_user}}"
     state: present
-#    key: "{{ ANSIBLE_REPO_PATH }}/workdir/{{env_authorized_key}}.pub"
     key: "{{ lookup('file', '{{ ANSIBLE_REPO_PATH }}/workdir/{{env_authorized_key}}.pub') }}"
 
 - name: Generate host .ssh/config Template


### PR DESCRIPTION
- set `use_own_key` to true by default so user's private SSH key is not copied to
  bastion
- fix boolean logic:
    `{{key_name}}.pem` was copied to bastion even when `use_own_key` was true
- when copying `{{key_name}}.pem` to bastion, copy it to `{{key_name}}.pem`, not
  `{{env_authorized_key}}`  (probably a typo/omission)