### PR TITLE
Parksmap workload

### DIFF
--- a/ansible/roles/ocp-workload-parksmap-demo/defaults/main.yml
+++ b/ansible/roles/ocp-workload-parksmap-demo/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+ocp_username: jmorales-redhat.com
+ocp_user_needs_quota: True
+
+ocp_user_groups:
+  - OPENTLC-PROJECT-PROVISIONERS
+
+quota_requests_cpu: 5
+quota_limits_cpu: 10
+  
+quota_requests_memory: '6Gi'
+quota_limits_memory: '20Gi'
+
+quota_configmaps: 4
+quota_pods: 20
+quota_persistentvolumeclaims: 5
+quota_services: 15
+quota_secrets: 30
+quota_requests_storage: 5Gi

--- a/ansible/roles/ocp-workload-parksmap-demo/files/workshop-mlbparks.yaml
+++ b/ansible/roles/ocp-workload-parksmap-demo/files/workshop-mlbparks.yaml
@@ -1,0 +1,338 @@
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: mlbparks
+    labels:
+      app: workshop
+      component: mlbparks
+      role: frontend
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - name: latest
+      importPolicy: {}
+      referencePolicy:
+        type: Source
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: mlbparks
+    labels:
+      app: workshop
+      build: mlbparks
+      component: mlbparks
+  spec:
+    failedBuildsHistoryLimit: 5
+    output:
+      to:
+        kind: ImageStreamTag
+        name: mlbparks:latest
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        ref: 1.0.0
+        uri: https://github.com/openshift-roadshow/mlbparks-py
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: python:3.5
+          namespace: openshift
+        incremental: false
+      type: Source
+    successfulBuildsHistoryLimit: 5
+    triggers:
+    - github:
+        secret: ri2F3RF6
+      type: GitHub
+    - generic:
+        secret: L4fu58wx
+      type: Generic
+    - type: ConfigChange
+    - imageChange: {}
+      type: ImageChange
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    name: mlbparks
+    labels:
+      app: workshop
+      component: mlbparks
+      role: frontend
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      app: workshop
+      component: mlbparks
+      deploymentconfig: mlbparks
+      role: frontend
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        post:
+          execNewPod:
+            command:
+            - curl
+            - -s
+            - http://mlbparks:8080/ws/data/load
+            containerName: mlbparks
+          failurePolicy: Ignore
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: workshop
+          component: mlbparks
+          deploymentconfig: mlbparks
+          role: frontend
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: DB_HOST
+            value: mongodb-mlbparks
+          - name: DB_USERNAME
+            valueFrom:
+              configMapKeyRef:
+                key: db.user
+                name: mlbparks
+          - name: DB_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                key: db.password
+                name: mlbparks
+          - name: DB_NAME
+            valueFrom:
+              configMapKeyRef:
+                key: db.name
+                name: mlbparks
+          image: mlbparks
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ws/healthz/
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 120
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: mlbparks
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ws/healthz/
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - mlbparks
+        from:
+          kind: ImageStreamTag
+          name: mlbparks:latest
+      type: ImageChange
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: workshop
+      component: mlbparks
+      role: frontend
+    name: mongodb-mlbparks
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      app: workshop
+      component: mlbparks
+      role: frontend
+      deploymentconfig: mongodb-mlbparks
+    strategy:
+      activeDeadlineSeconds: 21600
+      recreateParams:
+        timeoutSeconds: 600
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: workshop
+          component: mlbparks
+          role: frontend
+          deploymentconfig: mongodb-mlbparks
+      spec:
+        containers:
+        - env:
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+          - name: MONGODB_USER
+            valueFrom:
+              configMapKeyRef:
+                key: db.user
+                name: mlbparks
+          - name: MONGODB_PASSWORD
+            valueFrom:
+              configMapKeyRef:
+                key: db.password
+                name: mlbparks
+          - name: MONGODB_DATABASE
+            valueFrom:
+              configMapKeyRef:
+                key: db.name
+                name: mlbparks
+          - name: MONGODB_ADMIN_PASSWORD
+            value: axPDHoCG
+          image: centos/mongodb-32-centos7@sha256:bf746d7851d334a3a6afb0842e50081abd9c1d2c2c28123bc5c55c0e2fd2b3bb
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 27017
+            timeoutSeconds: 1
+          name: mongodb-mlbparks
+          ports:
+          - containerPort: 27017
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+                --eval="quit()"
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 512Mi
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /var/lib/mongodb/data
+            name: mongodb-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - emptyDir: {}
+          name: mongodb-data
+    test: false
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - mongodb-mlbparks
+        from:
+          kind: ImageStreamTag
+          name: mongodb:3.2
+          namespace: openshift
+      type: ImageChange
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: workshop
+      component: mlbparks
+      role: frontend
+      type: parksmap-backend
+    name: mlbparks
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: mlbparks
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: workshop
+      component: mlbparks
+      role: database
+    name: mongodb-mlbparks
+  spec:
+    ports:
+    - name: mongo
+      port: 27017
+      protocol: TCP
+      targetPort: 27017
+    selector:
+      deploymentconfig: mongodb-mlbparks
+    sessionAffinity: None
+    type: ClusterIP
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: mlbparks
+    labels:
+      app: workshop
+      component: mlbparks
+      role: config
+  data:
+    application.properties: spring.data.mongodb.uri=mongodb://uservIw:YWSRuDpR@mongodb-mlbparks:27017/mongodb
+    db.name: mongodb
+    db.password: YWSRuDpR
+    db.properties: |-
+      db.user=uservIw
+      db.password=YWSRuDpR
+      db.name=mongodb
+    db.user: uservIw

--- a/ansible/roles/ocp-workload-parksmap-demo/files/workshop-nationalparks.yaml
+++ b/ansible/roles/ocp-workload-parksmap-demo/files/workshop-nationalparks.yaml
@@ -1,0 +1,335 @@
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    labels:
+      app: workshop
+      component: nationalparks
+      role: frontend
+    name: nationalparks
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - name: latest
+      importPolicy: {}
+      referencePolicy:
+        type: ""
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    labels:
+      app: workshop
+      component: nationalparks
+      role: frontend
+    name: nationalparks
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: nationalparks:latest
+    postCommit: {}
+    resources: {}
+    runPolicy: Serial
+    source:
+      git:
+        ref: master
+        uri: https://github.com/openshift-roadshow/nationalparks-py
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: python:3.5
+          namespace: openshift
+      type: Source
+    triggers:
+    - generic:
+        secret: 3ce175ca0406c24d
+      type: Generic
+    - github:
+        secret: "0739955342648413"
+      type: GitHub
+    - imageChange: {}
+      type: ImageChange
+    - type: ConfigChange
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    name: nationalparks
+    labels:
+      app: workshop
+      component: nationalparks
+      role: frontend
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: nationalparks
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        post:
+          execNewPod:
+            command:
+            - curl
+            - -s
+            - http://nationalparks:8080/ws/data/load
+            containerName: nationalparks
+          failurePolicy: Ignore
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: workshop
+          component: nationalparks
+          deploymentconfig: nationalparks
+          role: frontend
+      spec:
+        containers:
+        - env:
+          - name: DB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: mongodb-nationalparks
+          - name: DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: mongodb-nationalparks
+          - name: DB_NAME
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: mongodb-nationalparks
+          - name: DB_HOST
+            value: mongodb-nationalparks
+          image: nationalparks
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ws/healthz/
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: nationalparks
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ws/healthz/
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - nationalparks
+        from:
+          kind: ImageStreamTag
+          name: nationalparks:latest
+      type: ImageChange
+    - type: ConfigChange
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: nationalparks
+    labels:
+      app: workshop
+      component: nationalparks
+      role: frontend
+      type: parksmap-backend
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: nationalparks
+    sessionAffinity: None
+    type: ClusterIP
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    name: mongodb-nationalparks
+    labels:
+      app: workshop
+      component: nationalparks
+      role: database
+  spec:
+    replicas: 1
+    selector:
+      deploymentconfig: mongodb-nationalparks
+      app: workshop
+      component: nationalparks
+      role: database
+    strategy:
+      activeDeadlineSeconds: 21600
+      recreateParams:
+        timeoutSeconds: 600
+      resources: {}
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          deploymentconfig: mongodb-nationalparks
+          app: workshop
+          component: nationalparks
+          role: database
+      spec:
+        containers:
+        - env:
+          - name: MONGODB_USER
+            valueFrom:
+              secretKeyRef:
+                key: database-user
+                name: mongodb-nationalparks
+          - name: MONGODB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-password
+                name: mongodb-nationalparks
+          - name: MONGODB_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: database-admin-password
+                name: mongodb-nationalparks
+          - name: MONGODB_DATABASE
+            valueFrom:
+              secretKeyRef:
+                key: database-name
+                name: mongodb-nationalparks
+          image: mongodb
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 27017
+            timeoutSeconds: 1
+          name: mongodb
+          ports:
+          - containerPort: 27017
+            protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -i
+              - -c
+              - mongo 127.0.0.1:27017/$MONGODB_DATABASE -u $MONGODB_USER -p $MONGODB_PASSWORD
+                --eval="quit()"
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 512Mi
+          securityContext:
+            capabilities: {}
+            privileged: false
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /var/lib/mongodb/data
+            name: mongodb-data
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: mongodb-data
+          persistentVolumeClaim:
+            claimName: mongodb-nationalparks
+    test: false
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - mongodb
+        from:
+          kind: ImageStreamTag
+          name: mongodb:3.2
+          namespace: openshift
+      type: ImageChange
+    - type: ConfigChange
+- kind: Service
+  apiVersion: v1
+  metadata:
+    labels:
+      app: workshop
+      component: nationalparks
+      role: database
+    name: mongodb-nationalparks
+  spec:
+    ports:
+    - name: mongo
+      port: 27017
+      protocol: TCP
+      targetPort: 27017
+    selector:
+      deploymentconfig: mongodb-nationalparks
+    sessionAffinity: None
+    type: ClusterIP
+- kind: Secret
+  apiVersion: v1
+  metadata:
+    name: mongodb-nationalparks
+    labels:
+      app: workshop
+      component: nationalparks
+      role: database
+  type: Opaque
+  data:
+    database-admin-password: bW9uZ29kYg==
+    database-name: bW9uZ29kYg==
+    database-password: bW9uZ29kYg==
+    database-user: bW9uZ29kYg==
+- kind: PersistentVolumeClaim
+  apiVersion: v1
+  metadata:
+    name: mongodb-nationalparks
+    labels:
+      app: workshop
+      component: nationalparks
+      role: database
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi

--- a/ansible/roles/ocp-workload-parksmap-demo/files/workshop-parksmap.yaml
+++ b/ansible/roles/ocp-workload-parksmap-demo/files/workshop-parksmap.yaml
@@ -1,0 +1,127 @@
+kind: List
+apiVersion: v1
+metadata: {}
+items:
+- kind: RoleBinding
+  apiVersion: v1
+  groupNames: null
+  metadata:
+    name: view
+  roleRef:
+    name: view
+  subjects:
+  - kind: ServiceAccount
+    name: default
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: parksmap
+    labels:
+      app: workshop
+      component: parksmap
+      role: ui
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - name: 1.2.0
+      from:
+        kind: DockerImage
+        name: docker.io/openshiftroadshow/parksmap:1.2.0
+      importPolicy: {}
+      referencePolicy:
+        type: Source
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: parksmap
+    labels:
+      app: workshop
+      component: parksmap
+      role: ui
+  spec:
+    replicas: 1
+    selector:
+      app: workshop
+      component: parksmap
+      role: ui
+      deploymentconfig: parksmap
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: workshop
+          component: parksmap
+          role: ui
+          deploymentconfig: parksmap
+      spec:
+        containers:
+        - name: parksmap
+          image: parksmap
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - parksmap
+        from:
+          kind: ImageStreamTag
+          name: parksmap:1.2.0
+      type: ImageChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: parksmap
+    labels:
+      app: workshop
+      component: parksmap
+      role: ui
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      deploymentconfig: parksmap
+    sessionAffinity: None
+    type: ClusterIP
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: parksmap
+    labels:
+      app: workshop
+      component: parksmap
+      role: ui
+  spec:
+    host:
+    port:
+      targetPort: 8080-tcp
+    to:
+      kind: Service
+      name: parksmap
+      weight: 100
+    wildcardPolicy: None

--- a/ansible/roles/ocp-workload-parksmap-demo/files/workshopper-template.yaml
+++ b/ansible/roles/ocp-workload-parksmap-demo/files/workshopper-template.yaml
@@ -1,0 +1,165 @@
+kind: Template
+apiVersion: v1
+metadata:
+  name: guide
+  annotations:
+    description: Template to deploy a workshop guide with workshopper. Look into any of the workshops for the used variables that can be defined in the configMap.
+parameters:
+- name: CONTENT_URL_PREFIX
+  description: Console url (e.g. https://raw.githubusercontent.com/osevg/workshopper-content/36)
+  value:  
+  displayName: Content URL prefix
+  required: true
+- name: WORKSHOPS_URLS
+  description: Workshop definition url (e.g. https://raw.githubusercontent.com/osevg/workshopper-content/36/_workshops/training.yml)
+  value:  
+  displayName: Workshop Url
+  required: true
+- name: CONSOLE_ADDRESS
+  description: Console url (e.g. master.mycluster.openshiftworkshop.com or console.mycluster.gce.pixy.io:8443)
+  value:  
+  displayName: Console url
+  required: true
+- name: ROUTER_ADDRESS
+  description: Application subdomain (e.g. apps.mycluster.openshiftworkshop.com or apps.mycluster.gce.pixy.io)
+  value: 
+  displayName: Application subdomain
+  required: true
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: workshopper
+    labels:
+      app: guides
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - name: latest
+      from:
+        kind: DockerImage
+        name: osevg/workshopper:latest
+      importPolicy: {}
+      referencePolicy:
+        type: Source
+- kind: DeploymentConfig
+  apiVersion: v1
+  metadata:
+    name: guides
+    labels:
+      app: guides
+  spec:
+    replicas: 1
+    selector:
+      app: guides
+      deploymentconfig: guides
+    strategy:
+      activeDeadlineSeconds: 21600
+      resources: {}
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: guides
+          deploymentconfig: guides
+      spec:
+        containers:
+        - image: workshopper
+          envFrom:
+            - configMapRef:
+                name: guides
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: guides
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          readinessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - guides
+        from:
+          kind: ImageStreamTag
+          name: workshopper:latest
+      type: ImageChange
+- kind: Service
+  apiVersion: v1
+  metadata:
+    name: guides
+    labels:
+      app: guides
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      app: guides
+      deploymentconfig: guides
+    sessionAffinity: None
+    type: ClusterIP
+- kind: Route
+  apiVersion: v1
+  metadata:
+    name: guides
+    labels:
+      app: guides
+  spec:
+    host:
+    port:
+      targetPort: 8080-tcp
+    to:
+      kind: Service
+      name: guides
+      weight: 100
+    wildcardPolicy: None
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: guides
+    labels:
+      app: guides
+      role: config
+  data:
+    CONTENT_URL_PREFIX: ${CONTENT_URL_PREFIX}
+    WORKSHOPS_URLS: ${WORKSHOPS_URLS}
+    CONSOLE_ADDRESS: ${CONSOLE_ADDRESS}
+    ROUTER_ADDRESS: ${ROUTER_ADDRESS}

--- a/ansible/roles/ocp-workload-parksmap-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-parksmap-demo/readme.adoc
@@ -1,0 +1,133 @@
+= ocp-workload-developer-environment - Sample Config
+
+== Role overview
+
+* This is a simple role that does the following:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment
+*** Adds a user to a list of groups defined in the
+ link:./defaults/main.yml[defaults file].
+*** Sets a cluster resource quota for the user based on the variables in the
+ link:./defaults/main.yml[defaults file] .
+*** Debug task will print out: `pre_workload Tasks Complete`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy the actual
+ workload, i.e, 3scale, Mobile or some Demo
+*** This role doesn't do anything here
+*** Debug task will print out: `workload Tasks Complete`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks Complete`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you
+ need to define to control the deployment of your workload.
+
+* You can modify any of these default values by adding
+`-e"variable_name=variable_value"` to the command line
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ ANSIBLE_REPO_PATH }}/roles/{{ocp_workload}}", when: 'ocp_workload is defined' }
+
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Common configuration to run these playbooks
+You should have these environment variables defined/exported in your system in order
+to run these playbooks.
+
+----
+HOST_GUID=dev37
+TARGET_HOST="bastion.$HOST_GUID.openshift.opentlc.com"
+OCP_USERNAME="jmorales-redhat.com"
+SSH_USER="opentlc-mgr"
+SSH_PRIVATE_KEY="id_rsa"
+GUID=unpoucode
+----
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+----
+WORKLOAD="ocp-workload-parksmap-demo"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+                 -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
+                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ANSIBLE_REPO_PATH=`pwd`" \
+                 -e"ocp_username=${OCP_USERNAME}" \
+                 -e"ocp_workload=${WORKLOAD}" \
+                 -e"guid=${GUID}" \
+                 -e"ocp_user_needs_quota=true" \
+                 -e"ocp_master=master.${HOST_GUID}.openshift.opentlc.com" \
+                 -e"ocp_apps_domain=apps.${HOST_GUID}.openshift.opentlc.com" \
+                 -e"ACTION=create"
+----
+
+=== To Delete an environment
+Use the common configuration first. Then run this.
+
+----
+WORKLOAD="ocp-workload-parksmap-demo"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+                    -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
+                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ANSIBLE_REPO_PATH=`pwd`" \
+                    -e"ocp_username=${OCP_USERNAME}" \
+                    -e"ocp_workload=${WORKLOAD}" \
+                    -e"guid=${GUID}" \
+                    -e"ACTION=remove"
+----
+
+== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection
+ method to your host (Master/Bastion with OC command)
+
+* You can also use the command line to define the hosts directly if your `ssh`
+ configuration is set to connect to the host correctly
+
+* You can also use the command line to use localhost or if your cluster is
+ already authenticated and configured in your `oc` configuration
+[source, ini]
+
+.example inventory file
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_ssh_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com ansible_ssh_host=ec2-11-111-111-11.us-west-2.compute.amazonaws.com
+bastion.cluster4.openshift.opentlc.com
+
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp-workload-parksmap-demo/tasks/main.yml
+++ b/ansible/roles/ocp-workload-parksmap-demo/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Running Pre Workload Tasks
+  include: ./pre_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  include: ./workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  include: ./post_workload.yml
+  become: false
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  include: ./remove_workload.yml
+  become: false
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles/ocp-workload-parksmap-demo/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-parksmap-demo/tasks/post_workload.yml
@@ -1,0 +1,9 @@
+---
+- name: Delete the remote files used in this role
+  file:
+    path: /tmp/{{guid}}
+    state: absent
+
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully"

--- a/ansible/roles/ocp-workload-parksmap-demo/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-parksmap-demo/tasks/pre_workload.yml
@@ -1,0 +1,40 @@
+---
+
+# - name: Add user to developer group (allowed to create projects)
+#   shell: "oadm groups add-users {{item}} {{ocp_username}}"
+#   register: groupadd_register
+#   with_items: "{{ocp_user_groups}}"
+#   when: ocp_username is defined and ocp_user_groups is defined
+#
+# - name: test that command worked
+#   debug:
+#     var: groupadd_register
+#     verbosity: 2
+
+- name: Create user Quota - clusterresourcequota
+  shell: |
+        oc create clusterquota clusterquota-"{{ocp_username}}-{{guid}}" \
+        --project-annotation-selector=openshift.io/requester="{{ocp_username}}" \
+        --hard requests.cpu="{{quota_requests_cpu}}" \
+        --hard limits.cpu="{{quota_limits_cpu}}"  \
+        --hard requests.memory="{{quota_requests_memory}}" \
+        --hard limits.memory="{{quota_limits_memory}}" \
+        --hard configmaps="{{quota_configmaps}}" \
+        --hard pods="{{quota_pods}}" \
+        --hard persistentvolumeclaims="{{quota_persistentvolumeclaims}}"  \
+        --hard services="{{quota_services}}" \
+        --hard secrets="{{quota_secrets}}" \
+        --hard requests.storage="{{quota_requests_storage}}"
+  ignore_errors: true
+
+- name: Copy the files used in this role
+  synchronize:
+    src: "files/"
+    dest: "/tmp/{{guid}}/"
+    rsync_opts:
+      - "--no-motd"
+      - "--exclude=.git,*.qcow2"
+
+- name: pre_workload Tasks Complete
+  debug:
+    msg: "Pre-Software checks completed successfully"

--- a/ansible/roles/ocp-workload-parksmap-demo/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-parksmap-demo/tasks/remove_workload.yml
@@ -1,0 +1,25 @@
+---
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Pre-Software checks completed successfully - Removed"
+
+- name: define ocp_project
+  set_fact:
+    ocp_project: "parksmap-{{guid}}"
+    ocp_project_completed: "parksmap-{{guid}}-completed"
+
+- name: Remove user Project
+  shell: "oc delete project {{ocp_project}}"
+  ignore_errors: true
+
+- name: Remove user Project
+  shell: "oc delete project {{ocp_project_completed}}"
+  ignore_errors: true
+
+- name: Remove user Quota - oc delete clusterresourcequota  "clusterquota-{{ocp_username}}-{{guid}}"
+  shell: oc delete clusterresourcequota clusterquota-{{ocp_username}}-{{guid}}
+  ignore_errors: true
+
+- name: post_workload Tasks Complete
+  debug:
+    msg: "Post-Software checks completed successfully - Removed"

--- a/ansible/roles/ocp-workload-parksmap-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-parksmap-demo/tasks/workload.yml
@@ -1,0 +1,66 @@
+---
+- name: define ocp_project
+  set_fact:
+    ocp_project: "parksmap-{{guid}}"
+    ocp_project_completed: "parksmap-{{guid}}-completed"
+
+    # Templates come from here: https://raw.githubusercontent.com/jorgemoralespou/ose-sample-apps-layouts
+
+- name: Create project for completed parksmap example
+  shell: |
+         oc new-project {{ocp_project_completed}} \
+         --display-name="Parksmap (completed)" \
+         --description="Project with the Parksmap demo completed (and guides)"
+  ignore_errors: true
+
+- name: Deploy Parksmap
+  shell: "oc apply -f /tmp/{{guid}}/workshop-parksmap.yaml -n {{ocp_project_completed}}"
+
+- name: Deploy Nationalparks
+  shell: "oc apply -f /tmp/{{guid}}/workshop-nationalparks.yaml -n {{ocp_project_completed}}"
+
+- name: Deploy MLBParks
+  shell: "oc apply -f /tmp/{{guid}}/workshop-mlbparks.yaml -n {{ocp_project_completed}}"
+
+- name: Add the template guide
+  shell: "oc apply -f /tmp/{{guid}}/workshopper-template.yaml -n {{ocp_project_completed}}"
+
+- name: Deploy the guide to follow
+  shell: |
+          oc new-app guide \
+          -p CONTENT_URL_PREFIX=https://raw.githubusercontent.com/osevg/workshopper-content/master \
+          -p WORKSHOPS_URLS=https://raw.githubusercontent.com/jorgemoralespou/workshopper-content/GPE/_workshops/gpe-parksmap-demo.yml \
+          -p CONSOLE_ADDRESS={{ocp_master}} \
+          -p ROUTER_ADDRESS={{ocp_apps_domain}} \
+          -n "{{ocp_project_completed}}"
+
+- name: Print where's the guide
+  debug:
+    msg: "Guide has been installed in http://guides-{{ocp_project_completed}}.{{ocp_apps_domain}}"
+
+- name: Annotate the completed project as requested by user
+  shell: "oc annotate namespace {{ocp_project_completed}} openshift.io/requester={{ocp_username}} --overwrite"
+
+- name: Give user access to the completed project
+  shell: "oc policy add-role-to-user admin {{ocp_username}} -n {{ocp_project_completed}}"
+
+#
+# Now create an empty project for the user to execute the demo themselves
+#
+
+- name: Create project for empty parksmap
+  shell: |
+         oc new-project {{ocp_project}} \
+         --display-name="Parksmap" \
+         --description="Project to exercise the Parksmap demo"
+  ignore_errors: true
+
+- name: Annotate the empty project as requested by user
+  shell: "oc annotate namespace {{ocp_project}} openshift.io/requester={{ocp_username}} --overwrite"
+
+- name: Give user access to the empty project
+  shell: "oc policy add-role-to-user admin {{ocp_username}} -n {{ocp_project}}"
+
+- name: workload Tasks Complete
+  debug:
+    msg: workload Tasks Complete


### PR DESCRIPTION
This workload deploys a version of parksmap application demo.
It creates 2 projects:
- One with the full demo deployed, and the guides to learn the demo
- One empty project to exercise the demo

There's still some pending changes:
- me understanding better how to include other roles (siamak roles for workshopper and common_facts, etc... although the common facts should be core to the workloads IMHO)
- update to the workshop instructions and move the workshop.yml out of my personal repo into the openshift-labs one