### PR TITLE
Added support for m5.4xlarge instances and CRI-O 

### DIFF
--- a/ansible/configs/ans-tower-lab/env_vars.yml
+++ b/ansible/configs/ans-tower-lab/env_vars.yml
@@ -104,6 +104,13 @@ security_groups:
         rule_type: Ingress
   - name: TowerSG
     rules:
+      - name: SSHTower
+        description: "SSH public"
+        from_port: 22
+        to_port: 22
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
       - name: HTTPTower
         description: "HTTP public"
         from_port: 80

--- a/ansible/configs/ocp-ha-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-lab/env_vars.yml
@@ -38,7 +38,7 @@ config_nfs_uservols: "true"
 user_vols: 200
 user_vols_size: 4Gi
 master_api_port: 443
-osrelease: 3.7.9
+osrelease: 3.9.14
 openshift_master_overwrite_named_certificates: true
 deploy_openshift: true
 deploy_openshift_post: true
@@ -70,7 +70,7 @@ software_to_deploy: "openshift"
 #### OCP IMPLEMENATATION LAB
 ################################################################################
 
-repo_version: '3.7'
+repo_version: '3.9'
 cloudapps_dns: '*.apps.{{subdomain_base}}.'
 master_public_dns: "loadbalancer.{{subdomain_base}}."
 
@@ -89,11 +89,17 @@ common_packages:
   - git
   - vim-enhanced
   - ansible
+  - net-tools
+  - iptables-services
+  - bridge-utils
+  - sos
+  - psacct
 
 rhel_repos:
   - rhel-7-server-rpms
   - rhel-7-server-extras-rpms
   - rhel-7-server-ose-{{repo_version}}-rpms
+  - rhel-7-server-ansible-2.4-rpms
 
 use_subscription_manager: false
 use_own_repos: true
@@ -169,7 +175,7 @@ ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 
 project_tag: "{{ env_type }}-{{ guid }}"
 
-docker_version: "1.12.6"
+docker_version: "1.13.1"
 docker_device: /dev/xvdb
 
 create_internal_dns_entries: true

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.14.j2
@@ -16,6 +16,7 @@ openshift_disable_check="disk_availability,memory_availability,docker_image_avai
 
 # default project node selector
 osm_default_node_selector='env=app'
+openshift_hosted_infra_selector="env=infra"
 
 # Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
 openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['75']}
@@ -23,14 +24,6 @@ openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'imag
 # Configure logrotate scripts
 # See: https://github.com/nickhammond/ansible-logrotate
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
-
-{% if osrelease | version_compare('3.7', '<') %}
-# Anything before 3.7
-openshift_metrics_image_version=v{{ repo_version }}
-#openshift_image_tag=v{{ repo_version }}
-#openshift_release={{ osrelease }}
-#docker_version="{{docker_version}}"
-{% endif %}
 
 
 ###########################################################################
@@ -65,11 +58,6 @@ openshift_portal_net=172.30.0.0/16
 #os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 {{multi_tenant_setting}}
 
-{% if osrelease | version_compare('3.7', '>=') %}
-# This should be turned on once all dependent scripts use firewalld rather than iptables
-# os_firewall_use_firewalld=True
-{% endif %}
-
 ###########################################################################
 ### OpenShift Authentication Vars
 ###########################################################################
@@ -97,8 +85,6 @@ openshift_master_htpasswd_file=/root/htpasswd.openshift
 ###########################################################################
 
 # Enable cluster metrics
-{% if osrelease | version_compare('3.7', '>=') %}
-
 openshift_metrics_install_metrics={{install_metrics}}
 
 openshift_metrics_storage_kind=nfs
@@ -109,7 +95,9 @@ openshift_metrics_storage_volume_name=metrics
 openshift_metrics_storage_volume_size=10Gi
 openshift_metrics_storage_labels={'storage': 'metrics'}
 
-#openshift_master_metrics_public_url=https://hawkular-metrics.{{cloudapps_suffix}}/hawkular/metrics
+openshift_metrics_cassandra_nodeselector={"env":"infra"}
+openshift_metrics_hawkular_nodeselector={"env":"infra"}
+openshift_metrics_heapster_nodeselector={"env":"infra"}
 
 ## Add Prometheus Metrics:
 openshift_hosted_prometheus_deploy=true
@@ -144,28 +132,9 @@ openshift_prometheus_alertbuffer_storage_volume_size=10Gi
 openshift_prometheus_alertbuffer_storage_labels={'storage': 'prometheus-alertbuffer'}
 openshift_prometheus_alertbuffer_storage_type='pvc'
 
-{% else %}
-
-openshift_hosted_metrics_deploy={{install_metrics}}
-
-openshift_hosted_metrics_storage_kind=nfs
-openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
-openshift_hosted_metrics_storage_host=support1.{{guid}}.internal
-openshift_hosted_metrics_storage_nfs_directory=/srv/nfs
-openshift_hosted_metrics_storage_nfs_options='*(rw,root_squash)'
-openshift_hosted_metrics_storage_volume_name=metrics
-openshift_hosted_metrics_storage_volume_size=10Gi
-
-openshift_hosted_metrics_public_url=https://hawkular-metrics.{{cloudapps_suffix}}/hawkular/metrics
-
-{% endif %}
-openshift_metrics_cassandra_nodeselector={"env":"infra"}
-openshift_metrics_hawkular_nodeselector={"env":"infra"}
-openshift_metrics_heapster_nodeselector={"env":"infra"}
+openshift_prometheus_node_exporter_image_version=v3.9
 
 # Enable cluster logging
-{% if osrelease | version_compare('3.7', '>=') %}
-
 openshift_logging_install_logging={{install_logging}}
 
 openshift_logging_storage_kind=nfs
@@ -179,26 +148,6 @@ openshift_logging_storage_labels={'storage': 'logging'}
 # openshift_logging_kibana_hostname=kibana.{{cloudapps_suffix}}
 openshift_logging_es_cluster_size=1
 
-{% else %}
-
-openshift_hosted_logging_deploy={{install_logging}}
-openshift_master_logging_public_url=https://kibana.{{cloudapps_suffix}}
-
-openshift_hosted_logging_storage_kind=nfs
-openshift_hosted_logging_storage_access_modes=['ReadWriteOnce']
-openshift_hosted_logging_storage_nfs_directory=/srv/nfs
-openshift_hosted_logging_storage_nfs_options='*(rw,root_squash)'
-openshift_hosted_logging_storage_volume_name=logging
-openshift_hosted_logging_storage_volume_size=10Gi
-openshift_hosted_logging_hostname=kibana.{{cloudapps_suffix}}
-openshift_hosted_logging_elasticsearch_cluster_size=1
-
-openshift_hosted_logging_deployer_version=v{{repo_version}}
-# This one is wrong (down arrow)
-#openshift_hosted_logging_image_version=v{{repo_version}}
-#openshift_logging_image_version=v{{repo_version}}
-{% endif %}
-
 openshift_logging_es_nodeselector={"env":"infra"}
 openshift_logging_kibana_nodeselector={"env":"infra"}
 openshift_logging_curator_nodeselector={"env":"infra"}
@@ -210,16 +159,13 @@ openshift_logging_curator_nodeselector={"env":"infra"}
 # Configure additional projects
 openshift_additional_projects={'openshift-template-service-broker': {'default_node_selector': ''}}
 
-
 ###########################################################################
 ### OpenShift Router and Registry Vars
 ###########################################################################
 
-openshift_hosted_router_selector='env=infra'
 openshift_hosted_router_replicas={{infranode_instance_count}}
 #openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
 
-openshift_hosted_registry_selector='env=infra'
 openshift_hosted_registry_replicas=1
 
 openshift_hosted_registry_storage_kind=nfs
@@ -237,13 +183,22 @@ openshift_hosted_registry_enforcequota=true
 ### OpenShift Service Catalog Vars
 ###########################################################################
 
-{% if osrelease | version_compare('3.7', '>=') %}
 openshift_enable_service_catalog=true
+
 template_service_broker_install=true
-template_service_broker_selector={"env":"infra"}
 openshift_template_service_broker_namespaces=['openshift']
-ansible_service_broker_install=false
-{% endif %}
+
+ansible_service_broker_install=true
+ansible_service_broker_local_registry_whitelist=['.*-apb$']
+
+openshift_hosted_etcd_storage_kind=nfs
+openshift_hosted_etcd_storage_nfs_options="*(rw,root_squash,sync,no_wdelay)"
+openshift_hosted_etcd_storage_nfs_directory=/srv/nfs
+openshift_hosted_etcd_storage_labels={'storage': 'etcd-asb'}
+openshift_hosted_etcd_storage_volume_name=etcd-asb
+openshift_hosted_etcd_storage_access_modes=['ReadWriteOnce']
+openshift_hosted_etcd_storage_volume_size=10G
+
 
 ###########################################################################
 ### OpenShift Hosts

--- a/ansible/configs/ocp-ha-lab/files/repos_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/repos_template.j2
@@ -34,4 +34,11 @@ baseurl={{own_repo_path}}/rhel-7-fast-datapath-rpms
 enabled=1
 gpgcheck=0
 
+[rhel-7-server-ansible-2.4-rpms]
+name=Red Hat Enterprise Linux 7 Ansible RPMS
+baseurl={{own_repo_path}}/rhel-7-server-ansible-2.4-rpms
+enabled=1
+gpgcheck=0
+
+
 

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -54,11 +54,8 @@ idm_ca_url: http://ipa.opentlc.com/ipa/config/ca.crt
 install_metrics: true
 install_logging: true
 repo_version: "3.9"
-
 docker_version: "{{ '1.12.6' if repo_version | version_compare('3.9', '<')  else '1.13.1' }}"
-docker_device: /dev/xvdb
-# For m5.4xlarge instance types use the following:
-#docker_device: /dev/nvme1n1
+crio_enabled: false
 
 ### If you want a Key Pair name created and injected into the hosts,
 # set `set_env_authorized_key` to true and set the keyname in `env_authorized_key`
@@ -121,6 +118,33 @@ support_instance_count: "{{ 3 if install_glusterfs|bool else 1 }}"
 new_node_instance_count: 0
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
+
+# Set up Docker Device for AWS.
+# For older instance types (c4.4xlarge) the device gets mounted as /dev/xvdb
+# For newer instance types (m5.4xlarge) the device gets mounted as /dev/nvme1n1
+# AWS in the Cloud Formation Template however can't handle '/dev/nvme1n1' as the device name
+
+# AWS c4.4xlarge: /dev/sda1, /dev/xvdb
+# [root@node1 ~]# lsblk
+# NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
+# xvda    202:0    0   50G  0 disk
+# ├─xvda1 202:1    0    1M  0 part
+# └─xvda2 202:2    0   50G  0 part /
+# xvdb    202:16   0  100G  0 disk
+# └─xvdb1 202:17   0  100G  0 part
+
+# AWS m5.4xlarge: /dev/sda1, /dev/sdb
+# [root@ip-192-199-0-132 ~]# lsblk
+# NAME        MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
+# nvme0n1     259:1    0  10G  0 disk
+# ├─nvme0n1p1 259:2    0   1M  0 part
+# └─nvme0n1p2 259:3    0  10G  0 part /
+# nvme1n1     259:0    0  20G  0 disk
+
+# Device Name to be used in the Cloud Formation Template
+aws_docker_device: /dev/xvdb
+# Device Name to be used when creating Docker Volume Group
+docker_device: '{{ "/dev/nvme1n1" if node_instance_type is search ("m5.*") else aws_docker_device }}'
 
 ## This might get removed
 env_specific_images:
@@ -281,7 +305,7 @@ instances:
         value: "linux"
     rootfs_size: "{{ rootfs_size_master }}"
     volumes:
-      - device_name: "{{docker_device}}"
+      - device_name: "{{aws_docker_device}}"
         volume_size: "{{master_docker_size|default(docker_size)|default('20')}}"
         volume_type: gp2
         purpose: docker
@@ -301,7 +325,7 @@ instances:
         value: "linux"
     rootfs_size: "{{ rootfs_size_node }}"
     volumes:
-      - device_name: "{{docker_device}}"
+      - device_name: "{{aws_docker_device}}"
         volume_size: "{{node_docker_size|d(docker_size)|d('100')}}"
         volume_type: gp2
         purpose: docker
@@ -321,7 +345,7 @@ instances:
         value: "linux"
     rootfs_size: "{{ rootfs_size_infranode }}"
     volumes:
-      - device_name: "{{docker_device}}"
+      - device_name: "{{aws_docker_device}}"
         volume_size: "{{infranode_docker_size|d(docker_size)|d('50')}}"
         volume_type: gp2
         purpose: docker
@@ -341,7 +365,7 @@ instances:
         value: "linux"
     rootfs_size: "{{ rootfs_size_support }}"
     volumes:
-      - device_name: "{{docker_device}}"
+      - device_name: "{{aws_docker_device}}"
         volume_size: "{{support_docker_size|d(docker_size)|d('50')}}"
         volume_type: gp2
         purpose: docker

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.14.j2
@@ -16,10 +16,14 @@ ansible_ssh_user={{ansible_ssh_user}}
 deployment_type=openshift-enterprise
 containerized=false
 openshift_disable_check="disk_availability,memory_availability,docker_image_availability"
+{% if crio_enabled|bool %}
+openshift_use_crio=True
+openshift_crio_enable_docker_gc=True
+{% endif %}
 
 # default project node selector
 osm_default_node_selector='env=users'
-openshift_hosted_infra_selector={"env":"infra"}
+openshift_hosted_infra_selector="env=infra"
 
 # Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
 openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['75']}
@@ -215,14 +219,14 @@ openshift_logging_curator_nodeselector={"env":"infra"}
 ### OpenShift Router and Registry Vars
 ###########################################################################
 
-openshift_hosted_router_selector='env=infra'
+# openshift_hosted_router_selector='env=infra'
 openshift_hosted_router_replicas={{infranode_instance_count}}
 
 {% if install_lets_encrypt_certificates|bool %}
 openshift_hosted_router_certificate={"certfile": "/root/.acme.sh/{{ master_lb_dns }}/{{ master_lb_dns }}.cer", "keyfile": "/root/.acme.sh/{{ master_lb_dns }}/{{ master_lb_dns }}.key", "cafile": "/root/lets-encrypt-x3-cross-signed.pem"}
 {% endif %}
 
-openshift_hosted_registry_selector='env=infra'
+# openshift_hosted_registry_selector='env=infra'
 openshift_hosted_registry_replicas=1
 openshift_hosted_registry_pullthrough=true
 openshift_hosted_registry_acceptschema2=true
@@ -249,7 +253,7 @@ openshift_hosted_registry_storage_s3_rootdirectory=/registry
 openshift_enable_service_catalog=true
 
 template_service_broker_install=true
-template_service_broker_selector={"env":"infra"}
+# template_service_broker_selector={"env":"infra"}
 openshift_template_service_broker_namespaces=['openshift']
 
 ansible_service_broker_install=true
@@ -297,12 +301,20 @@ new_nodes
 [nodes]
 ## These are the masters
 {% for host in groups['masters'] %}
+{% if crio_enabled|bool %}
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['placement']}}', 'runtime':'cri-o'}"
+{% else %}
 {{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['placement']}}'}"
+{% endif %}
 {% endfor %}
 
 ## These are infranodes
 {% for host in groups['infranodes'] %}
+{% if crio_enabled|bool %}
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra', 'zone': '{{hostvars[host]['placement']}}', 'runtime':'cri-o'}"
+{% else %}
 {{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra', 'zone': '{{hostvars[host]['placement']}}'}"
+{% endif %}
 {% endfor %}
 
 ## These are regular nodes
@@ -310,13 +322,21 @@ new_nodes
   if host not in groups['newnodes']|d([])
   and host not in groups['glusterfs']|d([])
   %}
+{% if crio_enabled|bool %}
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime':'cri-o'}"
+{% else %}
 {{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{% endif %}
 {% endfor %}
 
 {% if groups['glusterfs']|d([])|length > 0 %}
 ## These are glusterfs nodes
 {% for host in groups['glusterfs'] %}
+{% if crio_enabled|bool %}
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'glusterfs', 'zone': '{{hostvars[host]['placement']}}', 'runtime':'cri-o'}"
+{% else %}
 {{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'glusterfs', 'zone': '{{hostvars[host]['placement']}}'}"
+{% endif %}
 {% endfor %}
 {% endif %}
 
@@ -325,7 +345,11 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
+{% if crio_enabled|bool %}
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime':'cri-o'}"
+{% else %}
 {{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{% endif %}
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -269,6 +269,17 @@
       command: "docker tag registry.access.redhat.com/openshift3/ose-recycler:latest registry.access.redhat.com/openshift3/ose-recycler:v{{ osrelease }}"
       when: osrelease | version_compare('3.7', '>=')
 
+- name: Fix CRI-O Garbage Collection DaemonSet for OCP 3.9 and newer
+  gather_facts: False
+  become: yes
+  hosts: masters[0]
+  tasks:
+    - name: Patch dockergc DaemonSet
+      command: "oc patch daemonset dockergc --patch='\"spec\": { \"template\": { \"spec\": { \"containers\": [ { \"command\": [ \"/usr/bin/oc\" ], \"name\": \"dockergc\" } ] } } }' -n default"
+      when:
+        - osrelease | version_compare('3.9', '>=')
+        - crio_enabled|bool
+
 # Set up Prometheus/Node Exporter/Alertmanager/Grafana
 # on the OpenShift Cluster
 - name: Install Prometheus and Grafana

--- a/ansible/roles/ocp-workload-amq-enmasse/defaults/main.yml
+++ b/ansible/roles/ocp-workload-amq-enmasse/defaults/main.yml
@@ -25,3 +25,6 @@ enmasse_git_url: "https://raw.githubusercontent.com/EnMasseProject/enmasse/{{enm
 admin_user: developer
 keycloak_admin_password: admin
 
+enmasse_repo_url: https://github.com/EnMasseProject/enmasse
+enmasse_repo_tag: 0.18.0
+keycloak_admin_password: admin123

--- a/ansible/roles/ocp-workload-amq-enmasse/defaults/main.yml
+++ b/ansible/roles/ocp-workload-amq-enmasse/defaults/main.yml
@@ -27,4 +27,9 @@ keycloak_admin_password: admin
 
 enmasse_repo_url: https://github.com/EnMasseProject/enmasse
 enmasse_repo_tag: 0.18.0
-keycloak_admin_password: admin123
+keycloak_admin_password: admin
+
+# Using 0.18.0, getting wierd error with keycloak/H2 setup:
+#   Caused by: org.h2.jdbc.JdbcSQLException: The database has been closed [90098-193]
+authentication_services:
+    - none

--- a/ansible/roles/ocp-workload-amq-enmasse/readme.adoc
+++ b/ansible/roles/ocp-workload-amq-enmasse/readme.adoc
@@ -43,8 +43,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"guid=${GUID}" \
                     -e"ocp_user_needs_quota=true" \
                     -e"ocp_apps_domain=apps.${HOST_GUID}.openshift.opentlc.com" \
-                    -e"enmasse_tag=0.17.2" \
-                    -e"enmasse_path=/tmp/enmasse-{{enmasse_tag}}" \
+                    -e"enmasse_repo_tag=0.18.0" \
                     -e"namespace=amq-enmasse-${GUID}" \
                     -e"ACTION=create"
 

--- a/ansible/roles/ocp-workload-amq-enmasse/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-amq-enmasse/tasks/pre_workload.yml
@@ -11,21 +11,21 @@
 #     var: groupadd_register
 #     verbosity: 2
 
-#- name: Create user Quota - clusterresourcequota
-#  shell: |
-#        oc create clusterquota clusterquota-"{{ocp_username}}-{{guid}}" \
-#        --project-annotation-selector=openshift.io/requester="{{ocp_username}}" \
-#        --hard requests.cpu="{{quota_requests_cpu}}" \
-#        --hard limits.cpu="{{quota_limits_cpu}}"  \
-#        --hard requests.memory="{{quota_requests_memory}}" \
-#        --hard limits.memory="{{quota_limits_memory}}" \
-#        --hard configmaps="{{quota_configmaps}}" \
-#        --hard pods="{{quota_pods}}" \
-#        --hard persistentvolumeclaims="{{quota_persistentvolumeclaims}}"  \
-#        --hard services="{{quota_services}}" \
-#        --hard secrets="{{quota_secrets}}" \
-#        --hard requests.storage="{{quota_requests_storage}}"
-#  ignore_errors: true
+- name: Create user Quota - clusterresourcequota
+  shell: |
+        oc create clusterquota clusterquota-"{{ocp_username}}-{{guid}}" \
+        --project-annotation-selector=openshift.io/requester="{{ocp_username}}" \
+        --hard requests.cpu="{{quota_requests_cpu}}" \
+        --hard limits.cpu="{{quota_limits_cpu}}"  \
+        --hard requests.memory="{{quota_requests_memory}}" \
+        --hard limits.memory="{{quota_limits_memory}}" \
+        --hard configmaps="{{quota_configmaps}}" \
+        --hard pods="{{quota_pods}}" \
+        --hard persistentvolumeclaims="{{quota_persistentvolumeclaims}}"  \
+        --hard services="{{quota_services}}" \
+        --hard secrets="{{quota_secrets}}" \
+        --hard requests.storage="{{quota_requests_storage}}"
+  ignore_errors: true
 
 - name: pre_workload Tasks Complete
   debug:

--- a/ansible/roles/ocp-workload-amq-enmasse/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-amq-enmasse/tasks/workload.yml
@@ -29,7 +29,8 @@
       ansible-playbook /tmp/{{namespace}}/enmasse/templates/install/ansible/playbooks/openshift/multitenant.yml \
       -e namespace={{namespace}} \
       -e admin_user={{ocp_username}} \
-      -e keycloak_admin_password={{keycloak_admin_password}}  
+      -e keycloak_admin_password={{keycloak_admin_password}} \
+      -e authentication_services={{authentication_services}}
 
 # ###############################################
 

--- a/ansible/roles/ocp-workload-amq-enmasse/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-amq-enmasse/tasks/workload.yml
@@ -1,71 +1,43 @@
 ---
 
-# Plagarized from the following enmasse roles as per:  ansible/roles/enmasse/tasks/main.yml
-# 1)    plans_standard
-# 2)    plans_brokered
-# 3)    address_controller_sa
-# 4)    address_controller_singletenant
-# 5)    none_authservice
-# 6)    address_controller
-
 # Project and user administration
 
 - name: "Create project for workload {{namespace}}"
   shell: "oc new-project {{namespace}}"
 
-- name: Give ocp_username access to ocp_project
-  shell: "oc policy add-role-to-user admin {{ocp_username}} -n {{namespace}}"
-
 - name: Make sure we go back to default project
   shell: "oc project default"
+
+
+
+# ###############       enmasse specific        ###############
+
+- name: Ensure the following directory exists in remote, /tmp/{{namespace}}/enmasse
+  file:
+    path: "/tmp/{{namespace}}/enmasse"
+    state: directory
+
+- name: Clone community enmasse
+  git:
+    repo: "{{enmasse_repo_url}}"
+    dest: "/tmp/{{namespace}}/enmasse"
+    depth: 1
+    version: "{{enmasse_repo_tag}}"
+
+- name: execute ansible-playbook using shell
+  shell: |
+      ansible-playbook /tmp/{{namespace}}/enmasse/templates/install/ansible/playbooks/openshift/multitenant.yml \
+      -e namespace={{namespace}} \
+      -e admin_user={{ocp_username}} \
+      -e keycloak_admin_password={{keycloak_admin_password}}  
+
+# ###############################################
 
 - name: annotate the project as requested by user
   shell: "oc annotate namespace {{namespace}} openshift.io/requester={{ocp_username}} --overwrite"
 
-
-# As per ansible/roles/plans_standard/tasks/main.yml
-- name: Deploy standard address space plans
-  shell: "oc apply -f {{ enmasse_git_url }}/openshift/addons/standard-plans.yaml"
-
-# As per ansible/roles/plans_brokered/tasks/main.yml
-- name: Deploy brokered address space plans
-  shell: "oc apply -f {{ enmasse_git_url }}/openshift/addons/brokered-plans.yaml"
-
-# As per ansible roles/address_controller_sa/tasks/main.yml
-- name: Check if enmasse-admin SA exists
-  shell: oc get sa enmasse-admin
-  register: sa_exists
-  ignore_errors: True
-- name: Create enmasse-admin SA
-  shell: oc create sa enmasse-admin -n {{ namespace }}
-  when: sa_exists.failed
-
-# As per ansible/roles/address_controller_singletenant/tasks/main.yml
-- name: Check if address-space-admin SA exists
-  shell: oc get sa address-space-admin
-  register: sa_exists
-  ignore_errors: True
-- name: Create address space admin SA
-  shell: oc create sa address-space-admin -n {{ namespace }}
-  when: sa_exists.failed
-- name: Grant view policy to default SA
-  shell: oc policy add-role-to-user view system:serviceaccount:{{ namespace }}:default
-- name: Grant admin policy to enmasse-admin
-  shell: oc policy add-role-to-user admin system:serviceaccount:{{ namespace }}:enmasse-admin
-- name: Grant admin policy to address-space-admin
-  shell: oc policy add-role-to-user admin system:serviceaccount:{{ namespace }}:address-space-admin
-- name: Deploy default address space
-  shell: oc process -f {{ enmasse_git_url }}/openshift/address-space.yaml NAME=default NAMESPACE={{ namespace }} TYPE={{ address_space_type }} PLAN={{ address_space_plan }} | oc apply -n {{ namespace }} -f -
-
-# As per ansible/roles/none_authservice/tasks/main.yml
-- name: Create the none authentication service
-  shell: oc process -f {{ enmasse_git_url }}/openshift/addons/none-authservice.yaml | oc apply -n {{ namespace }} -f -
-
-# As per ansible/roles/address_controller/tasks/main.yml
-- name: Deploy the address controller
-  shell: oc process -f {{ enmasse_git_url }}/openshift/enmasse.yaml ENABLE_RBAC={{ enable_rbac }} ADDRESS_CONTROLLER_CERT_SECRET=address-controller-cert IMPERSONATE_USER={{ admin_user }} | oc apply -n {{ namespace }} -f -
-
-
+- name: Give ocp_username access to ocp_project
+  shell: "oc policy add-role-to-user admin {{ocp_username}} -n {{namespace}}"
 
 - name: workload Tasks Complete
   debug:

--- a/ansible/roles/ocp-workload-fuse-ignite/ilt_provision.sh
+++ b/ansible/roles/ocp-workload-fuse-ignite/ilt_provision.sh
@@ -40,7 +40,7 @@ function help() {
 function login() {
 
     echo -en "\nHOST_GUID=$HOST_GUID\n" >> $LOG_FILE
-    oc login https://master.$HOST_GUID.openshift.opentlc.com -u opentlc-mgr -p r3dh4t1! >> $LOG_FILE
+    oc login https://master.$HOST_GUID.openshift.opentlc.com -u opentlc-mgr -p r3dh4t1!
 }
 
 

--- a/ansible/software_playbooks/openshift.yml
+++ b/ansible/software_playbooks/openshift.yml
@@ -95,6 +95,29 @@
   tags:
     - openshift_node_tasks
 
+- name: Install Atomic and pre-pull CRI-O container for CRI-O installation
+  hosts:
+    - nodes
+    - infranodes
+    - masters
+  become: true
+  gather_facts: false
+  vars_files:
+    - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_vars.yml"
+    - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
+  tags:
+    - cri-o
+  tasks:
+    - name: Install atomic on nodes
+      yum:
+        name: atomic
+        state: present
+      when: crio_enabled|bool
+
+    - name: Pre-pull cri-o image to nodes
+      command: "atomic pull --storage ostree registry.access.redhat.com/openshift3/cri-o:latest"
+      when: crio_enabled|bool  
+
 - name: Configuring glusterfs nodes
   gather_facts: False
   become: yes


### PR DESCRIPTION
Added support for m5.4xlarge instances (**need to be same** on masters, infranodes and nodes).

Also added support for CRI-O (crio_enabled=false/true). The Garbage Collection Daemon Set still crashes though preventing cleanup of build docker containers... (missing fix for bug https://bugzilla.redhat.com/show_bug.cgi?id=1564271). Somehow I needed to pre-install atomic on all nodes and pre-pull the cri-o image - that weirdly failed during running of the prerequisites playbook. With the pre-install/pull it works.
