### PR TITLE
Updated HA Workshop for OCP 3.9

### DIFF
--- a/ansible/configs/ocp-ha-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-lab/env_vars.yml
@@ -38,7 +38,7 @@ config_nfs_uservols: "true"
 user_vols: 200
 user_vols_size: 4Gi
 master_api_port: 443
-osrelease: 3.7.9
+osrelease: 3.9.14
 openshift_master_overwrite_named_certificates: true
 deploy_openshift: true
 deploy_openshift_post: true
@@ -70,7 +70,7 @@ software_to_deploy: "openshift"
 #### OCP IMPLEMENATATION LAB
 ################################################################################
 
-repo_version: '3.7'
+repo_version: '3.9'
 cloudapps_dns: '*.apps.{{subdomain_base}}.'
 master_public_dns: "loadbalancer.{{subdomain_base}}."
 
@@ -89,11 +89,17 @@ common_packages:
   - git
   - vim-enhanced
   - ansible
+  - net-tools
+  - iptables-services
+  - bridge-utils
+  - sos
+  - psacct
 
 rhel_repos:
   - rhel-7-server-rpms
   - rhel-7-server-extras-rpms
   - rhel-7-server-ose-{{repo_version}}-rpms
+  - rhel-7-server-ansible-2.4-rpms
 
 use_subscription_manager: false
 use_own_repos: true
@@ -169,7 +175,7 @@ ansible_ssh_private_key_file: ~/.ssh/{{key_name}}.pem
 
 project_tag: "{{ env_type }}-{{ guid }}"
 
-docker_version: "1.12.6"
+docker_version: "1.13.1"
 docker_device: /dev/xvdb
 
 create_internal_dns_entries: true

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.14.j2
@@ -16,6 +16,7 @@ openshift_disable_check="disk_availability,memory_availability,docker_image_avai
 
 # default project node selector
 osm_default_node_selector='env=app'
+openshift_hosted_infra_selector="env=infra"
 
 # Configure node kubelet arguments. pods-per-core is valid in OpenShift Origin 1.3 or OpenShift Container Platform 3.3 and later.
 openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'image-gc-high-threshold': ['85'], 'image-gc-low-threshold': ['75']}
@@ -23,14 +24,6 @@ openshift_node_kubelet_args={'pods-per-core': ['10'], 'max-pods': ['250'], 'imag
 # Configure logrotate scripts
 # See: https://github.com/nickhammond/ansible-logrotate
 logrotate_scripts=[{"name": "syslog", "path": "/var/log/cron\n/var/log/maillog\n/var/log/messages\n/var/log/secure\n/var/log/spooler\n", "options": ["daily", "rotate 7","size 500M", "compress", "sharedscripts", "missingok"], "scripts": {"postrotate": "/bin/kill -HUP `cat /var/run/syslogd.pid 2> /dev/null` 2> /dev/null || true"}}]
-
-{% if osrelease | version_compare('3.7', '<') %}
-# Anything before 3.7
-openshift_metrics_image_version=v{{ repo_version }}
-#openshift_image_tag=v{{ repo_version }}
-#openshift_release={{ osrelease }}
-#docker_version="{{docker_version}}"
-{% endif %}
 
 
 ###########################################################################
@@ -65,11 +58,6 @@ openshift_portal_net=172.30.0.0/16
 #os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 {{multi_tenant_setting}}
 
-{% if osrelease | version_compare('3.7', '>=') %}
-# This should be turned on once all dependent scripts use firewalld rather than iptables
-# os_firewall_use_firewalld=True
-{% endif %}
-
 ###########################################################################
 ### OpenShift Authentication Vars
 ###########################################################################
@@ -97,8 +85,6 @@ openshift_master_htpasswd_file=/root/htpasswd.openshift
 ###########################################################################
 
 # Enable cluster metrics
-{% if osrelease | version_compare('3.7', '>=') %}
-
 openshift_metrics_install_metrics={{install_metrics}}
 
 openshift_metrics_storage_kind=nfs
@@ -109,7 +95,9 @@ openshift_metrics_storage_volume_name=metrics
 openshift_metrics_storage_volume_size=10Gi
 openshift_metrics_storage_labels={'storage': 'metrics'}
 
-#openshift_master_metrics_public_url=https://hawkular-metrics.{{cloudapps_suffix}}/hawkular/metrics
+openshift_metrics_cassandra_nodeselector={"env":"infra"}
+openshift_metrics_hawkular_nodeselector={"env":"infra"}
+openshift_metrics_heapster_nodeselector={"env":"infra"}
 
 ## Add Prometheus Metrics:
 openshift_hosted_prometheus_deploy=true
@@ -144,28 +132,9 @@ openshift_prometheus_alertbuffer_storage_volume_size=10Gi
 openshift_prometheus_alertbuffer_storage_labels={'storage': 'prometheus-alertbuffer'}
 openshift_prometheus_alertbuffer_storage_type='pvc'
 
-{% else %}
-
-openshift_hosted_metrics_deploy={{install_metrics}}
-
-openshift_hosted_metrics_storage_kind=nfs
-openshift_hosted_metrics_storage_access_modes=['ReadWriteOnce']
-openshift_hosted_metrics_storage_host=support1.{{guid}}.internal
-openshift_hosted_metrics_storage_nfs_directory=/srv/nfs
-openshift_hosted_metrics_storage_nfs_options='*(rw,root_squash)'
-openshift_hosted_metrics_storage_volume_name=metrics
-openshift_hosted_metrics_storage_volume_size=10Gi
-
-openshift_hosted_metrics_public_url=https://hawkular-metrics.{{cloudapps_suffix}}/hawkular/metrics
-
-{% endif %}
-openshift_metrics_cassandra_nodeselector={"env":"infra"}
-openshift_metrics_hawkular_nodeselector={"env":"infra"}
-openshift_metrics_heapster_nodeselector={"env":"infra"}
+openshift_prometheus_node_exporter_image_version=v3.9
 
 # Enable cluster logging
-{% if osrelease | version_compare('3.7', '>=') %}
-
 openshift_logging_install_logging={{install_logging}}
 
 openshift_logging_storage_kind=nfs
@@ -179,26 +148,6 @@ openshift_logging_storage_labels={'storage': 'logging'}
 # openshift_logging_kibana_hostname=kibana.{{cloudapps_suffix}}
 openshift_logging_es_cluster_size=1
 
-{% else %}
-
-openshift_hosted_logging_deploy={{install_logging}}
-openshift_master_logging_public_url=https://kibana.{{cloudapps_suffix}}
-
-openshift_hosted_logging_storage_kind=nfs
-openshift_hosted_logging_storage_access_modes=['ReadWriteOnce']
-openshift_hosted_logging_storage_nfs_directory=/srv/nfs
-openshift_hosted_logging_storage_nfs_options='*(rw,root_squash)'
-openshift_hosted_logging_storage_volume_name=logging
-openshift_hosted_logging_storage_volume_size=10Gi
-openshift_hosted_logging_hostname=kibana.{{cloudapps_suffix}}
-openshift_hosted_logging_elasticsearch_cluster_size=1
-
-openshift_hosted_logging_deployer_version=v{{repo_version}}
-# This one is wrong (down arrow)
-#openshift_hosted_logging_image_version=v{{repo_version}}
-#openshift_logging_image_version=v{{repo_version}}
-{% endif %}
-
 openshift_logging_es_nodeselector={"env":"infra"}
 openshift_logging_kibana_nodeselector={"env":"infra"}
 openshift_logging_curator_nodeselector={"env":"infra"}
@@ -210,16 +159,13 @@ openshift_logging_curator_nodeselector={"env":"infra"}
 # Configure additional projects
 openshift_additional_projects={'openshift-template-service-broker': {'default_node_selector': ''}}
 
-
 ###########################################################################
 ### OpenShift Router and Registry Vars
 ###########################################################################
 
-openshift_hosted_router_selector='env=infra'
 openshift_hosted_router_replicas={{infranode_instance_count}}
 #openshift_hosted_router_certificate={"certfile": "/path/to/router.crt", "keyfile": "/path/to/router.key", "cafile": "/path/to/router-ca.crt"}
 
-openshift_hosted_registry_selector='env=infra'
 openshift_hosted_registry_replicas=1
 
 openshift_hosted_registry_storage_kind=nfs
@@ -237,13 +183,22 @@ openshift_hosted_registry_enforcequota=true
 ### OpenShift Service Catalog Vars
 ###########################################################################
 
-{% if osrelease | version_compare('3.7', '>=') %}
 openshift_enable_service_catalog=true
+
 template_service_broker_install=true
-template_service_broker_selector={"env":"infra"}
 openshift_template_service_broker_namespaces=['openshift']
-ansible_service_broker_install=false
-{% endif %}
+
+ansible_service_broker_install=true
+ansible_service_broker_local_registry_whitelist=['.*-apb$']
+
+openshift_hosted_etcd_storage_kind=nfs
+openshift_hosted_etcd_storage_nfs_options="*(rw,root_squash,sync,no_wdelay)"
+openshift_hosted_etcd_storage_nfs_directory=/srv/nfs
+openshift_hosted_etcd_storage_labels={'storage': 'etcd-asb'}
+openshift_hosted_etcd_storage_volume_name=etcd-asb
+openshift_hosted_etcd_storage_access_modes=['ReadWriteOnce']
+openshift_hosted_etcd_storage_volume_size=10G
+
 
 ###########################################################################
 ### OpenShift Hosts

--- a/ansible/configs/ocp-ha-lab/files/repos_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/repos_template.j2
@@ -34,4 +34,11 @@ baseurl={{own_repo_path}}/rhel-7-fast-datapath-rpms
 enabled=1
 gpgcheck=0
 
+[rhel-7-server-ansible-2.4-rpms]
+name=Red Hat Enterprise Linux 7 Ansible RPMS
+baseurl={{own_repo_path}}/rhel-7-server-ansible-2.4-rpms
+enabled=1
+gpgcheck=0
+
+
 


### PR DESCRIPTION
@newgoliath @sborenst @fridim Please review. Updated HA Workshop for 3.9. I also removed all logic for releases before 3.7. We don't run any classes on earlier versions any more.