### PR TITLE
Correction to reference to 3scale workload file

### DIFF
--- a/ansible/roles/ocp-workload-fuse-ignite/readme.adoc
+++ b/ansible/roles/ocp-workload-fuse-ignite/readme.adoc
@@ -54,8 +54,8 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 
 == Execution using localhost oc client
-
-WORKLOAD="ocp-workload-3scale-multitenant"
+----
+WORKLOAD="ocp-workload-fuse-ignite"
 HOST_GUID=dev39
 GUID=adm0
 POSTGRESQL_MEMORY_LIMIT=512Mi
@@ -80,3 +80,4 @@ ansible-playbook -i localhost, -c local ./configs/ocp-workloads/ocp-workload.yml
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=$GUID" \
                     -e"ACTION=remove"
+----


### PR DESCRIPTION
On line 58 of the readme.adoc, *ocp-workload-fuse-ignite* should replace *ocp-workload-3scale-multitenant*