### PR TITLE
fix tower admin name, fix tower setup delegation to bastion and fix ansible_host for the inventory

### DIFF
--- a/ansible/configs/ansible-cicd-lab/create_host.yml
+++ b/ansible/configs/ansible-cicd-lab/create_host.yml
@@ -2,7 +2,7 @@
 
 - name: Set Hostname
   set_fact:
-    lab_host_hostname: "{{ hostvars[lab_host]['ansible_host'] }}"
+    lab_host_hostname: "{{ hostvars[lab_host]['ansible_host'] | default(hostvars[lab_host]['ansible_ssh_host']) | default(hostvars[lab_host]['inventory_hostname']) }}"
 
 - name: Determine if Host Exists
   uri:

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -268,6 +268,7 @@ jenkins_admin_password: r3dh4t1!
 
 ### Tower Variables
 
+tower_admin: admin # don't change this! There are places where no variable is used.
 tower_org_name: Acme
 tower_project_name: Acme
 tower_project_scm: git

--- a/ansible/configs/ansible-cicd-lab/post_software.yml
+++ b/ansible/configs/ansible-cicd-lab/post_software.yml
@@ -27,8 +27,7 @@
     - { role: "{{ ANSIBLE_REPO_PATH }}/roles/host-jenkins-server" }
     - { role: "{{ ANSIBLE_REPO_PATH }}/roles/molecule" }
 
-- hosts: localhost
-  connection: local
+- hosts: bastion
   become: false
   vars_files:
     - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_vars.yml"
@@ -38,7 +37,7 @@
   tasks:
     - include_tasks: tower_setup.yml
       vars:
-        bastion_host: "{{ groups['bastion'][0] }}"
+        ansible_tower_ip: "{{ groups['towers'][0] }}"
 
 - name: PostSoftware flight-check
   hosts: localhost

--- a/ansible/configs/ansible-cicd-lab/tower_setup.yml
+++ b/ansible/configs/ansible-cicd-lab/tower_setup.yml
@@ -162,7 +162,6 @@
     src: "/root/.ssh/{{ guid }}key.pem"
   register: credential_ssh_key
   no_log: True
-  delegate_to: "{{ bastion_host }}"
   when: response.json.count == 0
 
 - name: Create Credential


### PR DESCRIPTION
At the subject says. The setup works now but there seems to still be issues with the credentials or something around it: doing a ping on the hosts from the inventory in Tower doesn't yet work, I didn't analyse in depth, running out of time. Merge and continue from there.