### PR TITLE
rhte-ocp-workshop: ignore errors when creating clientVM DNS records

### DIFF
--- a/ansible/configs/rhte-ocp-workshop/post_infra.yml
+++ b/ansible/configs/rhte-ocp-workshop/post_infra.yml
@@ -58,6 +58,7 @@
           ttl: 90
           value: "{{hostvars[item].public_ip_address}}"
         with_items: "{{groups['clientvms']}}"
+        ignore_errors: yes
         loop_control:
           index_var: idx
           pause: 2


### PR DESCRIPTION
We can manually add them for a couple of clientVM, no big deal.