### PR TITLE
rhte-ocp-workshop: populate /etc/hosts for internaldns

### DIFF
--- a/ansible/configs/rhte-ocp-workshop/pre_software.yml
+++ b/ansible/configs/rhte-ocp-workshop/pre_software.yml
@@ -91,6 +91,14 @@
   roles:
     - { role: "{{ ANSIBLE_REPO_PATH }}/roles/bastion", when: 'install_bastion' }
     - { role: "{{ ANSIBLE_REPO_PATH }}/roles/bastion-student-user", when: student_password is defined }
+  tasks:
+    - name: Populate /etc/hosts with internaldns to relief route53
+      lineinfile:
+        dest: /etc/hosts
+        regexp: "{{ hostvars[item].internaldns }}$"
+        line: "{{ hostvars[item].private_ip_address}} {{ hostvars[item].internaldns }}"
+      when: item not in [ 'localhost' ]
+      with_items: "{{ groups['all'] }}"
 
 - name: Configuring Bastion Hosts
   hosts: clientvms


### PR DESCRIPTION
Error is :

Failed to connect to the host via ssh: ssh: Could not resolve hostname support1.8d25.internal

during playbook run from bastion.

Populate /etc/hosts to keep dns resolution local.