### PR TITLE
rhte-oc-cluster-vms: Fix reboot

### DIFF
--- a/ansible/configs/rhte-oc-cluster-vms/post_software.yml
+++ b/ansible/configs/rhte-oc-cluster-vms/post_software.yml
@@ -90,12 +90,14 @@
     when: r_systemd is failed
     block:
       - name: Reboot VM
-        command: shutdown -r now
+        command: shutdown -r +1
+        async: 0
+        poll: 0
         ignore_errors: yes
 
       - name: wait for linux host to be available (retry)
         wait_for_connection:
-          delay: 60
+          delay: 90
           timeout: 200
 
       - ping:


### PR DESCRIPTION
Error is:

TASK [Reboot VM] ***************************************************************
Friday 07 September 2018  13:10:04 +0000 (0:05:02.849)       0:17:49.293 ******
fatal: [clientvm.ce4a.internal]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Shared connection to ec2-18-182-111-209.ap-northeast-1.compute.amazonaws.com closed.\r\n", "unreachable": true}
        to retry, use: --limit
        @/tmp/rhte-oc-cluster-vms-ce4a/ansible_agnostic_deployer/ansible/main.retry

'ignore_errors' is not enough because SSH connection is close by 'shutdown -r
now'

use async + poll=0 too.