### PR TITLE
Switches to file repos and adds missing cloudapps dns entry

### DIFF
--- a/ansible/configs/ocp-gpu-single-node/env_vars.yml
+++ b/ansible/configs/ocp-gpu-single-node/env_vars.yml
@@ -8,15 +8,15 @@
 
 ### Vars that can be removed:
 # use_satellite: true
-# use_subscription_manager: false
-# use_own_repos: false
+use_subscription_manager: false
+use_own_repos: true
 
 ###### VARIABLES YOU SHOULD CONFIGURE FOR YOUR DEPLOYEMNT
 ###### OR PASS as "-e" args to ansible-playbook command
 
 ### Common Host settings
 repo_version: "3.10"
-repo_method: rhn # Other Options are: file, satellite and rhn
+repo_method: file # Other Options are: file, satellite and rhn
 
 #If using repo_method: satellite, you must set these values as well.
 # satellite_url: https://satellite.example.com

--- a/ansible/configs/ocp-gpu-single-node/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-gpu-single-node/files/cloud_providers/ec2_cloud_template.j2
@@ -284,6 +284,23 @@ Resources:
             - "Fn::GetAtt":
               - {{instance['name']}}{{loop.index}}
               - PublicIp
+
+# cloud dns is same as the bastion which is our only host
+  {{instance['name']}}{{loop.index}}CloudDNS:
+    Type: "AWS::Route53::RecordSetGroup"
+    DependsOn:
+      - {{instance['name']}}{{loop.index}}EIP
+    Properties:
+      HostedZoneId: {{HostedZoneId}}
+      RecordSets:
+        - Name: "{{cloudapps_dns}}"
+          Type: A
+          TTL: 900
+          ResourceRecords:
+            - Fn::GetAtt:
+                - {{instance['name']}}{{loop.index}}
+                - PublicIp
+
 {% endif %}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
I was missing a DNS entry for the router in my cloudformation template. I was also using RHSM and now that GPTE has the 3.10.14 repos I have switched to using "file".