### PR TITLE
Protect rabbitmq password to avoid non-alphanumerical passwords

### DIFF
--- a/ansible/configs/ansible-cicd-lab/files/tower_hosts_template.j2
+++ b/ansible/configs/ansible-cicd-lab/files/tower_hosts_template.j2
@@ -22,7 +22,8 @@ rabbitmq_port=5672
 rabbitmq_vhost=tower
 
 rabbitmq_username=tower
-rabbitmq_password={{tower_admin_password}}
+# because RabbitMQ accepts only alpha-numeric passwords with no special characters
+rabbitmq_password={{ tower_admin_password | regex_replace('[^a-zA-Z0-9]') }}
 rabbitmq_cookie=cookiemonster
 
 rabbitmq_use_long_name=true


### PR DESCRIPTION
RabbitMQ doesn't like non-alphanumerical passwords according to https://docs.ansible.com/ansible-tower/latest/html/installandreference/tower_install_wizard.html (and based on experience).

I've fixed this by protecting the password using a regexp_replace.

Side note: if this proves working for the CI/CD Lab, it should be fixed in a generic manner, there are other places potentially impacted:

```
[.../ansible_agnostic_deployer]$ grep -r rabbitmq_password .
./ansible/configs/ans-tower-lab/files/tower_hosts_template.j2:rabbitmq_password="{{tower_admin_password}}"
./ansible/configs/ansible-cicd-lab/files/tower_hosts_template.j2:rabbitmq_password={{ tower_admin_password | regex_replace('[^a-zA-Z0-9]') }}
./ansible/roles/install-tower/templates/tower_template_inventory.j2:rabbitmq_password={{tower_admin_password}}
```