### PR TITLE
Add variable to fix Tower version instead of latest.

### DIFF
--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -278,6 +278,7 @@ jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
 
 ### Tower Variables
 
+tower_setup_version: "3.2.6" # default would be latest, which is dangerous
 tower_admin: admin # don't change this! There are places where no variable is used.
 tower_org_name: Acme
 tower_project_name: Acme

--- a/ansible/software_playbooks/tower.yml
+++ b/ansible/software_playbooks/tower.yml
@@ -49,7 +49,7 @@
         dest: "{{tower_inventory_path}}"
     - name: unarchive the latest tower software
       unarchive:
-        src: "https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-latest.tar.gz"
+        src: "https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-{{ tower_setup_version | default('latest') }}.tar.gz"
         dest: /opt/tower
         remote_src: yes
 


### PR DESCRIPTION
Add variable `tower_setup_version` to fix Tower version instead of latest. Latest broke our build after Tower 3.3 was released.