### PR TITLE
Bigger VMs, Docker and more idempotency for Ansible CI/CD Lab

### DIFF
--- a/ansible/configs/ansible-cicd-lab/docker_setup.yml
+++ b/ansible/configs/ansible-cicd-lab/docker_setup.yml
@@ -1,0 +1,24 @@
+---
+- name: Install Docker.
+  package:
+    name: docker
+    state: present
+
+- name: Add docker group if it doesn't yet exist.
+  group:
+    name: docker
+    state: present
+    system: true
+
+- name: Ensure Docker is started and enabled at boot.
+  service:
+    name: docker
+    state: started
+    enabled: true
+
+- name: Ensure docker users are added to the docker group.
+  user:
+    name: "{{ item }}"
+    groups: docker
+    append: yes
+  with_items: "{{ docker_users }}"

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -88,8 +88,8 @@ subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
 ## Environment Sizing
 
 bastion_instance_type: "m4.large"
-tower_instance_type: "m4.large"
-cicd_instance_type: "m4.large"
+tower_instance_type: "m4.xlarge"
+cicd_instance_type: "m4.xlarge"
 app_instance_type: "m4.large"
 appdb_instance_type: "m4.large"
 support_instance_type: "m4.large"

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -295,3 +295,9 @@ tower_credential_username: ec2-user
 ansible_service_mgr: systemd
 gogs_admin_username: cicduser1
 gogs_admin_password: r3dh4t!
+
+### Docker variables (Docker is needed by Molecule)
+docker_users:
+  - jenkins
+  - git
+  - "{{ remote_user }}"

--- a/ansible/configs/ansible-cicd-lab/post_software.yml
+++ b/ansible/configs/ansible-cicd-lab/post_software.yml
@@ -36,6 +36,10 @@
     - { role: "{{ ANSIBLE_REPO_PATH }}/roles/host-jenkins-server" }
     - { role: "{{ ANSIBLE_REPO_PATH }}/roles/molecule" }
 
+  tasks:
+    - name: include docker_setup tasks
+      include_tasks: docker_setup.yml
+
 - hosts: bastions
   become: false
   vars_files:

--- a/ansible/configs/ansible-cicd-lab/requirements.yml
+++ b/ansible/configs/ansible-cicd-lab/requirements.yml
@@ -1,5 +1,9 @@
 # Use with `ansible-galaxy install --force -r requirements.yml -p ../../roles/`
 # (only during development, not during installation)
 ---
-- src: geerlingguy.jenkins
-  name: host-jenkins-server
+# commented out as it has been customized to support SSL
+#- src: geerlingguy.jenkins
+#  name: host-jenkins-server
+# this installs docker from the Docker Inc. repositories, not what we want
+#- src: geerlingguy.docker
+#  name: host-docker-server

--- a/ansible/roles/host-gogs-server/tasks/main.yml
+++ b/ansible/roles/host-gogs-server/tasks/main.yml
@@ -4,4 +4,6 @@
     url: http://{{ ansible_hostname }}:3000/install
     method: POST
     body: "{{ lookup('template', 'templates/gogs_config.j2') }}"
-    status_code: 302
+    status_code:
+    - 302
+    - 404 # because the /install URL disappears after configuration

--- a/ansible/roles/host-jenkins-server/tasks/main.yml
+++ b/ansible/roles/host-jenkins-server/tasks/main.yml
@@ -54,7 +54,7 @@
     dest: "{{ jenkins_jar_location }}"
     validate_certs: no
   register: jarfile_get
-  until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg"
+  until: "'OK' in jarfile_get.msg or 'file already exists' in jarfile_get.msg or 'Not Modified' in jarfile_get.msg"
   retries: 5
   delay: 10
   check_mode: no


### PR DESCRIPTION
- Make Jenkins and Gogs roles more idempotent.
- Add Docker to CI/CD server.
- Push Tower and CI/CD VMs to xlarge.