### PR TITLE
unify passwords and users

### DIFF
--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -266,13 +266,13 @@ jenkins_plugins:
   - extended-choice-parameter # Extended Choice Parameter
   - ansible-tower         # Ansible Tower Plugin
 jenkins_plugin_timeout: 240 # Jenkins tends to run into timeout while installing plug-ins
-jenkins_admin_password: r3dh4t1!
+jenkins_admin_password: "{{ tower_admin_password }}"
 jenkins_protocol: "https"
 jenkins_selfsigned_certificate: yes
 jenkins_port: 8443
 jenkins_home: /var/lib/jenkins
 jenkins_keystore_path: "/opt/jenkins/jenkins.jks"
-jenkins_keystore_password: "r3dh4t1!"
+jenkins_keystore_password: "{{ tower_admin_password }}"
 jenkins_url_prefix: ""
 jenkins_java_options_env_var: JENKINS_JAVA_OPTIONS
 jenkins_java_options: "-Djenkins.install.runSetupWizard=false"
@@ -295,8 +295,8 @@ tower_credential_username: ec2-user
 
 ### Gogs Variables
 ansible_service_mgr: systemd
-gogs_admin_username: cicduser1
-gogs_admin_password: r3dh4t!
+gogs_admin_username: admin
+gogs_admin_password: "{{ tower_admin_password }}"
 
 ### Docker variables (Docker is needed by Molecule)
 docker_users:


### PR DESCRIPTION
Make sure all app users are called admin and have the same (usual) password.