### PR TITLE
Add python-py library to Molecule role

### DIFF
--- a/ansible/roles/molecule/defaults/main.yml
+++ b/ansible/roles/molecule/defaults/main.yml
@@ -7,3 +7,4 @@ molecule_yum_packages:
 
 molecule_pip_packages:
   - molecule
+  - docker-py


### PR DESCRIPTION
Add python-py library to use Docker as a Molecule driver.