### PR TITLE
Force reinstallation of configparser lib

### DIFF
--- a/ansible/roles/molecule/tasks/main.yml
+++ b/ansible/roles/molecule/tasks/main.yml
@@ -8,3 +8,8 @@
   pip:
     name: "{{ molecule_pip_packages }}"
     state: present
+
+- name: Force reinstallation of configparser lib
+  pip:
+    name: configparser
+    state: forcereinstall


### PR DESCRIPTION
configparser lib is in a bad state after the installation of Molecule making flake8 unusable (python linter)
A reinstallation of the library fixes the issue
