### PR TITLE
ocp-ha-lab: add ocs version lock

### DIFF
--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.10.34.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.10.34.j2
@@ -66,6 +66,22 @@ openshift_master_default_subdomain={{cloudapps_suffix}}
 #openshift_master_ca_certificate={'certfile': '/root/intermediate_ca.crt', 'keyfile': '/root/intermediate_ca.key'}
 openshift_master_overwrite_named_certificates={{openshift_master_overwrite_named_certificates}}
 
+# GlsuterFS version
+#  Knowledgebase
+#   https://access.redhat.com/solutions/3617551
+#  Bugzilla
+#   https://bugzilla.redhat.com/show_bug.cgi?id=163.1057
+#  Complete OpenShift GlusterFS Configuration README
+#   https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_storage_glusterfs
+openshift_storage_glusterfs_version=v3.10
+openshift_storage_glusterfs_block_version=v3.10
+openshift_storage_glusterfs_s3_version=v3.10
+openshift_storage_glusterfs_heketi_version=v3.10
+# openshift_storage_glusterfs_registry_version=v3.10
+# openshift_storage_glusterfs_registry_block_version=v3.10
+# openshift_storage_glusterfs_registry_s3_version=v3.10
+# openshift_storage_glusterfs_registry_heketi_version=v3.10
+
 ###########################################################################
 ### OpenShift Network Vars
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.41.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.41.j2
@@ -34,6 +34,23 @@ openshift_master_overwrite_named_certificates={{openshift_master_overwrite_named
 # Set this line to enable NFS
 openshift_enable_unsupported_configurations=True
 
+# GlsuterFS version
+#  Knowledgebase
+#   https://access.redhat.com/solutions/3617551
+#  Bugzilla
+#   https://bugzilla.redhat.com/show_bug.cgi?id=1630957
+#  Complete OpenShift GlusterFS Configuration README
+#   https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_storage_glusterfs
+openshift_storage_glusterfs_version=v3.9
+openshift_storage_glusterfs_block_version=v3.9
+openshift_storage_glusterfs_s3_version=v3.9
+openshift_storage_glusterfs_heketi_version=v3.9
+# openshift_storage_glusterfs_registry_version=v3.9
+# openshift_storage_glusterfs_registry_block_version=v3.9
+# openshift_storage_glusterfs_registry_s3_version=v3.9
+# openshift_storage_glusterfs_registry_heketi_version=v3.9
+
+
 ###########################################################################
 ### OpenShift Network Vars
 ###########################################################################


### PR DESCRIPTION
default setting is "latest." 

prevent unintended upgrades by specifying version.