### PR TITLE
Fix ec2_remote_facts deprecation warnings

### DIFF
--- a/ansible/configs/archive/ocp-storage-cns_based_on_ocp-workshop/post_software.yml
+++ b/ansible/configs/archive/ocp-storage-cns_based_on_ocp-workshop/post_software.yml
@@ -562,7 +562,7 @@
       register: ansible_agnostic_deployer_head
 
     - name: Gather ec2 facts
-      ec2_remote_facts:
+      ec2_instance_facts:
         aws_access_key: "{{ aws_access_key_id }}"
         aws_secret_key: "{{ aws_secret_access_key }}"
         region: "{{ aws_region_final|d(aws_region) }}"

--- a/ansible/configs/ocp-workshop/post_software.yml
+++ b/ansible/configs/ocp-workshop/post_software.yml
@@ -808,7 +808,7 @@
     register: ansible_agnostic_deployer_head
 
   - name: Gather ec2 facts
-    ec2_remote_facts:
+    ec2_instance_facts:
       aws_access_key: "{{ aws_access_key_id }}"
       aws_secret_key: "{{ aws_secret_access_key }}"
       region: "{{ aws_region_final|d(aws_region) }}"

--- a/ansible/configs/rhte-ocp-workshop/post_software.yml
+++ b/ansible/configs/rhte-ocp-workshop/post_software.yml
@@ -833,7 +833,7 @@
     register: ansible_agnostic_deployer_head
 
   - name: Gather ec2 facts
-    ec2_remote_facts:
+    ec2_instance_facts:
       aws_access_key: "{{ aws_access_key_id }}"
       aws_secret_key: "{{ aws_secret_access_key }}"
       region: "{{ aws_region_final|d(aws_region) }}"

--- a/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
@@ -4,7 +4,7 @@
     verbosity: 2
 
 - name: Gather EC2 facts
-  ec2_remote_facts:
+  ec2_instance_facts:
     aws_access_key: "{{ aws_access_key_id }}"
     aws_secret_key: "{{ aws_secret_access_key }}"
     region: "{{ aws_region_final | default(aws_region) | default(region) | default('us-east-1')}}"
@@ -51,13 +51,13 @@
     state: "{{item['state']}}"
     internaldns: "{{item.tags.internaldns | default(item.private_dns_name)}}"
     isolated: "{{item.tags.isolated | default(false)}}"
-    instance_id: "{{ item.id }}"
-    region: "{{item['region']}}"
+    instance_id: "{{ item.instance_id }}"
+    region: "{{ aws_region_final | default(aws_region) | default(region) | default('us-east-1')}}"
     public_dns_name: "{{item['public_dns_name']}}"
     private_dns_name: "{{item['private_dns_name']}}"
     private_ip_address: "{{item['private_ip_address']}}"
     public_ip_address: "{{item['public_ip_address']}}"
-    placement: "{{item['placement']['zone']}}"
+    placement: "{{item['placement']['availability_zone']}}"
     image_id: "{{item['image_id']}}"
     ansible_ssh_extra_args: "-o StrictHostKeyChecking=no"
   with_items: "{{ec2_facts['instances']}}"


### PR DESCRIPTION
use `ec2_instance_facts` module instead of ~~`ec2_remote_facts`~~

This works with ocp-workshop environment.

- Continue testing on different environments
- Merge this **after** RHTE
