### PR TITLE
Adding ocp-workload-integreatly role

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+become_override: False
+silent: False
+install_dir: /tmp/integreatly
+inventory_hosts_file: inventories/hosts
+self_signed_certs_enabled: True
+master_host: localhost
+release_tag: release-0.0.1

--- a/ansible/roles/ocp-workload-integreatly/readme.adoc
+++ b/ansible/roles/ocp-workload-integreatly/readme.adoc
@@ -1,0 +1,130 @@
+= ocp-workload-integreatly - Sample Config
+
+== Role overview
+
+* This role executes the following tasks:
+** Playbook: link:./tasks/pre_workload.yml[pre_workload.yml] - Runs pre-requisitie steps before installing Integreatly
+*** Clones the Integreatly https://github.com/integr8ly/installation[Github repository] into a specified installation directory
+*** Debug task will print out: `Pre-Workload tasks completed successfully.`
+
+** Playbook: link:./tasks/workload.yml[workload.yml] - Used to deploy Integreatly
+*** Executes the Integreatly installer which installs a set of Middleware products on the target Openshift workshop cluster
+*** Debug task will print out: `Workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `Post-Workload Tasks completed successfully.`
+
+** Playbook: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ uninstall Integreatly
+*** Executes the Integreatly uninstall playbook
+*** Removes locally cloned Integreatly Github repository
+*** Debug task will print out: `Remove Workload tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you
+ need to define to control the deployment of your workload.
+
+* You can modify any of these default values by adding
+`-e"variable_name=variable_value"` to the command line
+
+=== Deploy Workload on OpenShift Cluster from an existing playbook:
+
+[source,yaml]
+----
+- name: Deploy a workload role on a master host
+  hosts: all
+  become: true
+  gather_facts: False
+  tags:
+    - step007
+  roles:
+    - { role: "{{ ANSIBLE_REPO_PATH }}/roles/{{ocp_workload}}", when: 'ocp_workload is defined' }
+
+----
+NOTE: You might want to change `hosts: all` to fit your requirements
+
+
+=== Common configuration to run these playbooks
+You should have these environment variables defined/exported in your system in order
+to run these playbooks.
+
+----
+HOST_GUID=waterford
+DOMAIN="$HOST_GUID.openshiftworkshop.com"
+TARGET_HOST="master.$DOMAIN"
+SSH_USER="ec2-user"
+SSH_PRIVATE_KEY="ocp-workshop.pem"
+GUID=waterford
+----
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+----
+WORKLOAD="ocp-workload-integreatly"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+                 -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
+                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ANSIBLE_REPO_PATH=`pwd`" \
+                 -e"ocp_workload=${WORKLOAD}" \
+                 -e"guid=${GUID}" \
+                 -e"ocp_user_needs_quota=false" \
+                 -e"ACTION=create"
+----
+
+=== To Delete an environment
+Use the common configuration first. Then run this.
+
+----
+WORKLOAD="ocp-workload-integreatly"
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+                    -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
+                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ANSIBLE_REPO_PATH=`pwd`" \
+                    -e"ocp_workload=${WORKLOAD}" \
+                    -e"guid=${GUID}" \
+                    -e"ACTION=remove"
+----
+
+== Set up your Ansible inventory file
+
+* You can create an Ansible inventory file to define your connection
+ method to your host (Master/Bastion with OC command)
+
+* You can also use the command line to define the hosts directly if your `ssh`
+ configuration is set to connect to the host correctly
+
+* You can also use the command line to use localhost or if your cluster is
+ already authenticated and configured in your `oc` configuration
+[source, ini]
+
+.example inventory file
+----
+[gptehosts:vars]
+ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
+ansible_ssh_user=ec2-user
+
+[gptehosts:children]
+openshift
+
+[openshift]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+bastion.cluster3.openshift.opentlc.com ansible_ssh_host=ec2-11-111-111-11.us-west-2.compute.amazonaws.com
+bastion.cluster4.openshift.opentlc.com
+
+
+[dev]
+bastion.cluster1.openshift.opentlc.com
+bastion.cluster2.openshift.opentlc.com
+
+
+[prod]
+bastion.cluster3.openshift.opentlc.com
+bastion.cluster4.openshift.opentlc.com
+----

--- a/ansible/roles/ocp-workload-integreatly/tasks/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Running Pre Workload Tasks
+  import_tasks: ./pre_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Post Workload Tasks
+  import_tasks: ./post_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Remove Workload Tasks
+  import_tasks: ./remove_workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "remove"
+
+

--- a/ansible/roles/ocp-workload-integreatly/tasks/post_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/post_workload.yml
@@ -1,0 +1,6 @@
+---
+
+- name: post_workload tasks complete
+  debug:
+    msg: "Post-Workload Tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-integreatly/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/pre_workload.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Clone integreatly installer GIT repository
+  shell: |
+    git clone --branch {{ release_tag }} https://github.com/integr8ly/installation.git {{ install_dir }}
+  args:
+    creates: "{{ install_dir }}"
+
+- name: pre_workload tasks complete
+  debug:
+    msg: "Pre-Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Uninstall Integreatly
+  shell: |
+          ansible-playbook -i "{{ inventory_hosts_file }}" \
+          playbooks/uninstall.yml \
+          -e eval_master_host="{{ master_host }}"
+  args:
+    chdir: "{{ install_dir }}/evals"
+
+- name: Clean up local Integreatly installer repo
+  file:
+    path: "{{ install_dir }}"
+    state: absent
+
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not silent|bool

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Run Integreatly installer
+  shell: |
+          ansible-playbook -i "{{ inventory_hosts_file }}" \
+          playbooks/install.yml \
+          -e eval_self_signed_certs="{{ self_signed_certs_enabled }}" \
+          -e eval_master_host="{{ master_host }}"
+  args:
+    chdir: "{{ install_dir }}/evals"
+
+- name: workload tasks complete
+  debug:
+    msg: "Workload Tasks completed successfully."
+  when: not silent|bool
+  


### PR DESCRIPTION
**Summary**
Adding Integreatly ocp-workload role

**Validation**
Provision Workload:
```
HOST_GUID=pmccarthy
DOMAIN="$HOST_GUID.openshiftworkshop.com"
TARGET_HOST="master.$DOMAIN"
SSH_USER="ec2-user"
SSH_PRIVATE_KEY="ocp-workshop.pem"
GUID=pmccarthy
WORKLOAD="ocp-workload-integreatly"

ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                 -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
                 -e"ansible_ssh_user=${SSH_USER}" \
                 -e"ANSIBLE_REPO_PATH=`pwd`" \
                 -e"ocp_workload=${WORKLOAD}" \
                 -e"guid=${GUID}" \
                 -e"ocp_user_needs_quota=false" \
                 -e"ACTION=create"

```
Remove workload:
```
ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                    -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
                    -e"ansible_ssh_user=${SSH_USER}" \
                    -e"ANSIBLE_REPO_PATH=`pwd`" \
                    -e"ocp_workload=${WORKLOAD}" \
                    -e"guid=${GUID}" \
                    -e"ACTION=remove"
```