### PR TITLE
Added variable to disable TLS web hook verification

### DIFF
--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -302,6 +302,7 @@ tower_credential_username: ec2-user
 ansible_service_mgr: systemd
 gogs_admin_username: cicduser1 # can't be called admin or it fails
 gogs_admin_password: "{{ tower_admin_password }}"
+gogs_webhook_skip_tls_verify: True
 
 ### Docker variables (Docker is needed by Molecule)
 docker_users:


### PR DESCRIPTION
Added variable to disable TLS web hook verification in CICD lab