### PR TITLE
Updating Integreatly installer workload

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -1,9 +1,7 @@
 ---
 
-become_override: False
+become_override: True
 silent: False
 install_dir: /tmp/integreatly
 inventory_hosts_file: inventories/hosts
-self_signed_certs_enabled: True
-master_host: localhost
 release_tag: release-0.0.1

--- a/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/remove_workload.yml
@@ -3,8 +3,7 @@
 - name: Uninstall Integreatly
   shell: |
           ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/uninstall.yml \
-          -e eval_master_host="{{ master_host }}"
+          playbooks/uninstall.yml
   args:
     chdir: "{{ install_dir }}/evals"
 

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -3,9 +3,7 @@
 - name: Run Integreatly installer
   shell: |
           ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/install.yml \
-          -e eval_self_signed_certs="{{ self_signed_certs_enabled }}" \
-          -e eval_master_host="{{ master_host }}"
+          playbooks/install.yml
   args:
     chdir: "{{ install_dir }}/evals"
 


### PR DESCRIPTION
**Summary**
Updating Integreatly install command by removing additional params
Setting become_override to True

**Validation**
```
HOST_GUID=pamccart
DOMAIN="$HOST_GUID.openshiftworkshop.com"
TARGET_HOST="master.$DOMAIN"
SSH_USER="ec2-user"
SSH_PRIVATE_KEY="ocp-workshop.pem"
GUID=pamccart

ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                 -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
                 -e"ansible_ssh_user=${SSH_USER}" \
                 -e"ANSIBLE_REPO_PATH=`pwd`" \
                 -e"ocp_workload=${WORKLOAD}" \
                 -e"guid=${GUID}" \
                 -e"ocp_user_needs_quota=false" \
                 -e"ACTION=create"
```