### PR TITLE
Setting TLS flag for Integreatly workload

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -4,8 +4,9 @@ become_override: True
 silent: False
 install_dir: /tmp/integreatly
 inventory_hosts_file: inventories/hosts
-release_tag: release-1.0.0
+release_tag: release-1.0.1
 webapp_namespace: webapp
+self_signed_certs_enabled: false
 openshift_master_config_path: /etc/origin/master/master-config.yaml
 admin_username: admin@example.com
 admin_password: Password1

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -3,7 +3,7 @@
 - name: Run Integreatly installer
   shell: |
           ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/install.yml
+          playbooks/install.yml -e eval_self_signed_certs="{{ self_signed_certs_enabled }}"
   args:
     chdir: "{{ install_dir }}/evals"
 


### PR DESCRIPTION
**Summary**
Now that the Integreatly catalog item has LetsEncrypt enabled by default, we need to set a flag as part of the Integreatly install.

Also bumped Integreatly release tag