### PR TITLE
Update parksmap with instructions valid for 3.10 and 3.11

### DIFF
--- a/ansible/roles/ocp-workload-parksmap-demo/files/workshopper-template.yaml
+++ b/ansible/roles/ocp-workload-parksmap-demo/files/workshopper-template.yaml
@@ -11,12 +11,12 @@ parameters:
   displayName: Application name
   required: true
 - name: CONTENT_URL_PREFIX
-  description: Console url (e.g. https://raw.githubusercontent.com/openshift-labs/starter-guides/ocp-3.9)
-  value: https://raw.githubusercontent.com/openshift-labs/starter-guides/ocp-3.9
+  description: Console url (e.g. https://raw.githubusercontent.com/openshift-labs/starter-guides/ocp-3.11)
+  value: https://raw.githubusercontent.com/openshift-labs/starter-guides/ocp-3.11
   displayName: Content URL prefix
   required: true
 - name: WORKSHOPS_URLS
-  description: Workshop definition url (e.g. https://raw.githubusercontent.com/openshift-labs/starter-guides/ocp-3.9/_workshops/training.yml)
+  description: Workshop definition url (e.g. https://raw.githubusercontent.com/openshift-labs/starter-guides/ocp-3.11/_workshops/training.yml)
   value: file:///workshop/workshop.yml
   displayName: Workshop Url
   required: true
@@ -29,16 +29,6 @@ parameters:
   description: Application subdomain (e.g. apps.mycluster.openshiftworkshop.com or apps.mycluster.gce.pixy.io)
   value:
   displayName: Application subdomain
-  required: true
-- name: USER_PROJECT
-  description: User project name
-  value: 
-  displayName: User project name
-  required: true
-- name: INFRA_PROJECT
-  description: Infra project name
-  value: 
-  displayName: Infra project name
   required: true
 objects:
 - kind: ConfigMap
@@ -76,9 +66,10 @@ objects:
         - parksmap-permissions
         - parksmap-rsh
         - nationalparks-java
-        - nationalparks-databases
+        - nationalparks-java-databases
         - nationalparks-application-health
-        - nationalparks-codechanges-gogs
+        - nationalparks-java-pipeline
+        - nationalparks-java-pipeline-codechanges-gogs
         - mlbparks-templates
         - mlbparks-clustering
         - mlbparks-binary-build
@@ -96,7 +87,7 @@ objects:
     - name: latest
       from:
         kind: DockerImage
-        name: osevg/workshopper:latest
+        name: quay.io/osevg/workshopper:latest
       importPolicy: {}
       referencePolicy:
         type: Source


### PR DESCRIPTION
Wayne Boxall reported on Oct 23rd that the guides were incomplete. I missed to fix this sooner. This is a patch that should fix the issue.