### PR TITLE
Custom images using packer

### DIFF
--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -34,7 +34,7 @@
       fail:
         msg: "FAIL {{ project_tag }} Destroy Cloudformation"
       when:
-        - not cloudformation_result|succeeded
+        - not cloudformation_result is succeeded
         - cloud_provider == 'ec2'
       tags:
         - destroying

--- a/ansible/configs/ocp-clientvm/env_vars.yml
+++ b/ansible/configs/ocp-clientvm/env_vars.yml
@@ -72,6 +72,7 @@ env_specific_images:
 ## TODO: This should be registered as a variable. Awk for os verions (OCP).
 ## yum info openshift...
 osrelease: 3.9.27
+repo_version: "{{ osrelease | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2')  }}"
 
 ###### You can, but you usually wouldn't need to.
 ansible_ssh_user: ec2-user

--- a/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
@@ -333,11 +333,15 @@ Resources:
   clientvm:
     Type: "AWS::EC2::Instance"
     Properties:
+{% if custom_image is defined %}
+      ImageId: {{ custom_image.image_id }}
+{% else %}
       ImageId:
         Fn::FindInMap:
         - RegionMapping
         - Ref: AWS::Region
         - 'RHELAMI'
+{% endif %}
       InstanceType: "{{instances[0]['flavor'][cloud_provider]}}"
       KeyName: "{{instances[0]['key_name'] | default(key_name)}}"
       SecurityGroupIds:

--- a/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/ocp-clientvm/files/cloud_providers/ec2_cloud_template.j2
@@ -238,11 +238,15 @@ Resources:
   clientvm{{loop.index}}:
     Type: "AWS::EC2::Instance"
     Properties:
+{% if custom_image is defined %}
+      ImageId: {{ custom_image.image_id }}
+{% else %}
       ImageId:
         Fn::FindInMap:
         - RegionMapping
         - Ref: AWS::Region
         - 'RHELAMI'
+{% endif %}
       InstanceType: "{{instances[0]['flavor'][cloud_provider]}}"
       KeyName: "{{instances[0]['key_name'] | default(key_name)}}"
       SecurityGroupIds:

--- a/ansible/configs/ocp-clientvm/post_software.yml
+++ b/ansible/configs/ocp-clientvm/post_software.yml
@@ -7,7 +7,7 @@
   - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_vars.yml"
   tasks:
   - debug:
-    msg: "Post-Software Steps starting"
+      msg: "Post-Software Steps starting"
 
 - name: PostSoftware flight-check
   hosts: localhost

--- a/ansible/configs/ocp-clientvm/pre_infra.yml
+++ b/ansible/configs/ocp-clientvm/pre_infra.yml
@@ -1,3 +1,4 @@
+---
 - name: Step 000 Pre Infrastructure
   hosts: localhost
   connection: local
@@ -5,9 +6,10 @@
   vars_files:
   - "./env_vars.yml"
   - "./env_secret_vars.yml"
+  gather_facts: false
   tags:
   - step001
   - pre_infrastructure
   tasks:
-  - debug:
-      msg: "Step 000 Pre Infrastructure - Dummy action"
+    - debug:
+        msg: "Step 000 Pre Infrastructure - Dummy action"

--- a/ansible/configs/ocp-clientvm/software.yml
+++ b/ansible/configs/ocp-clientvm/software.yml
@@ -19,7 +19,7 @@
     - "{{ ANSIBLE_REPO_PATH }}/configs/{{ env_type }}/env_secret_vars.yml"
   tasks:
   - name: Set up Client VM
-    include_role:
+    import_role:
       name: "{{ ANSIBLE_REPO_PATH }}/roles/ocp-client-vm"
 
 - name: Software flight-check

--- a/ansible/roles/bastion-opentlc-ipa/tasks/main.yml
+++ b/ansible/roles/bastion-opentlc-ipa/tasks/main.yml
@@ -8,6 +8,8 @@
   yum:
     name: "ipa-client"
     state: present
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
+  tags: packer
 
 - name: Register bastion with IPA using host password (first try)
   command: >

--- a/ansible/roles/bastion/tasks/main.yml
+++ b/ansible/roles/bastion/tasks/main.yml
@@ -8,6 +8,8 @@
     dest: /root/.ssh
     mode: 0700
     state: directory
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
+  tags: packer
 
 - name: copy the environment .pem key
   become: true
@@ -54,6 +56,8 @@
   yum:
     name:
     - python-requests
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
+  tags: packer
 
 # - name: Ensure that iptables service is installed
 #   yum:
@@ -71,6 +75,8 @@
   yum:
     name: http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/m/mosh-1.3.0-1.el7.x86_64.rpm
   ignore_errors: yes
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
+  tags: packer
 
 - name: Open UDP Ports 60001 - 61000 for Mosh
   iptables:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -8,10 +8,15 @@
   yum:
     name: '*'
     state: latest
-  when: update_packages|bool
+  when:
+    - update_packages|bool
+    - not hostvars.localhost.skip_packer_tasks | d(false)
+  tags: packer
 
 ######################## Install Basic Packages
 - name: Install Basic Packages
   import_tasks: ./packages.yml
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
   tags:
     - install_basic_packages
+    - packer

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -19,12 +19,15 @@
 - name: Select AMI among candidates
   when:
     - amifacts is succeeded
+    - amifacts is not skipped
     - "'images' in amifacts"
     - amifacts.images | d([]) | length > 0
   include_tasks: select_custom_image.yml
 
 - name: Get custom AMI using the provided filter - plan B
   when:
+    - amifacts is not skipped
+    - amifacts is succeeded
     - amifacts.images | length == 0
     - custom_image_filter is defined
   environment:

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -8,7 +8,7 @@
     owner: self
     filters:
       tag:env_type: "{{ env_type }}"
-      tag:version: "{{ osrelease }}"
+      tag:version: "{{ osrelease | default(repo_version) }}"
       tag:stages: "*{{ custom_image_stage | d('unknown') }}*"
   register: amifacts
 

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -1,0 +1,36 @@
+---
+- name: Get all custom AMI for that environment / version
+  environment:
+    AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
+    AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
+    AWS_DEFAULT_REGION: "{{aws_region_loop|d(aws_region)}}"
+  ec2_ami_facts:
+    owner: self
+    filters:
+      tag:env_type: "{{ env_type }}"
+      tag:version: "{{ osrelease }}"
+      tag:stages: "*{{ custom_image_stage | d('unknown') }}*"
+  register: amifacts
+
+# by default do not skip docker tasks
+- set_fact:
+    skip_packer_tasks: false
+
+- when: amifacts.images | length > 0
+  block:
+    # For now, use one image for all the machines of the config. Start simple.
+    # TODO: add another tag to the image to apply it to specific group of hosts in the config
+    - set_fact:
+        custom_image: "{{ amifacts | json_query('images[]') | sort(attribute='creation_date') | last }}"
+
+    - name: Print debug information about the custom image used
+      debug:
+        var: custom_image
+
+    - name: Skip packer tasks if the tags in the image say to do so
+      set_fact:
+        skip_packer_tasks: true
+      when:
+        - custom_image is defined
+        - custom_image.tags.skip_packer_tasks is defined
+        - custom_image.tags.skip_packer_tasks in ['true', 'yes', 'True', 'Yes']

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -16,7 +16,9 @@
 - set_fact:
     skip_packer_tasks: false
 
-- when: amifacts.images | length > 0
+- when:
+    - amifacts is succeeded
+    - amifacts.images | length > 0
   include_tasks: select_custom_image.yml
 
 - name: Get custom AMI using the provided filter
@@ -33,5 +35,7 @@
       name: "*{{ custom_image_filter }}*"
   register: amifacts
 
-- when: amifacts.images | length > 0
+- when:
+    - amifacts is succeeded
+    - amifacts.images | length > 0
   include_tasks: select_custom_image.yml

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -40,6 +40,9 @@
       name: "*{{ custom_image_filter }}*"
   register: amifacts2
 
+- debug:
+    msg: "name: \"*{{ custom_image_filter }}*\""
+
 - when:
     - amifacts2 is not skipped
     - amifacts2 is succeeded
@@ -47,6 +50,13 @@
     - name: Write back the register to amifacts
       set_fact:
         amifacts: "{{ amifacts2 }}"
+
+    - name: debug amifacts2
+      debug:
+        var: amifacts2
+    - name: debug amifact
+      debug:
+        var: amifacts
 
     - name: Select AMI among candidates
       when:

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -1,5 +1,5 @@
 ---
-- name: Get all custom AMI for this specific ( envtype / version / stage )
+- name: Get all custom AMI for this specific ( envtype / version / stage ) - plan A
   environment:
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
@@ -16,10 +16,14 @@
 - set_fact:
     skip_packer_tasks: false
 
-- when: amifacts.images | d([]) | length > 0
+- name: Select AMI among candidates
+  when:
+    - amifacts is succeeded
+    - "'images' in amifacts"
+    - amifacts.images | d([]) | length > 0
   include_tasks: select_custom_image.yml
 
-- name: Get custom AMI using the provided filter
+- name: Get custom AMI using the provided filter - plan B
   when:
     - amifacts.images | length == 0
     - custom_image_filter is defined
@@ -33,9 +37,17 @@
       name: "*{{ custom_image_filter }}*"
   register: amifacts2
 
-- set_fact:
-    amifacts: "{{ amifacts2 }}"
-  when: amifacts2 is succeeded
+- when:
+    - amifacts2 is not skipped
+    - amifacts2 is succeeded
+  block:
+    - name: Write back the register to amifacts
+      set_fact:
+        amifacts: "{{ amifacts2 }}"
 
-- when: amifacts.images | d([]) | length > 0
-  include_tasks: select_custom_image.yml
+    - name: Select AMI among candidates
+      when:
+        - amifacts is succeeded
+        - "'images' in amifacts"
+        - amifacts.images | d([]) | length > 0
+      include_tasks: select_custom_image.yml

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -1,5 +1,5 @@
 ---
-- name: Get all custom AMI for that environment / version
+- name: Get all custom AMI for this specific ( envtype / version / stage )
   environment:
     AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
     AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
@@ -17,20 +17,21 @@
     skip_packer_tasks: false
 
 - when: amifacts.images | length > 0
-  block:
-    # For now, use one image for all the machines of the config. Start simple.
-    # TODO: add another tag to the image to apply it to specific group of hosts in the config
-    - set_fact:
-        custom_image: "{{ amifacts | json_query('images[]') | sort(attribute='creation_date') | last }}"
+  include_tasks: select_custom_image.yml
 
-    - name: Print debug information about the custom image used
-      debug:
-        var: custom_image
+- name: Get custom AMI using the provided filter
+  when:
+    - amifacts.images | length == 0
+    - custom_image_filter is defined
+  environment:
+    AWS_ACCESS_KEY_ID: "{{aws_access_key_id}}"
+    AWS_SECRET_ACCESS_KEY: "{{aws_secret_access_key}}"
+    AWS_DEFAULT_REGION: "{{aws_region_loop|d(aws_region)}}"
+  ec2_ami_facts:
+    owner: self
+    filters:
+      name: "*{{ custom_image_filter }}*"
+  register: amifacts
 
-    - name: Skip packer tasks if the tags in the image say to do so
-      set_fact:
-        skip_packer_tasks: true
-      when:
-        - custom_image is defined
-        - custom_image.tags.skip_packer_tasks is defined
-        - custom_image.tags.skip_packer_tasks in ['true', 'yes', 'True', 'Yes']
+- when: amifacts.images | length > 0
+  include_tasks: select_custom_image.yml

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -40,9 +40,6 @@
       name: "*{{ custom_image_filter }}*"
   register: amifacts2
 
-- debug:
-    msg: "name: \"*{{ custom_image_filter }}*\""
-
 - when:
     - amifacts2 is not skipped
     - amifacts2 is succeeded
@@ -50,13 +47,6 @@
     - name: Write back the register to amifacts
       set_fact:
         amifacts: "{{ amifacts2 }}"
-
-    - name: debug amifacts2
-      debug:
-        var: amifacts2
-    - name: debug amifact
-      debug:
-        var: amifacts
 
     - name: Select AMI among candidates
       when:

--- a/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/detect_custom_images.yml
@@ -16,9 +16,7 @@
 - set_fact:
     skip_packer_tasks: false
 
-- when:
-    - amifacts is succeeded
-    - amifacts.images | length > 0
+- when: amifacts.images | d([]) | length > 0
   include_tasks: select_custom_image.yml
 
 - name: Get custom AMI using the provided filter
@@ -33,9 +31,11 @@
     owner: self
     filters:
       name: "*{{ custom_image_filter }}*"
-  register: amifacts
+  register: amifacts2
 
-- when:
-    - amifacts is succeeded
-    - amifacts.images | length > 0
+- set_fact:
+    amifacts: "{{ amifacts2 }}"
+  when: amifacts2 is succeeded
+
+- when: amifacts.images | d([]) | length > 0
   include_tasks: select_custom_image.yml

--- a/ansible/roles/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/main.yml
@@ -32,7 +32,9 @@
             name: "{{ ANSIBLE_REPO_PATH }}/roles/infra-ec2-template-generate"
           when:
             - amifacts is defined
-            - amifacts.images | length > 0
+            - amifacts is not skipped
+            - "'images' in amifacts"
+            - amifacts.images | d([]) | length > 0
 
     - name: Launch CloudFormation template (local)
       cloudformation:

--- a/ansible/roles/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/main.yml
@@ -21,6 +21,17 @@
         - cloudformation_out is defined
         - cloudformation_out is failed
 
+    - when: allow_custom_images | d(true) | bool
+      block:
+        - include_tasks: detect_custom_images.yml
+
+        - name: Regenerate the CloudFormation template because of custom images
+          include_role:
+            name: "{{ ANSIBLE_REPO_PATH }}/roles/infra-ec2-template-generate"
+          when:
+            - amifacts is defined
+            - amifacts.images | length > 0
+
     - name: Launch CloudFormation template (local)
       cloudformation:
         aws_access_key: "{{ aws_access_key_id }}"

--- a/ansible/roles/infra-ec2-template-create/tasks/main.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/main.yml
@@ -21,7 +21,9 @@
         - cloudformation_out is defined
         - cloudformation_out is failed
 
-    - when: allow_custom_images | d(true) | bool
+    - when:
+        - allow_custom_images | d(true) | bool
+        - osrelease is defined or repo_version is defined
       block:
         - include_tasks: detect_custom_images.yml
 

--- a/ansible/roles/infra-ec2-template-create/tasks/select_custom_image.yml
+++ b/ansible/roles/infra-ec2-template-create/tasks/select_custom_image.yml
@@ -1,0 +1,18 @@
+---
+# For now, use one image for all the machines of the config. Start simple.
+# TODO: add another tag to the image to apply it to specific group of hosts in the config
+- name: Pick the most recent AMI
+  set_fact:
+    custom_image: "{{ amifacts | json_query('images[]') | sort(attribute='creation_date') | last }}"
+
+- name: Print debug information about the custom image used
+  debug:
+    var: custom_image
+
+- name: Skip packer tasks if the tags in the image say to do so
+  set_fact:
+    skip_packer_tasks: true
+  when:
+    - custom_image is defined
+    - custom_image.tags.skip_packer_tasks is defined
+    - custom_image.tags.skip_packer_tasks in ['true', 'yes', 'True', 'Yes']

--- a/ansible/roles/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles/infra-ec2-template-generate/templates/cloud_template.j2
@@ -153,11 +153,15 @@ Resources:
   {{instance['name']}}{{loop.index}}:
     Type: "AWS::EC2::Instance"
     Properties:
+{% if custom_image is defined %}
+      ImageId: {{ custom_image.image_id }}
+{% else %}
       ImageId:
         Fn::FindInMap:
         - RegionMapping
         - Ref: AWS::Region
         - {{ instance.image | default(aws_default_image) }}
+{% endif %}
       InstanceType: "{{instance['flavor'][cloud_provider]}}"
       KeyName: "{{instance.key_name | default(key_name)}}"
     {% if instance['UserData'] is defined %}

--- a/ansible/roles/ocp-client-vm/tasks/configure_docker.yml
+++ b/ansible/roles/ocp-client-vm/tasks/configure_docker.yml
@@ -4,6 +4,9 @@
   yum:
     name: "docker-{{ docker_version }}"
     state: present
+  tags:
+    - packer
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
 
 - name: Generate docker-storage-setup config
   template:

--- a/ansible/roles/ocp-client-vm/tasks/main.yml
+++ b/ansible/roles/ocp-client-vm/tasks/main.yml
@@ -3,11 +3,16 @@
 - name: Install OpenShift Client VM Packages
   import_tasks: ./packages.yml
   tags:
-  - install_openshift_client_vm
+    - install_openshift_client_vm
+    - packer
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
 
 - group:
     name: docker
     state: present
+  tags:
+    - packer
+  when: not hostvars.localhost.skip_packer_tasks | d(false)
 
 - name: Configure Docker
   import_tasks: ./configure_docker.yml

--- a/ansible/roles/ocp-client-vm/tasks/packages.yml
+++ b/ansible/roles/ocp-client-vm/tasks/packages.yml
@@ -3,19 +3,18 @@
 
 - name: Install Openshift Client VM packages
   yum:
-    name: "{{ item }}"
     state: present
-  with_items:
-  - java-1.8.0-openjdk-devel
-  - docker
-  - atomic-openshift-clients
-  - skopeo
-  - buildah
-  - python-docker
-  - apb
-  - cri-o
-  - cri-tools
-  - podman
+    name:
+      - java-1.8.0-openjdk-devel
+      - docker
+      - atomic-openshift-clients
+      - skopeo
+      - buildah
+      - python-docker
+      - apb
+      - cri-o
+      - cri-tools
+      - podman
   tags:
   - install_openshift_client_vm_packages
 
@@ -29,6 +28,7 @@
   until: r_geturl is succeeded
   tags:
   - install_openshift_client_vm_packages
+
 - name: Unarchive file
   unarchive:
     remote_src: yes
@@ -36,10 +36,12 @@
     dest: /root/
   tags:
   - install_openshift_client_vm_packages
+
 - name: Move maven to /usr/local
   command: mv -f /root/apache-maven-3.5.4 /usr/local
   tags:
   - install_openshift_client_vm_packages
+
 - name: Cleanup downloaded file
   file:
     dest: /root/apache-maven.tar.gz
@@ -62,12 +64,14 @@
     dest: /root/s2i.tar.gz
   tags:
   - install_openshift_client_vm_packages
+
 - name: Create unarchive directory
   file:
     path: /root/s2i
     state: directory
   tags:
   - install_openshift_client_vm_packages
+
 - name: Unarchive file
   unarchive:
     remote_src: yes
@@ -75,6 +79,7 @@
     dest: /root/s2i
   tags:
   - install_openshift_client_vm_packages
+
 - name: Move s2i to /usr/local/bin
   copy:
     remote_src: yes
@@ -85,12 +90,14 @@
     mode: 0755
   tags:
   - install_openshift_client_vm_packages
+
 - name: Cleanup Temp Directory
   file:
     dest: /root/s2i
     state: absent
   tags:
   - install_openshift_client_vm_packages
+
 - name: Cleanup downloaded file
   file:
     dest: /root/s2i.tar.gz

--- a/ansible/roles/ocp-client-vm/tasks/packages.yml
+++ b/ansible/roles/ocp-client-vm/tasks/packages.yml
@@ -37,6 +37,7 @@
   tags:
   - install_openshift_client_vm_packages
 
+# TODO: use the copy module here
 - name: Move maven to /usr/local
   command: mv -f /root/apache-maven-3.5.4 /usr/local
   tags:

--- a/ansible/roles/set-repositories/tasks/main.yml
+++ b/ansible/roles/set-repositories/tasks/main.yml
@@ -2,20 +2,19 @@
 ---
 ######################### Set up Subscription Method (File/Satellite/RHN)
 
-- name: Configure Satellite Subscription
-  import_tasks: ./satellite-repos.yml
-  when: repo_method == "satellite"
+- when: not hostvars.localhost.skip_packer_tasks | d(false)
   tags:
     - set_repositories
+    - packer
+  block:
+    - name: Configure Satellite Subscription
+      import_tasks: ./satellite-repos.yml
+      when: repo_method == "satellite"
 
-- name: Configure RHN Subscription
-  import_tasks: ./rhn-repos.yml
-  when: repo_method == "rhn"
-  tags:
-    - set_repositories
+    - name: Configure RHN Subscription
+      import_tasks: ./rhn-repos.yml
+      when: repo_method == "rhn"
 
-- name: Configure Repository File
-  import_tasks: ./file-repos.yml
-  when: repo_method == "file"
-  tags:
-    - set_repositories
+    - name: Configure Repository File
+      import_tasks: ./file-repos.yml
+      when: repo_method == "file"

--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -7,11 +7,13 @@
 # satellite_activationkey: "activation_key_id_name"
 
 - name: Remove rh-amazon-rhui-client package
+  tags: packer
   yum:
     name: rh-amazon-rhui-client
     state: absent
 
 - name: Remove satellite Cert
+  tags: packer
   yum:
     name: katello-ca-consumer-*.noarch
     state: absent

--- a/builds/packer/readme.adoc
+++ b/builds/packer/readme.adoc
@@ -1,0 +1,23 @@
+= Packer common images
+
+== Build to your account
+Create and copy the image to multiple regions:
+
+[source,bash]
+----
+packer build -var-file=${HOME}/secrets/gpte.json rhel_gold.json
+----
+
+== Use the image
+
+When deploying a config:
+
+. Make sure either:
+  * the config is using the common CloudFormation template
+  * the CF template in the config directory supports the variable `custom_image`
+. Run the playbook with `-e custom_image_filter=IMAGENAME`. For example:
+
+  -e "custom_image_filter=RHEL 7.5 GOLD packer 1542702393"
+
+
+If the image is found, then it will be used, otherwise, playbook defaults to what is defined in the CloudFormation template.

--- a/builds/packer/readme.adoc
+++ b/builds/packer/readme.adoc
@@ -16,7 +16,7 @@ Example:
 ----
 custom_image_filter: RHEL 7.5 GOLD packer 1542702393
 ----
-. Opiniated image using tags and the tuple (env_type, version, stage)
+. Opinionated image using tags and the tuple (env_type, version, stage)
 +
 Variable: `custom_image_stage`  (env_type and version are already provided)
 +
@@ -58,6 +58,6 @@ When deploying a config:
 
 If the image is found, then it will be used, otherwise, playbook defaults to what is defined in the CloudFormation template.
 
-== Build opiniated images
+== Build opinionated images
 
 TODO

--- a/builds/packer/readme.adoc
+++ b/builds/packer/readme.adoc
@@ -1,6 +1,41 @@
-= Packer common images
+= Custom images
 
-== Build to your account
+== What happens during deployment
+
+The AMI is detected before the cloudformation stack is created.
+
+There is 2 detection strategies:
+
+. Common images using the image name
++
+Variable: `custom_image_filter`
++
+Example:
++
+[source,yaml]
+----
+custom_image_filter: RHEL 7.5 GOLD packer 1542702393
+----
+. Opiniated image using tags and the tuple (env_type, version, stage)
++
+Variable: `custom_image_stage`  (env_type and version are already provided)
++
+This allows us to enable or disable an AMI easily by adding or not the stage into its tag `stages`. env_type and version have to match the values in the tags of the image too.
++
+Example:
++
+[source,yaml]
+----
+custom_image_stage: PROD
+----
+
+
+If no AMI is found, then it defaults to what is used in the template.
+
+== Build common images
+
+=== Build to your account
+
 Create and copy the image to multiple regions:
 
 [source,bash]
@@ -8,7 +43,7 @@ Create and copy the image to multiple regions:
 packer build -var-file=${HOME}/secrets/gpte.json rhel_gold.json
 ----
 
-== Use the image
+== Requirements to use custom images
 
 When deploying a config:
 
@@ -16,8 +51,13 @@ When deploying a config:
   * the config is using the common CloudFormation template
   * the CF template in the config directory supports the variable `custom_image`
 . Run the playbook with `-e custom_image_filter=IMAGENAME`. For example:
-
-  -e "custom_image_filter=RHEL 7.5 GOLD packer 1542702393"
-
++
+----
+-e "custom_image_filter='RHEL 7.5 GOLD packer 1542702393'"
+----
 
 If the image is found, then it will be used, otherwise, playbook defaults to what is defined in the CloudFormation template.
+
+== Build opiniated images
+
+TODO

--- a/builds/packer/rhel_gold.json
+++ b/builds/packer/rhel_gold.json
@@ -1,0 +1,20 @@
+{
+    "variables": {
+        "ami_regions": "us-east-1,eu-central-1,ap-southeast-1,sa-east-1"
+    },
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "region": "us-east-1",
+            "source_ami": "ami-0456c465f72bd0c95",
+            "subnet_id": "subnet-0110de3d886fb926e",
+            "associate_public_ip_address": "true",
+            "instance_type": "t2.medium",
+            "ssh_username": "ec2-user",
+            "access_key": "{{user `aws_access_key_id`}}",
+            "secret_key": "{{user `aws_secret_access_key`}}",
+            "ami_regions": "{{user `ami_regions`}}",
+            "ami_name": "RHEL 7.5 GOLD packer {{timestamp}}"
+        }
+    ]
+}


### PR DESCRIPTION
Enable use of custom images:

The AMI is detected before the cloudformation stack is created.
There is 2 detection strategies:
- using the image name
  variable: `custom_image_filter`
  example: `custom_image_filter: RHEL 7.5 GOLD packer 1542702393`
- specific image using tags and the tuple `(env_type, version, stage)`
  variable: `custom_image_stage`
  This allows us to enable or disable an AMI easily by adding or not the stage into its tag `stages`. env_type and version have to match too.
  example: `custom_image_stage: PROD`

If no AMI is found, then it defaults to what is used in the template.