### PR TITLE
Fixed missing parameters

### DIFF
--- a/ansible/roles/ocp-workload-parksmap-demo/files/workshopper-template.yaml
+++ b/ansible/roles/ocp-workload-parksmap-demo/files/workshopper-template.yaml
@@ -30,6 +30,16 @@ parameters:
   value:
   displayName: Application subdomain
   required: true
+- name: USER_PROJECT
+  description: User project name
+  value: 
+  displayName: User project name
+  required: true
+- name: INFRA_PROJECT
+  description: Infra project name
+  value: 
+  displayName: Infra project name
+  required: true  
 objects:
 - kind: ConfigMap
   apiVersion: v1


### PR DESCRIPTION
In the provided template 2 parameters were expected but were not in the parameters section. This parameters are additional to the standard guide for the parksmap demo, that's the reason they were missing. In the regular workshops these are not needed.

 