### PR TITLE
Adding support for LE Staging Cert

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/defaults/main.yml
+++ b/ansible/roles/ocp-workload-integreatly/defaults/main.yml
@@ -12,3 +12,6 @@ admin_username: admin@example.com
 admin_password: Password1
 evals_username: evals@example.com
 evals_password: Password1
+letsencrypt_staging_root_cert_url: https://letsencrypt.org/certs/fakelerootx1.pem
+letsencrypt_staging_root_cert_path: /etc/origin/master/fakelerootx1.pem
+rhsso_identity_provider_ca_cert_path: "{{ letsencrypt_staging_root_cert_path }}"

--- a/ansible/roles/ocp-workload-integreatly/tasks/pre_workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/pre_workload.yml
@@ -6,6 +6,12 @@
   args:
     creates: "{{ install_dir }}"
 
+- name: Retrieve LetsEncrypt Staging Root Certificate
+  get_url:
+    url: "{{ letsencrypt_staging_root_cert_url }}"
+    dest: "{{ letsencrypt_staging_root_cert_path }}"
+    mode: 0440
+
 - name: pre_workload tasks complete
   debug:
     msg: "Pre-Workload tasks completed successfully."

--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -1,9 +1,15 @@
 ---
 
+- name: Set Identity Provider CA Cert Path
+  set_fact:
+    rhsso_identity_provider_ca_cert_path: ""
+  tags:
+    - production
+
 - name: Run Integreatly installer
   shell: |
           ansible-playbook -i "{{ inventory_hosts_file }}" \
-          playbooks/install.yml -e eval_self_signed_certs="{{ self_signed_certs_enabled }}"
+          playbooks/install.yml -e eval_self_signed_certs="{{ self_signed_certs_enabled }} -e rhsso_identity_provider_ca_cert_path={{ rhsso_identity_provider_ca_cert_path }}"
   args:
     chdir: "{{ install_dir }}/evals"
 


### PR DESCRIPTION
##### SUMMARY
Adding support for LetsEncrypt staging Root Certificate

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
Integreatly Workload

##### ADDITIONAL INFORMATION
This change allows Integreatly to support LE staging environments for both Dev and Test while continuing support in Prod. 

It will mean that `--skip-tags production` will need to be set for both Dev and Test catalog items in Cloudforms
