### PR TITLE
Replacing prod tag with lets_encrypt_production var

### DIFF
--- a/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-integreatly/tasks/workload.yml
@@ -3,8 +3,7 @@
 - name: Set Identity Provider CA Cert Path
   set_fact:
     rhsso_identity_provider_ca_cert_path: ""
-  tags:
-    - production
+  when: lets_encrypt_production|bool
 
 - name: Run Integreatly installer
   shell: |


### PR DESCRIPTION
##### SUMMARY
Updating LetsEncrypt logic in Integreatly role by using `lets_encrypt_production` instead of tags

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
Integreatly
