### PR TITLE
Change ansible_ssh_user to ansible_user Issue #109

### DIFF
--- a/ansible/cloud_providers/azure_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/azure_infrastructure_deployment.yml
@@ -212,7 +212,7 @@
           - "tag_{{stack_tag}}_ostype_{{item.tags.ostype | default('unknown')}}"
           - "{{item.tags.ostype | default('unknowns')}}"
           - "{{ 'newnodes' if (item.tags.newnode|d()|bool) else 'all'}}"
-        ansible_ssh_user: "{{ remote_user }}"
+        ansible_user: "{{ remote_user }}"
         remote_user: "{{ remote_user | d('azure') }}"
         ansible_ssh_private_key_file: "{{ssh_key}}"
         key_name: "{{key_name}}"
@@ -356,7 +356,6 @@
         ansible_password: "{{ windows_password | default(hostvars['localhost'].generated_windows_password) }}"
         ansible_port: 5986
         ansible_user: Administrator
-        ansible_ssh_user: Administrator
         ansible_winrm_server_cert_validation: ignore
 
     - name: wait for windows host to be available

--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -114,7 +114,6 @@
         ansible_password: "{{ hostvars['localhost'].windows_password | default(hostvars['localhost'].generated_windows_password) }}"
         ansible_port: 5986
         ansible_user: Administrator
-        ansible_ssh_user: Administrator
         ansible_winrm_server_cert_validation: ignore
         aws_region_final: "{{hostvars['localhost'].aws_region_final}}"
 

--- a/ansible/configs/ans-network-lab/env_vars.yml
+++ b/ansible/configs/ans-network-lab/env_vars.yml
@@ -53,7 +53,7 @@ admin_user_password: ''
 
 #### Connection Settings
 
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/ansible/configs/ans-network-lab/files/hosts_template.j2
+++ b/ansible/configs/ans-network-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Hosts

--- a/ansible/configs/ans-tower-lab/env_vars.yml
+++ b/ansible/configs/ans-tower-lab/env_vars.yml
@@ -351,7 +351,7 @@ install_win_ad: false
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/ansible-cicd-lab/env_vars.yml
+++ b/ansible/configs/ansible-cicd-lab/env_vars.yml
@@ -187,7 +187,7 @@ instances:
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/ansible-cicd-lab/files/hosts_template.j2
+++ b/ansible/configs/ansible-cicd-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"
 [3tierapp:children]

--- a/ansible/configs/ansible-provisioner/env_vars.yml
+++ b/ansible/configs/ansible-provisioner/env_vars.yml
@@ -76,7 +76,7 @@ aws_region: us-west-1
 # admin_user_password: 'r3dh4t1!'
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/ansible/configs/ansible-provisioner/files/hosts_template.j2
+++ b/ansible/configs/ansible-provisioner/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=90
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 

--- a/ansible/configs/just-some-nodes-example/files/hosts_template.j2
+++ b/ansible/configs/just-some-nodes-example/files/hosts_template.j2
@@ -4,7 +4,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"
 

--- a/ansible/configs/ocp-clientvm/env_vars.yml
+++ b/ansible/configs/ocp-clientvm/env_vars.yml
@@ -76,7 +76,7 @@ docker_device: /dev/xvdb
 docker_version: "{{ '1.12.6' if repo_version is version_compare('3.9', '<')  else '1.13.1' }}"
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/ocp-gpu-single-node/env_vars.yml
+++ b/ansible/configs/ocp-gpu-single-node/env_vars.yml
@@ -220,7 +220,7 @@ available_identity_providers:
     filename: /etc/origin/master/htpasswd
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/ocp-gpu-single-node/files/hosts_template.3.10.14.j2
+++ b/ansible/configs/ocp-gpu-single-node/files/hosts_template.3.10.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-gpu-single-node/files/hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-gpu-single-node/files/hosts_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 log_path=/root
 

--- a/ansible/configs/ocp-gpu-single-node/files/hosts_template.3.9.31.j2
+++ b/ansible/configs/ocp-gpu-single-node/files/hosts_template.3.9.31.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -361,7 +361,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-ha-disconnected-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-disconnected-lab/env_vars.yml
@@ -131,7 +131,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.11.43.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.11.43.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.11.51.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.11.51.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.25.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.25.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.27.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.27.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.30.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.3.9.30.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.3.11.43.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.3.11.43.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.3.11.51.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.3.11.51.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.j2
+++ b/ansible/configs/ocp-ha-disconnected-lab/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 # disable memory check, as we are not a production environment

--- a/ansible/configs/ocp-ha-lab/env_vars.yml
+++ b/ansible/configs/ocp-ha-lab/env_vars.yml
@@ -138,7 +138,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/ansible/configs/ocp-ha-lab/files/hosts_homework8_template.3.11.16.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_homework8_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_homework8_template.3.11.43.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_homework8_template.3.11.43.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_homework8_template.3.11.51.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_homework8_template.3.11.51.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.10.14.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.10.14.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.10.34.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.10.34.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.11.43.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.11.43.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.11.51.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.11.51.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.25.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.25.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.27.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.27.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.30.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.30.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.41.j2
+++ b/ansible/configs/ocp-ha-lab/files/hosts_template.3.9.41.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.10.14.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.10.14.j2
@@ -9,7 +9,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.10.34.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.10.34.j2
@@ -9,7 +9,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.11.43.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.11.43.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.11.51.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.11.51.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.9.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.9.30.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.9.30.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.9.41.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.3.9.41.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/ansible/configs/ocp-ha-lab/files/labs_hosts_template.j2
+++ b/ansible/configs/ocp-ha-lab/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/ansible/configs/ocp-implementation-lab/env_vars.yml
+++ b/ansible/configs/ocp-implementation-lab/env_vars.yml
@@ -120,7 +120,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.25.j2
+++ b/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.25.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.27.j2
+++ b/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.27.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.30.j2
+++ b/ansible/configs/ocp-implementation-lab/files/hosts_template.3.9.30.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-implementation-lab/files/hosts_template.j2
+++ b/ansible/configs/ocp-implementation-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-implementation-lab/files/labs_hosts_template.j2
+++ b/ansible/configs/ocp-implementation-lab/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/ansible/configs/ocp-storage-cns/env_vars.yml
+++ b/ansible/configs/ocp-storage-cns/env_vars.yml
@@ -120,7 +120,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.25.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.25.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.27.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.27.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.30.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.30.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.31.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.31.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.40.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.40.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.43.j2
+++ b/ansible/configs/ocp-storage-cns/files/hosts_template.3.9.43.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/ansible/configs/ocp-storage-cns/files/labs_hosts_template.j2
+++ b/ansible/configs/ocp-storage-cns/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/ansible/configs/ocp-workshop/env_vars.yml
+++ b/ansible/configs/ocp-workshop/env_vars.yml
@@ -267,7 +267,7 @@ admission_plugin_config:
       kind: WebhookAdmission
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.10.14.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.10.14.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################
@@ -363,7 +363,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.10.34.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.10.34.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################
@@ -366,7 +366,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.10.45.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.10.45.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################
@@ -366,7 +366,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.16.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.16.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 log_path=/root
 
@@ -324,7 +324,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.43.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.43.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 log_path=/root
 
@@ -324,7 +324,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.11.51.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.11.51.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 log_path=/root
 
@@ -341,9 +341,9 @@ new_nodes
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
 {% if container_runtime == "cri-o" %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute-crio'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute-crio'
 {% else %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.14.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.14.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -323,7 +323,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.25.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.25.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -322,7 +322,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.27.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.27.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -361,7 +361,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.30.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.30.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -365,7 +365,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.31.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.31.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -369,7 +369,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.33.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.33.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -383,7 +383,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.40.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.40.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -383,7 +383,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.41.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.41.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -382,7 +382,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.43.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.43.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -382,7 +382,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.3.9.51.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.3.9.51.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -382,7 +382,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp-workshop/files/hosts_template.j2
+++ b/ansible/configs/ocp-workshop/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -362,7 +362,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 {% endif %}
 

--- a/ansible/configs/ocp4-coreos-deployer/env_vars.yml
+++ b/ansible/configs/ocp4-coreos-deployer/env_vars.yml
@@ -86,7 +86,7 @@ worker_instance_count: 3
 #osrelease: 3.9.27
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/quay-enterprise/env_vars.yml
+++ b/ansible/configs/quay-enterprise/env_vars.yml
@@ -105,7 +105,7 @@ subdomain_base: "{{subdomain_base_short}}{{subdomain_base_suffix}}"
 osrelease: 3.10.14
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/rhte-oc-cluster-vms/env_vars.yml
+++ b/ansible/configs/rhte-oc-cluster-vms/env_vars.yml
@@ -78,7 +78,7 @@ env_specific_images:
 osrelease: 3.9.40
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/three-tier-app/env_vars.yml
+++ b/ansible/configs/three-tier-app/env_vars.yml
@@ -182,7 +182,7 @@ instances:
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/ansible/configs/three-tier-app/files/hosts_template.j2
+++ b/ansible/configs/three-tier-app/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"
 [3tierapp:children]

--- a/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles/infra-ec2-create-inventory/tasks/main.yml
@@ -43,7 +43,7 @@
       - "{{item.tags.ostype | default('unknowns')}}"
       - "{{item['tags'][project_tag_ostype] | default('unknowns')}}"
       - "{{ 'newnodes' if (item.tags.newnode|d()|bool) else 'all'}}"
-    ansible_ssh_user: ec2-user
+    ansible_user: ec2-user
     remote_user: ec2-user
     ansible_ssh_private_key_file: "{{item['key_name']}}"
     key_name: "{{item['key_name']}}"

--- a/ansible/roles/ocp-client-vm/README.md
+++ b/ansible/roles/ocp-client-vm/README.md
@@ -49,7 +49,7 @@ WORKLOAD="ocp-client-vm"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"ACTION=create"
 

--- a/ansible/roles/ocp-workload-3scale-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-3scale-demo/readme.adoc
@@ -37,7 +37,7 @@
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift
@@ -95,7 +95,7 @@ GUID=0418
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/id_rsa" \
-                 -e"ansible_ssh_user=opentlc-mgr" \
+                 -e"ansible_user=opentlc-mgr" \
 
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
@@ -116,7 +116,7 @@ GUID=0418
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/id_rsa" \
-                    -e"ansible_ssh_user=opentlc-mgr" \
+                    -e"ansible_user=opentlc-mgr" \
 
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \

--- a/ansible/roles/ocp-workload-amq-enmasse/readme.adoc
+++ b/ansible/roles/ocp-workload-amq-enmasse/readme.adoc
@@ -36,7 +36,7 @@ SSH_PRIVATE_KEY="id_ocp"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -60,7 +60,7 @@ SSH_PRIVATE_KEY="id_ocp"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \

--- a/ansible/roles/ocp-workload-appdev-homework/readme.adoc
+++ b/ansible/roles/ocp-workload-appdev-homework/readme.adoc
@@ -39,7 +39,7 @@ GUID=1001
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-                 -e"ansible_ssh_user=ec2-user" \
+                 -e"ansible_user=ec2-user" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -58,7 +58,7 @@ GUID=1002
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-                    -e"ansible_ssh_user=ec2-user" \
+                    -e"ansible_user=ec2-user" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -100,7 +100,7 @@ NOTE: You might want to change `hosts: all` to fit your requirements
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-bxms-dm/ilt_provision.sh
+++ b/ansible/roles/ocp-workload-bxms-dm/ilt_provision.sh
@@ -78,7 +78,7 @@ function executeAnsible() {
 
     ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
 
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \

--- a/ansible/roles/ocp-workload-bxms-pam/ilt_provision.sh
+++ b/ansible/roles/ocp-workload-bxms-pam/ilt_provision.sh
@@ -73,7 +73,7 @@ function executeAnsible() {
 
     ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
 
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \

--- a/ansible/roles/ocp-workload-developer-environment/readme.adoc
+++ b/ansible/roles/ocp-workload-developer-environment/readme.adoc
@@ -39,7 +39,7 @@ GUID=1001
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-                 -e"ansible_ssh_user=ec2-user" \
+                 -e"ansible_user=ec2-user" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -58,7 +58,7 @@ GUID=1002
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-                    -e"ansible_ssh_user=ec2-user" \
+                    -e"ansible_user=ec2-user" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -100,7 +100,7 @@ NOTE: You might want to change `hosts: all` to fit your requirements
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-dm7-qlb-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/readme.adoc
@@ -66,7 +66,7 @@ WORKLOAD="ocp-workload-fsi-client-onboarding-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
                  -e"ocp_username=${OCP_USERNAME}" \
                  -e"ocp_workload=${WORKLOAD}" \
                  -e"guid=${GUID}" \
@@ -85,7 +85,7 @@ WORKLOAD="ocp-workload-fsi-client-onboarding-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -108,7 +108,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-example/readme.adoc
+++ b/ansible/roles/ocp-workload-example/readme.adoc
@@ -40,7 +40,7 @@ GUID=1001
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
     -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-    -e"ansible_ssh_user=ec2-user" \
+    -e"ansible_user=ec2-user" \
     -e"ocp_username=${OCP_USERNAME}" \
     -e"ocp_workload=${WORKLOAD}" \
     -e"silent=False" \
@@ -59,7 +59,7 @@ GUID=1002
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
     -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
-    -e"ansible_ssh_user=ec2-user" \
+    -e"ansible_user=ec2-user" \
     -e"ocp_username=${OCP_USERNAME}" \
     -e"ocp_workload=${WORKLOAD}" \
     -e"guid=${GUID}" \
@@ -96,7 +96,7 @@ NOTE: You might want to change `hosts: all` to fit your requirements
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-fsi-client-onboarding-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-fsi-client-onboarding-demo/readme.adoc
@@ -66,7 +66,7 @@ WORKLOAD="ocp-workload-fsi-client-onboarding-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
                  -e"ocp_username=${OCP_USERNAME}" \
                  -e"ocp_workload=${WORKLOAD}" \
                  -e"guid=${GUID}" \
@@ -85,7 +85,7 @@ WORKLOAD="ocp-workload-fsi-client-onboarding-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -108,7 +108,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-fuse-on-ocp/ilt_provision.sh
+++ b/ansible/roles/ocp-workload-fuse-on-ocp/ilt_provision.sh
@@ -74,7 +74,7 @@ function executeAnsible() {
 
     ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
 
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \

--- a/ansible/roles/ocp-workload-fuse-on-ocp/readme.adoc
+++ b/ansible/roles/ocp-workload-fuse-on-ocp/readme.adoc
@@ -14,7 +14,7 @@ OCP_USERNAME="jbride-redhat.com"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -34,7 +34,7 @@ OCP_USERNAME="jbride-redhat.com"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USERNAME}" \
+                    -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \

--- a/ansible/roles/ocp-workload-integreatly/readme.adoc
+++ b/ansible/roles/ocp-workload-integreatly/readme.adoc
@@ -67,7 +67,7 @@ WORKLOAD="ocp-workload-integreatly"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
                  -e"ocp_workload=${WORKLOAD}" \
                  -e"guid=${GUID}" \
                  -e"ocp_user_needs_quota=false" \
@@ -83,7 +83,7 @@ WORKLOAD="ocp-workload-integreatly"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
                     -e"ACTION=remove"
@@ -105,7 +105,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-iot-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-iot-demo/readme.adoc
@@ -69,7 +69,7 @@ WORKLOAD="ocp-workload-parksmap-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
                  -e"ocp_username=${OCP_USERNAME}" \
                  -e"ocp_workload=${WORKLOAD}" \
                  -e"guid=${GUID}" \
@@ -88,7 +88,7 @@ WORKLOAD="ocp-workload-parksmap-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -111,7 +111,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/readme.adoc
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/readme.adoc
@@ -66,7 +66,7 @@ WORKLOAD="ocp-workload-fsi-client-onboarding-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
                  -e"ocp_username=${OCP_USERNAME}" \
                  -e"ocp_workload=${WORKLOAD}" \
                  -e"guid=${GUID}" \
@@ -85,7 +85,7 @@ WORKLOAD="ocp-workload-fsi-client-onboarding-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -108,7 +108,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-parksmap-demo/readme.adoc
+++ b/ansible/roles/ocp-workload-parksmap-demo/readme.adoc
@@ -66,7 +66,7 @@ WORKLOAD="ocp-workload-parksmap-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
                  -e"ocp_username=${OCP_USERNAME}" \
                  -e"ocp_workload=${WORKLOAD}" \
                  -e"guid=${GUID}" \
@@ -85,7 +85,7 @@ WORKLOAD="ocp-workload-parksmap-demo"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -108,7 +108,7 @@ ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
 ----
 [gptehosts:vars]
 ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem
-ansible_ssh_user=ec2-user
+ansible_user=ec2-user
 
 [gptehosts:children]
 openshift

--- a/ansible/roles/ocp-workload-rhte-mw-msa-mesh/readme.adoc
+++ b/ansible/roles/ocp-workload-rhte-mw-msa-mesh/readme.adoc
@@ -43,7 +43,7 @@ SSH_PRIVATE_KEY="id_ocp"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \
@@ -66,7 +66,7 @@ SSH_PRIVATE_KEY="id_ocp"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USERNAME}" \
+                 -e"ansible_user=${SSH_USERNAME}" \
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \
                     -e"guid=${GUID}" \

--- a/ansible/roles/ocp-workload-starter-workshop/readme.adoc
+++ b/ansible/roles/ocp-workload-starter-workshop/readme.adoc
@@ -74,7 +74,7 @@ WORKLOAD="ocp-workload-starter-workshop"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                  -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                 -e"ansible_ssh_user=${SSH_USER}" \
+                 -e"ansible_user=${SSH_USER}" \
 
                  -e"ocp_username=${OCP_USERNAME}" \
                  -e"ocp_workload=${WORKLOAD}" \
@@ -98,7 +98,7 @@ WORKLOAD="ocp-workload-starter-workshop"
 # a TARGET_HOST is specified in the command line, without using an inventory file
 ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
                     -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-                    -e"ansible_ssh_user=${SSH_USER}" \
+                    -e"ansible_user=${SSH_USER}" \
 
                     -e"ocp_username=${OCP_USERNAME}" \
                     -e"ocp_workload=${WORKLOAD}" \

--- a/ansible/roles/ocp-workload-vertx-reactica/readme.adoc
+++ b/ansible/roles/ocp-workload-vertx-reactica/readme.adoc
@@ -28,7 +28,7 @@ WORKLOAD="ocp-workload-vertx-reactica"
 
 ansible-playbook -v -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
               -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-              -e"ansible_ssh_user=${SSH_USER}" \
+              -e"ansible_user=${SSH_USER}" \
               -e"ocp_username=${OCP_USERNAME}" \
               -e"ocp_workload=${WORKLOAD}" \
               -e"guid=${GUID}" \
@@ -58,7 +58,7 @@ WORKLOAD="ocp-workload-vertx-reactica"
 
 ansible-playbook -v -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
               -e"ansible_ssh_private_key_file=~/.ssh/${SSH_PRIVATE_KEY}" \
-              -e"ansible_ssh_user=${SSH_USER}" \
+              -e"ansible_user=${SSH_USER}" \
               -e"ocp_username=${OCP_USERNAME}" \
               -e"ocp_workload=${WORKLOAD}" \
               -e"guid=${GUID}" \

--- a/ansible/roles/set_env_authorized_key/tasks/main.yml
+++ b/ansible/roles/set_env_authorized_key/tasks/main.yml
@@ -18,7 +18,7 @@
 
 - name: Set authorized key from file
   authorized_key:
-    user: "{{ansible_ssh_user}}"
+    user: "{{ansible_user}}"
     state: present
     key: "{{ lookup('file', '{{output_dir}}/{{env_authorized_key}}.pub') }}"
 

--- a/tests/static/scenarii/ocp-workshop-azure.yml
+++ b/tests/static/scenarii/ocp-workshop-azure.yml
@@ -3,7 +3,7 @@ guid: testconfig
 cloud_provider: azure
 azure_region: EastUS
 remote_user: azure
-ansible_ssh_user: azure
+ansible_user: azure
 az_dnszone_resource_group: foo
 
 key_name: bar

--- a/tools/archive/archived_roles/nodejs/README.md
+++ b/tools/archive/archived_roles/nodejs/README.md
@@ -16,7 +16,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 The Node.js version to install. "6.x" is the default and works on most supported OSes. Other versions such as "0.12", "4.x", "5.x", "6.x", etc. should work on the latest versions of Debian/Ubuntu and RHEL/CentOS.
 
-    nodejs_install_npm_user: "{{ ansible_ssh_user }}"
+    nodejs_install_npm_user: "{{ ansible_user }}"
 
 The user for whom the npm packages will be installed can be set here, this defaults to `ansible_user`.
 

--- a/tools/archive/archived_roles/zsh/README.md
+++ b/tools/archive/archived_roles/zsh/README.md
@@ -18,7 +18,7 @@ Available variables are listed below, along with default values:
 
 ```yaml
 zsh_users:
-  - "{{ ansible_ssh_user }}"
+  - "{{ ansible_user }}"
 zsh_ohmy_theme: pygmalion
 zsh_ohmy_plugins:
   - git

--- a/tools/archive/archived_roles/zsh/defaults/main.yml
+++ b/tools/archive/archived_roles/zsh/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 zsh_users:
-  - "{{ ansible_ssh_user }}"
+  - "{{ ansible_user }}"
 zsh_ohmy_theme: pygmalion
 zsh_ohmy_plugins:
   - git

--- a/tools/archive/archived_roles/zsh/tests/inventory
+++ b/tools/archive/archived_roles/zsh/tests/inventory
@@ -1,1 +1,1 @@
-localhost ansible_connection=local ansible_ssh_user=vagrant
+localhost ansible_connection=local ansible_user=vagrant

--- a/tools/archive/cloudproviders/archive/terraform_ec2_infrastructure_deployment.yml
+++ b/tools/archive/cloudproviders/archive/terraform_ec2_infrastructure_deployment.yml
@@ -89,7 +89,7 @@
         - "{{item.tags.ostype | default('unknowns')}}"
         - "{{item['tags'][project_tag_ostype] | default('unknowns')}}"
         - "{{ 'newnodes' if (item.tags.newnode|d()|bool) else 'all'}}"
-      ansible_ssh_user: ec2-user
+      ansible_user: ec2-user
       remote_user: ec2-user
       ansible_ssh_private_key_file: "{{item['key_name']}}"
       key_name: "{{item['key_name']}}"
@@ -183,7 +183,6 @@
         ansible_password: "{{ windows_password | default(hostvars['localhost'].generated_windows_password) }}"
         ansible_port: 5986
         ansible_user: Administrator
-        ansible_ssh_user: Administrator
         ansible_winrm_server_cert_validation: ignore
 
     - name: wait for windows host to be available

--- a/tools/archive/configs/ans-network-lab/env_vars.yml
+++ b/tools/archive/configs/ans-network-lab/env_vars.yml
@@ -152,7 +152,7 @@ instances:
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/ans-network-lab/files/hosts_template.j2
+++ b/tools/archive/configs/ans-network-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"
 [3tierapp:children]

--- a/tools/archive/configs/ansible-tower-terraform/env_vars.yml
+++ b/tools/archive/configs/ansible-tower-terraform/env_vars.yml
@@ -21,7 +21,7 @@ terraform_working_dir: "{{ lookup('env','PWD') }}/ansible/workdir"
 #####################################################
 ssh_key_path: "{{ terraform_working_dir }}/{{ workshop_prefix }}/{{ workshop_prefix }}-tower"
 ansible_ssh_private_key_file: "{{ terraform_working_dir }}/{{ workshop_prefix }}/{{ workshop_prefix }}-tower"
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 #####################################################
 # aws.infra.terraform  |  Number of Students
 #####################################################

--- a/tools/archive/configs/auth-playground-lab/env_vars.yml
+++ b/tools/archive/configs/auth-playground-lab/env_vars.yml
@@ -136,7 +136,7 @@ instances:
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/auth-playground-lab/files/hosts_template.j2
+++ b/tools/archive/configs/auth-playground-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 
 
 [GenericExample:children]
@@ -41,7 +41,6 @@ ansible_connection=winrm
 ansible_port=5986
 ansible_ssh_port=5986
 ansible_user=Administrator
-ansible_ssh_user=Administrator
 ansible_winrm_server_cert_validation=ignore
 ansible_winrm_transport=basic
 ansible_become=false

--- a/tools/archive/configs/bu-workshop/env_vars.yml
+++ b/tools/archive/configs/bu-workshop/env_vars.yml
@@ -1,6 +1,6 @@
 ### Common Vars
 guid: defaultguid
-ansible_ssh_user: "ec2-user"
+ansible_user: "ec2-user"
 remote_user: "ec2-user"
 use_internal_dns_zone: false
 deploy_openshift: true

--- a/tools/archive/configs/bu-workshop/files/hosts_template.j2
+++ b/tools/archive/configs/bu-workshop/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ ansible_ssh_user }}
+ansible_user={{ ansible_user }}
 
 
 ###########################################################################
@@ -153,16 +153,16 @@ nfs
 
 [nodes]
 {% for host in groups['masters'] %}
-{{ hostvars[host]['ec2_private_dns_name'] }} ansible_ssh_user={{ ansible_ssh_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }} openshift_node_labels="{'openshift_schedulable':'False','region': 'primary', 'zone': '{{ hostvars[host]['ec2_placement'] }}'}"
+{{ hostvars[host]['ec2_private_dns_name'] }} ansible_user={{ ansible_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }} openshift_node_labels="{'openshift_schedulable':'False','region': 'primary', 'zone': '{{ hostvars[host]['ec2_placement'] }}'}"
 {% endfor %}
 {% for host in groups['infranodes'] %}
-{{ hostvars[host]['ec2_private_dns_name'] }} ansible_ssh_user={{ ansible_ssh_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }} openshift_node_labels="{'region': 'primary', 'zone': '{{ hostvars[host]['ec2_placement'] }}', 'env': 'infra'}"
+{{ hostvars[host]['ec2_private_dns_name'] }} ansible_user={{ ansible_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }} openshift_node_labels="{'region': 'primary', 'zone': '{{ hostvars[host]['ec2_placement'] }}', 'env': 'infra'}"
 {% endfor %}
 {% for host in groups['nodes'] %}
-{{ hostvars[host]['ec2_private_dns_name'] }} ansible_ssh_user={{ ansible_ssh_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }} openshift_node_labels="{'region': 'primary', 'zone': '{{ hostvars[host]['ec2_placement'] }}', 'env': 'user'}"
+{{ hostvars[host]['ec2_private_dns_name'] }} ansible_user={{ ansible_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }} openshift_node_labels="{'region': 'primary', 'zone': '{{ hostvars[host]['ec2_placement'] }}', 'env': 'user'}"
 {% endfor %}
 
 [nfs]
 {% for host in groups['support'] %}
-{{ hostvars[host]['ec2_private_dns_name'] }} ansible_ssh_user={{ ansible_ssh_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }}
+{{ hostvars[host]['ec2_private_dns_name'] }} ansible_user={{ ansible_user }} ansible_ssh_private_key_file=~/.ssh/{{ key_name }}
 {% endfor %}

--- a/tools/archive/configs/generic-example/env_vars.yml
+++ b/tools/archive/configs/generic-example/env_vars.yml
@@ -82,7 +82,7 @@ support_instance_count: 1
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/generic-example/files/hosts_template.j2
+++ b/tools/archive/configs/generic-example/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 [GenericExample:children]
@@ -16,18 +16,18 @@ support
 [publichosts]
 ## These are the publichosts
 {% for host in groups['publichosts'] %}
-publichost{{loop.index}}.{{chomped_zone_internal_dns}} public_host_name=publichost{{loop.index}}.{{guid}}{{subdomain_base_suffix}} ansible_ssh_user={{remote_user}}
+publichost{{loop.index}}.{{chomped_zone_internal_dns}} public_host_name=publichost{{loop.index}}.{{guid}}{{subdomain_base_suffix}} ansible_user={{remote_user}}
 {% endfor %}
 
 [internalhosts]
 ## These are the internalhosts
 {% for host in groups['internalhosts'] %}
-internalhost{{loop.index}}.{{chomped_zone_internal_dns}}  ansible_ssh_user={{remote_user}}
+internalhost{{loop.index}}.{{chomped_zone_internal_dns}}  ansible_user={{remote_user}}
 {% endfor %}
 
 [internalhosts]
 ## These are the supporthosts
 [support]
 {% for host in groups['support'] %}
-support{{loop.index}}.{{chomped_zone_internal_dns}}  ansible_ssh_user={{remote_user}}
+support{{loop.index}}.{{chomped_zone_internal_dns}}  ansible_user={{remote_user}}
 {% endfor %}

--- a/tools/archive/configs/ocp-adv-deploy-hw/env_vars.yml
+++ b/tools/archive/configs/ocp-adv-deploy-hw/env_vars.yml
@@ -117,7 +117,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/tools/archive/configs/ocp-adv-deploy-hw/files/hosts_template.3.9.14.j2
+++ b/tools/archive/configs/ocp-adv-deploy-hw/files/hosts_template.3.9.14.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/tools/archive/configs/ocp-adv-deploy-hw/files/hosts_template.3.9.25.j2
+++ b/tools/archive/configs/ocp-adv-deploy-hw/files/hosts_template.3.9.25.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/tools/archive/configs/ocp-adv-deploy-hw/files/hosts_template.3.9.27.j2
+++ b/tools/archive/configs/ocp-adv-deploy-hw/files/hosts_template.3.9.27.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars

--- a/tools/archive/configs/ocp-adv-deploy-hw/files/labs_hosts_template.j2
+++ b/tools/archive/configs/ocp-adv-deploy-hw/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 # disable memory check, as we are not a production environment
 openshift_disable_check="memory_availability"

--- a/tools/archive/configs/ocp-demo-lab/env_vars.yml
+++ b/tools/archive/configs/ocp-demo-lab/env_vars.yml
@@ -47,7 +47,7 @@ use_own_key: true
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/ocp-demo-lab/files/hosts_template.j2
+++ b/tools/archive/configs/ocp-demo-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 ###########################################################################
@@ -180,20 +180,20 @@ nfs
 [nodes]
 ## These are the masters
 {% for host in groups['masters'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 
 ## These are infranodes
 {% for host in groups['infranodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 
 ## These are regular nodes
 {% for host in groups['nodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 
 [nfs]
 {% for host in groups['support'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
 {% endfor %}

--- a/tools/archive/configs/ocp-implementation-lab-2/env_vars.yml
+++ b/tools/archive/configs/ocp-implementation-lab-2/env_vars.yml
@@ -123,7 +123,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/tools/archive/configs/ocp-implementation-lab-2/files/hosts_template.j2
+++ b/tools/archive/configs/ocp-implementation-lab-2/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 ###########################################################################
@@ -184,20 +184,20 @@ master{{loop.index}}.{{chomped_zone_internal_dns}}
 [nodes]
 ## These are the masters
 {% for host in groups['masters'] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}   ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}'}"
+master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}   ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}'}"
 {% endfor %}
 
 ## These are infranodes
 {% for host in groups['infranodes'] %}
-infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra''}"
+infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra''}"
 {% endfor %}
 
 ## These are regular nodes
 {% for host in groups['nodes'] %}
-node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users'}"
+node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users'}"
 {% endfor %}
 
 [nfs]
 {% for host in groups['support'] %}
-support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
+support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
 {% endfor %}

--- a/tools/archive/configs/ocp-implementation-lab-2/files/labs_hosts_template.j2
+++ b/tools/archive/configs/ocp-implementation-lab-2/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 

--- a/tools/archive/configs/ocp-implementation-lab/env_vars.yml
+++ b/tools/archive/configs/ocp-implementation-lab/env_vars.yml
@@ -123,7 +123,7 @@ admin_user: ''
 admin_user_password: ''
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/tools/archive/configs/ocp-implementation-lab/files/hosts_template.j2
+++ b/tools/archive/configs/ocp-implementation-lab/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 ###########################################################################
@@ -183,20 +183,20 @@ master{{loop.index}}.{{chomped_zone_internal_dns}}
 [nodes]
 ## These are the masters
 {% for host in groups['masters'] %}
-master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}   ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}'}"
+master{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}   ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','cluster': '{{guid}}'}"
 {% endfor %}
 
 ## These are infranodes
 {% for host in groups['infranodes'] %}
-infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra''}"
+infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'infra''}"
 {% endfor %}
 
 ## These are regular nodes
 {% for host in groups['nodes'] %}
-node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users'}"
+node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users'}"
 {% endfor %}
 
 [nfs]
 {% for host in groups['support'] %}
-support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
+support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_hostname=support{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
 {% endfor %}

--- a/tools/archive/configs/ocp-implementation-lab/files/labs_hosts_template.j2
+++ b/tools/archive/configs/ocp-implementation-lab/files/labs_hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 

--- a/tools/archive/configs/ocp-multi-cloud-example/env_vars.yml
+++ b/tools/archive/configs/ocp-multi-cloud-example/env_vars.yml
@@ -432,7 +432,7 @@ available_identity_providers:
     filename: /etc/origin/master/htpasswd
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.14.j2
+++ b/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.14.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -323,7 +323,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.25.j2
+++ b/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.25.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -322,7 +322,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.27.j2
+++ b/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.27.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -358,7 +358,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.30.j2
+++ b/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.30.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -361,7 +361,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.31.j2
+++ b/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.3.9.31.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -361,7 +361,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.j2
+++ b/tools/archive/configs/ocp-multi-cloud-example/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -362,7 +362,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/env_vars.yml
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/env_vars.yml
@@ -228,7 +228,7 @@ available_identity_providers:
     filename: /etc/origin/master/htpasswd
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.14.j2
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.14.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -323,7 +323,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.25.j2
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.25.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -322,7 +322,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.27.j2
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.27.j2
@@ -8,7 +8,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -358,7 +358,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.30.j2
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.30.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -361,7 +361,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.31.j2
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.3.9.31.j2
@@ -10,7 +10,7 @@ openshift_enable_unsupported_configurations=True
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -367,7 +367,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.j2
+++ b/tools/archive/configs/ocp-storage-cns_based_on_ocp-workshop/files/hosts_template.j2
@@ -4,7 +4,7 @@
 ### Ansible Vars
 ########################################################################### timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -361,7 +361,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/opentlc-shared/env_vars.yml
+++ b/tools/archive/configs/opentlc-shared/env_vars.yml
@@ -75,7 +75,7 @@ use_own_key: true
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/opentlc-shared/files/hosts_template.j2
+++ b/tools/archive/configs/opentlc-shared/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 ###########################################################################
@@ -172,18 +172,18 @@ nfs
 
 [nodes]
 {% for host in groups['masters'] %}
-{{hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}  openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','region': 'primary', 'zone': '{{hostvars[host]['placement']}}'}"
+{{hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=master{{loop.index}}.{{chomped_zone_internal_dns}}  openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','openshift_schedulable':'False','region': 'primary', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 
 {% for host in groups['infranodes'] %}
-{{hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','region': 'primary', 'env':'infra', 'zone': '{{hostvars[host]['placement']}}'}"
+{{hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=infranode{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','region': 'primary', 'env':'infra', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 
 {% for host in groups['nodes'] %}
-{{hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','region': 'primary', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{{hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=node{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','region': 'primary', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 
 [nfs]
 {% for host in groups[('tag_' + env_type + '-' + guid + '_nfs') | replace('-', '_') ] %}
-{{ hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=nfs{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
+{{ hostvars[host]['ec2_private_dns_name'] }} openshift_hostname=nfs{{loop.index}}.{{chomped_zone_internal_dns}} openshift_ip={{hostvars[host]['ec2_private_ip_address']}} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem
 {% endfor %}

--- a/tools/archive/configs/opentlc-shared/ssh_vars.yml
+++ b/tools/archive/configs/opentlc-shared/ssh_vars.yml
@@ -1,5 +1,5 @@
 ansible_ssh_extra_args: >
-  -o User={{ ansible_ssh_user }}
+  -o User={{ ansible_user }}
   -o StrictHostKeyChecking=no
   -i ~/.ssh/{{ key_name }}.pem
-  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -i ~/.ssh/'{{ key_name }}'.pem -o User='{{ ansible_ssh_user }}' -W %h:%p {{ hostvars[ groups[ ('tag_' ~ env_type ~ '_' ~ guid ~ '_bastion') | replace('-', '_') ].0 ]['ec2_public_dns_name'] }}"
+  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -i ~/.ssh/'{{ key_name }}'.pem -o User='{{ ansible_user }}' -W %h:%p {{ hostvars[ groups[ ('tag_' ~ env_type ~ '_' ~ guid ~ '_bastion') | replace('-', '_') ].0 ]['ec2_public_dns_name'] }}"

--- a/tools/archive/configs/ravello-bastion-setup/env_vars.yml
+++ b/tools/archive/configs/ravello-bastion-setup/env_vars.yml
@@ -5,7 +5,7 @@
 ### Also, we should probably just create a variable reference in the README.md
 ### For now, just tagging comments in line with configuration file.
 
-ansible_ssh_user: cloud-user
+ansible_user: cloud-user
 remote_user: cloud-user
 
 blueprint_name: "{{env_type}}.{{guid}}"

--- a/tools/archive/configs/ravello-bastion-setup/files/hosts_template.j2
+++ b/tools/archive/configs/ravello-bastion-setup/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 

--- a/tools/archive/configs/ravello-test/env_vars.yml
+++ b/tools/archive/configs/ravello-test/env_vars.yml
@@ -5,7 +5,7 @@
 ### Also, we should probably just create a variable reference in the README.md
 ### For now, just tagging comments in line with configuration file.
 
-ansible_ssh_user: cloud-user
+ansible_user: cloud-user
 remote_user: cloud-user
 
 blueprint_name: "{{env_type}}.{{guid}}"

--- a/tools/archive/configs/ravello-test/files/hosts_template.j2
+++ b/tools/archive/configs/ravello-test/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 

--- a/tools/archive/configs/ravello-test/ssh_vars.yml
+++ b/tools/archive/configs/ravello-test/ssh_vars.yml
@@ -1,5 +1,5 @@
 ansible_ssh_extra_args: >
-  -o User={{ ansible_ssh_user }}
+  -o User={{ ansible_user }}
   -o StrictHostKeyChecking=no
   -i ~/.ssh/{{ key_name }}.pem
-  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -i ~/.ssh/'{{ key_name }}'.pem -o User='{{ ansible_ssh_user }}' -W %h:%p {{ hostvars[ groups[ ('tag_' ~ env_type ~ '_' ~ guid ~ '_ipa') | replace('-', '_') ].0 ]['ec2_public_dns_name'] }}"
+  -o ProxyCommand="ssh -o StrictHostKeyChecking=no -i ~/.ssh/'{{ key_name }}'.pem -o User='{{ ansible_user }}' -W %h:%p {{ hostvars[ groups[ ('tag_' ~ env_type ~ '_' ~ guid ~ '_ipa') | replace('-', '_') ].0 ]['ec2_public_dns_name'] }}"

--- a/tools/archive/configs/rhte-lb/env_vars.yml
+++ b/tools/archive/configs/rhte-lb/env_vars.yml
@@ -63,7 +63,7 @@ install_student_user: false
 osrelease: 3.10.34
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/rhte-ocp-workshop/env_vars.yml
+++ b/tools/archive/configs/rhte-ocp-workshop/env_vars.yml
@@ -259,7 +259,7 @@ admission_plugin_config:
 
 
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.10.14.j2
+++ b/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.10.14.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################
@@ -363,7 +363,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.10.34.j2
+++ b/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.10.34.j2
@@ -8,7 +8,7 @@
 ### Ansible Vars
 ###########################################################################
 timeout=60
-ansible_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 ansible_become=yes
 
 ###########################################################################
@@ -366,7 +366,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
+{{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_group_name='node-config-compute'
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.9.40.j2
+++ b/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.9.40.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -383,7 +383,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.9.41.j2
+++ b/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.3.9.41.j2
@@ -9,7 +9,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -382,7 +382,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes']|sort %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'runtime': '{{container_runtime}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.j2
+++ b/tools/archive/configs/rhte-ocp-workshop/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 ###########################################################################
 ### OpenShift Basic Vars
@@ -362,7 +362,7 @@ new_nodes
 # https://docs.openshift.com/container-platform/3.7/install_config/adding_hosts_to_existing_cluster.html
 [new_nodes]
 {% for host in groups['newnodes'] %}
-{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_ssh_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
+{{ hostvars[host].internaldns }} openshift_hostname={{ hostvars[host].internaldns }} ansible_user={{remote_user}} ansible_ssh_private_key_file=~/.ssh/{{key_name}}.pem openshift_node_labels="{'logging':'true','cluster': '{{guid}}', 'env':'users', 'zone': '{{hostvars[host]['placement']}}'}"
 {% endfor %}
 {% endif %}
 

--- a/tools/archive/configs/simple-multi-cloud-example/files/hosts_template.j2
+++ b/tools/archive/configs/simple-multi-cloud-example/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"
 [3tierapp:children]

--- a/tools/archive/configs/single-ipa/env_vars.yml
+++ b/tools/archive/configs/single-ipa/env_vars.yml
@@ -62,7 +62,7 @@ admin_user: 'admin'
 admin_user_password: 'r3dh4t1!'
 
 #### Connection Settings
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 #### Networking (AWS)

--- a/tools/archive/configs/single-ipa/files/hosts_template.j2
+++ b/tools/archive/configs/single-ipa/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{ansible_ssh_user}}
+ansible_user={{ansible_user}}
 
 
 

--- a/tools/archive/configs/three-tier-tower/env_vars.yml
+++ b/tools/archive/configs/three-tier-tower/env_vars.yml
@@ -182,7 +182,7 @@ instances:
 
 ###### VARIABLES YOU SHOULD ***NOT*** CONFIGURE FOR YOUR DEPLOYEMNT
 ###### You can, but you usually wouldn't need to.
-ansible_ssh_user: ec2-user
+ansible_user: ec2-user
 remote_user: ec2-user
 
 common_packages:

--- a/tools/archive/configs/three-tier-tower/files/hosts_template.j2
+++ b/tools/archive/configs/three-tier-tower/files/hosts_template.j2
@@ -5,7 +5,7 @@
 ###########################################################################
 timeout=60
 ansible_become=yes
-ansible_ssh_user={{remote_user}}
+ansible_user={{remote_user}}
 ansible_ssh_private_key_file="~/.ssh/{{guid}}key.pem"
 ansible_ssh_common_args="-o StrictHostKeyChecking=no"
 [3tierapp:children]

--- a/tools/examples/ocp-workshop-azure.rc
+++ b/tools/examples/ocp-workshop-azure.rc
@@ -29,7 +29,7 @@ ENVTYPE_ARGS=(
 -e rootfs_size_support=128
 
 -e remote_user=azure
--e ansible_ssh_user=azure
+-e ansible_user=azure
 
 -e "subdomain_base_suffix=${BASESUFFIX}"
 -e node_instance_count=1


### PR DESCRIPTION
##### SUMMARY
Replace ansible_ssh_user with ansible_user as requested by #109 

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
Ansible, config, tools and tests

##### ADDITIONAL INFORMATION
ansible_ssh_user was deprecated as shown here:

```
Note
Ansible 2.0 has deprecated the “ssh” from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port. If you are using a version of Ansible prior to 2.0, you should continue using the older style variables (ansible_ssh_*). These shorter variables are ignored, without warning, in older versions of Ansible.
```
https://docs.ansible.com/ansible/2.4/intro_inventory.html

If it fits, a follow-up PR will follow to change ansible_ssh_host ansible_ssh_port.