### PR TITLE
Replace removed 'oc volume' command with 'oc set volume'.

### DIFF
--- a/ansible/roles/ocp-workload-dm7-qlb-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-dm7-qlb-demo/tasks/workload.yml
@@ -55,7 +55,7 @@
             -p IMAGE_STREAM_NAMESPACE={{ocp_project}} -n {{ocp_project}}
 
 - name: "Add ConfigMap as Volume to Decision Central DC"
-  shell: oc volume dc/rhdm7-qlb-rhdmcentr --add --name=config-volume --configmap-name=rhdm-dc-setup-config-map --mount-path=/tmp/config-files
+  shell: oc set volume dc/rhdm7-qlb-rhdmcentr --add --name=config-volume --configmap-name=rhdm-dc-setup-config-map --mount-path=/tmp/config-files
 
 - name: "Add DC deployment hook."
   shell: oc set deployment-hook dc/rhdm7-qlb-rhdmcentr --post -c rhdm7-qlb-rhdmcentr -e DC_URL="http://rhdm7-qlb-rhdmcentr:8080" -v config-volume --failure-policy=abort -- /bin/bash /tmp/config-files/dc-clone-git-repository.sh

--- a/ansible/roles/ocp-workload-pam-order-it-hardware/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-pam-order-it-hardware/tasks/workload.yml
@@ -75,7 +75,7 @@
             -p IMAGE_STREAM_NAMESPACE={{ocp_project}} -n {{ocp_project}}
 
 - name: "Add ConfigMap as Volume to Business Central DC"
-  shell: oc volume dc/rhpam7-oih-rhpamcentr --add --name=config-volume --configmap-name=rhpam-bc-setup-config-map --mount-path=/tmp/config-files
+  shell: oc set volume dc/rhpam7-oih-rhpamcentr --add --name=config-volume --configmap-name=rhpam-bc-setup-config-map --mount-path=/tmp/config-files
 
 - name: "Add BC deployment hook."
   shell: oc set deployment-hook dc/rhpam7-oih-rhpamcentr --post -c rhpam7-oih-rhpamcentr -e BC_URL="http://rhpam7-oih-rhpamcentr:8080" -v config-volume --failure-policy=abort -- /bin/bash /tmp/config-files/bc-clone-git-repository.sh
@@ -103,10 +103,10 @@
   shell: "oc create configmap rhpam7-oih-order-app-settings-config-map --from-file=/tmp/{{guid}}/settings.xml -n {{ocp_project}}"
 
 - name: "Add ConfigMap as Volume to Order IT Hardware App DC"
-  shell: "oc volume dc/rhpam7-oih-order-app --add -m /home/jboss/.m2 -t configmap --configmap-name=rhpam7-oih-order-app-settings-config-map -n {{ocp_project}}"
+  shell: "oc set volume dc/rhpam7-oih-order-app --add -m /home/jboss/.m2 -t configmap --configmap-name=rhpam7-oih-order-app-settings-config-map -n {{ocp_project}}"
 
 - name: "Add Data Persistent Volume"
-  shell: "oc volume dc/rhpam7-oih-order-app --add --claim-size 100Mi --mount-path /data --name rhpam7-oih-order-app-data -n {{ocp_project}}"
+  shell: "oc set volume dc/rhpam7-oih-order-app --add --claim-size 100Mi --mount-path /data --name rhpam7-oih-order-app-data -n {{ocp_project}}"
 
 - name: "Expose Order IT HW App as service"
   shell: "oc expose service rhpam7-oih-order-app -n {{ocp_project}}"
@@ -129,7 +129,7 @@
   shell: "oc create configmap rhpam7-oih-order-app-properties-config-map --from-file=/tmp/{{guid}}/application-openshift-rhpam.properties -n {{ocp_project}}"
 
 - name: "Add SpringBoot ConfigMap as Volume to Order IT Hardware App DC"
-  shell: "oc volume dc/rhpam7-oih-order-app --add -m /deployments/config -t configmap --configmap-name=rhpam7-oih-order-app-properties-config-map -n {{ocp_project}}"
+  shell: "oc set volume dc/rhpam7-oih-order-app --add -m /deployments/config -t configmap --configmap-name=rhpam7-oih-order-app-properties-config-map -n {{ocp_project}}"
 
 #- name: "Configure application-openshift-rhpam.properties kie-server route"
 #  shell: "sed \"s/.*kieserver_host.*/\ \ \ \ \'kieserver_host\'\ :\ \'{{kie_server_route}}\',/g\" /tmp/{{guid}}/config.js.orig > /tmp/{{guid}}/config.js"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
'oc volume' command was removed in OpenShift 3.11. Replacing with 'oc set volume'.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
- ocp-workload-dm7-qlb-demo
- ocp-workload-pam-order-it-hardware

##### ADDITIONAL INFORMATION
n.a.