### PR TITLE
Fixes check whether project already exists.

### DIFF
--- a/ansible/roles/ocp-workload-fsi-cc-dispute-demo/tasks/workload.yml
+++ b/ansible/roles/ocp-workload-fsi-cc-dispute-demo/tasks/workload.yml
@@ -4,12 +4,11 @@
     ocp_project: "fsi-cc-dispute-{{guid}}"
 
     # Templates come from here: https://raw.githubusercontent.com/jorgemoralespou/ose-sample-apps-layouts
+
 - name: Check if project exists
-  shell: |
-         oc get project {{ocp_project}}
-  changed_when: false
+  shell: oc get project {{ocp_project}}
   register: project_exists_result
-  failed_when: false
+  ignore_errors: true
 
 - name: Create project for FSI Credit Card Dispute demo
   shell: |


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Deployment failed because check whether project existed did not function correctly, causing the project not to be created.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ocp-workload-fsi-cc-dispute-demo

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
n.a.