### PR TITLE
S1003 Extend rook rgw timeout in role ocp4-workload-rhte-analytics_data_ocp_infra

### DIFF
--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_infra/tasks/workload.yml
@@ -67,8 +67,8 @@
   command: "oc rollout status deployment rook-ceph-rgw-my-store -n rook-ceph -w"
   register: result
   until: result.stderr.find("Error from server (NotFound)") != 0
-  retries: 120
-  delay: 10
+  retries: 45
+  delay: 60
 
 - name: Get Rook Ceph RGW Service
   k8s_facts:
@@ -77,7 +77,8 @@
     name: rook-ceph-rgw-my-store
   register: rgw_service
   until: rgw_service.resources
-  retries: 60
+  retries: 5
+  delay: 60
 
 - name: Set the Rook Ceph RGW IP and Port
   set_fact:

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/defaults/main.yml
@@ -45,7 +45,7 @@ workshop_jupyter_notebook_imagestream_name: s2i-spark-scipy-notebook
 workshop_jupyter_notebook_imagestream_tag: "3.6"
 
 # Command separated string list each git repo url to preload on the notebook pod when it spawns
-workshop_preload_repos: "https://gitlab.com/vpavlin/hybrid-data-engineering-workshop"
+workshop_preload_repos: "https://gitlab.com/opendatahub/data-engineering-and-machine-learning-workshop.git"
 
 # Amount of memory for the JupyterHub server
 jupyterhub_memory: "1Gi"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_pre_operator_workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/tasks/per_user_pre_operator_workload.yml
@@ -112,6 +112,23 @@
         name: opendatahub-admin
         apiGroup: rbac.authorization.k8s.io
 
+- name: Make '{{ user_name }}' Seldon user
+  k8s:
+    state: present
+    definition:
+      kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: "seldon-user-{{ user_name }}"
+        namespace: "{{ project_name }}"
+      subjects:
+        - kind: User
+          name: "{{ user_name }}"
+      roleRef:
+        kind: ClusterRole
+        name: seldon-user
+        apiGroup: rbac.authorization.k8s.io
+
 ####################################################################################################
 # STRIMZI SETUP
 ####################################################################################################

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/jupyterhub-single-user-profile-user.configmap.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/jupyterhub-single-user-profile-user.configmap.yaml.j2
@@ -5,6 +5,7 @@ data:
       AWS_ACCESS_KEY_ID: {{ s3_access_key }}
       AWS_SECRET_ACCESS_KEY: {{ s3_secret_key }}
       JUPYTER_PRELOAD_REPOS: "{{ workshop_preload_repos }}"
+      NAMESPACE: "{{ project_name }}"
     gpu: '0'
     last_selected_image: s2i-spark-scipy-notebook:3.6
     last_selected_size: None

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub-operator.v0.4.0.clusterserviceversion.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub-operator.v0.4.0.clusterserviceversion.yaml.j2
@@ -52,7 +52,7 @@ metadata:
               "odh_deploy": true
             },
             "seldon": {
-              "odh_deploy": false
+              "odh_deploy": true
             },
             "ai-library": {
               "odh_deploy": false

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub_v1alpha1_opendatahub_cr.yaml.j2
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop/templates/opendatahub_v1alpha1_opendatahub_cr.yaml.j2
@@ -26,3 +26,5 @@ spec:
     odh_deploy: true
   kafka:
     odh_deploy: true
+  seldon:
+    odh_deploy: true


### PR DESCRIPTION
##### SUMMARY
Extends infrastructure timeouts while waiting for Rook Ceph to deploy.
Update doc repo used in workshop

Attempting to resolves failures in 
```
TASK [ocp4-workload-rhte-analytics_data_ocp_infra : Wait for deploy rook-ceph-rgw-my-store] ***
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
Role ocp4-workload-rhte-analytics_data_ocp_infra
Role ocp4-workload-rhte-analytics_data_ocp_workshop