### PR TITLE
use num_users instead of user_count in S2020

### DIFF
--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/defaults/main.yml
@@ -5,4 +5,4 @@ silent: False
 
 user_count_start: 1
 # The last user number to start with when creating projects
-user_count_end: "{{user_count_start|int + user_count|int}}"
+user_count_end: "{{user_count_start|int + num_users|int}}"

--- a/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-ml-workflows-workshop/tasks/workload.yml
@@ -6,7 +6,7 @@
 
 - name: Setting up workload for user
   debug:
-    msg: "Setting up workload for {{ user_count }} users"
+    msg: "Setting up workload for {{ num_users }} users"
 
 - include_tasks: per_user_workload.yml
   loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop_s2020/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop_s2020/defaults/main.yml
@@ -15,7 +15,7 @@ project_name: null
 # The first user number to start with when creating projects
 user_count_start: 1
 # The last user number to start with when creating projects
-user_count_end: "{{user_count_start|int + user_count|int}}"
+user_count_end: "{{user_count_start|int + num_users|int}}"
 
 # Rook Ceph Info
 # These variables will be initialized by the role ocp4-workload-rhte-analytics_data_ocp_infra

--- a/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop_s2020/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-rhte-analytics_data_ocp_workshop_s2020/tasks/workload.yml
@@ -4,9 +4,9 @@
     msg: User count end({{ user_count_end }}) < user count start ({{ user_count_start }})
   when: user_count_end|int < user_count_start|int
 
-- name: Setting up workload for user
+- name: Setting up workload for users
   debug:
-    msg: "Setting up workload for {{ user_count }} users"
+    msg: "Setting up workload for {{ num_users }} users"
 
 - include_tasks: per_user_pre_operator_workload.yml
   loop: "{{ range(user_count_start|int, user_count_end|int)|list }}"


### PR DESCRIPTION
##### SUMMARY

This uses `num_users` instead of `user_count` to indicate how many users and projects to provision in S2020.  (See also #708.)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- `ocp4-workload-ml-workflows-workshop`
- `ocp4-workload-rhte-analytics_data_ocp_workshop_s2020`
