### PR TITLE
increase user cache expiration to avoid expiring during workshops

### DIFF
--- a/ansible/roles/ocp4-workload-ccnrd/tasks/install-username-distribution.yaml
+++ b/ansible/roles/ocp4-workload-ccnrd/tasks/install-username-distribution.yaml
@@ -52,7 +52,7 @@
     -e LAB_REDIS_HOST=redis
     -e LAB_REDIS_PASS=redis
     -e LAB_TITLE={{ 'Containers & Cloud Native Roadshow' | quote }}
-    -e LAB_DURATION_HOURS=8h
+    -e LAB_DURATION_HOURS=1week
     -e LAB_USER_COUNT={{ num_users }}
     -e LAB_USER_ACCESS_TOKEN={{ workshop_openshift_user_password }}
     -e LAB_USER_PASS={{ workshop_openshift_user_password }}


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Most of the time workshops are deployed days before they are used, with instructors doing test runs. After 8 hours, these user ID assignments expire and can possibly be re-issued to students on day of labs, but since the instructors may have "dirtied" some of them, we don't want to give them back out again.

Setting it to 1 week will cause them to effectively never expire as workshops don't survive that long anyway (and userids are manually removable via an admin screen). For > 1 week special cases, admins would use the user ID blocklist feature to permanently block some user IDs.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`ocp4-workshop-ccnrd`

