### PR TITLE
Removed pruner.yaml from root directory

### DIFF
--- a/pruner.yaml
+++ b/pruner.yaml
@@ -1,7 +1,0 @@
-apiVersion: imageregistry.operator.openshift.io/v1
-kind: ImagePruner
-metadata:
-  name: cluster
-spec:
-  suspend: false
-


### PR DESCRIPTION
Not sure how that file ended up in the root directory. But it is not necessary. The "real" file is in roles_workloads/ocp4_workload_opentlc_production/files.