### PR TITLE
Update satellite-repos.yml ignore remove satellite cert

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -29,7 +29,7 @@
   package:
     name: katello-ca-consumer-*.noarch
     state: absent
-  ignore_errors: "{{ cloud_provider == 'gcp' }}"
+  ignore_errors: true
 
 - name: Find current repository files
   find:


### PR DESCRIPTION
##### SUMMARY

Some images dont have satellite cert RPM pre-installed.  Causing it to fail on this error is very problematic.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
set-repositories/satellite-repos.yml

##### ADDITIONAL INFORMATION

