### PR TITLE
Add agnosticd_virtualenv role

### DIFF
--- a/ansible/roles/agnosticd_virtualenv/.yamllint
+++ b/ansible/roles/agnosticd_virtualenv/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+rules:
+  comments:
+    require-starting-space: false
+  comments-indentation: disable
+  indentation:
+    level: warning
+    indent-sequences: whatever
+  line-length:
+    level: warning
+    max: 500
+    allow-non-breakable-inline-mappings: true

--- a/ansible/roles/agnosticd_virtualenv/.yamllint
+++ b/ansible/roles/agnosticd_virtualenv/.yamllint
@@ -7,8 +7,7 @@ rules:
   comments-indentation: disable
   indentation:
     level: warning
-    indent-sequences: whatever
+    indent-sequences: consistent
   line-length:
-    level: warning
-    max: 500
+    max: 120
     allow-non-breakable-inline-mappings: true

--- a/ansible/roles/agnosticd_virtualenv/README.adoc
+++ b/ansible/roles/agnosticd_virtualenv/README.adoc
@@ -7,7 +7,7 @@ This is role runs from setup_runtime with a default set of Python requirements t
 == Configuration
 
 `agnosticd_virtualenv_requirements` - Python requirements in list format as used by `pip` module `name` argument.
-Default value loaded from `configs/{{ env_type }}/requirements.txt` if it exists.
+Default value loaded from lines in `configs/{{ env_type }}/requirements.txt` if it exists.
 
 `agnosticd_virtualenv_base_dir` - Directory in which to create virtualenvs. Default `/tmp`.
 

--- a/ansible/roles/agnosticd_virtualenv/README.adoc
+++ b/ansible/roles/agnosticd_virtualenv/README.adoc
@@ -1,0 +1,18 @@
+= agnosticd_virtualenv
+
+Create a Python virtualenv for a host and set `ansible_python_interpreter` so that further task execution on the host will occur with this virtualenv.
+
+This is role runs from setup_runtime with a default set of Python requirements that can be set in a configs `requirements.txt`.
+
+== Configuration
+
+`agnosticd_virtualenv_requirements` - Python requirements in list format as used by `pip` module `name` argument.
+Default value loaded from `configs/{{ env_type }}/requirements.txt` if it exists.
+
+`agnosticd_virtualenv_base_dir` - Directory in which to create virtualenvs. Default `/tmp`.
+
+`agnosticd_virtualenv_python` - Python interpreter used to create the virtual env. Default `{{ ansible_python_interpreter }}`.
+
+`agnosticd_virtualenv` - Location to create virtualenv.
+This defaults to a path with a hash checksum of the requirements and python interpreter to give a unique path based on these values.
+This should not be set if a generated unique path is desired.

--- a/ansible/roles/agnosticd_virtualenv/README.adoc
+++ b/ansible/roles/agnosticd_virtualenv/README.adoc
@@ -2,12 +2,12 @@
 
 Create a Python virtualenv for a host and set `ansible_python_interpreter` so that further task execution on the host will occur with this virtualenv.
 
-This is role runs from setup_runtime with a default set of Python requirements that can be set in a configs `requirements.txt`.
+This is role runs from setup_runtime with a default set of Python requirements that can be set in a configs `python-requirements.txt`.
 
 == Configuration
 
 `agnosticd_virtualenv_requirements` - Python requirements in list format as used by `pip` module `name` argument.
-Default value loaded from lines in `configs/{{ env_type }}/requirements.txt` if it exists.
+Default value loaded from lines in `configs/{{ env_type }}/python-requirements.txt` if it exists.
 
 `agnosticd_virtualenv_base_dir` - Directory in which to create virtualenvs. Default `/tmp`.
 

--- a/ansible/roles/agnosticd_virtualenv/defaults/main.yml
+++ b/ansible/roles/agnosticd_virtualenv/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# List of requirements to pass to pip module in name parameter
+agnosticd_virtualenv_requirements: >-
+  {{ lookup('file', playbook_dir ~ '/configs/' ~ env_type ~ '/requirements.txt').split() }}
+
+# Where to create virtualenv directories
+agnosticd_virtualenv_base_dir: /tmp
+
+# Virtual environment python
+agnosticd_virtualenv_python: "{{ ansible_python_interpreter }}"
+
+# Path to agnosticd virtualenv
+agnosticd_virtualenv: >-
+  {{ agnosticd_virtualenv_base_dir
+   ~ '/agnosticd-venv-'
+   ~ [[agnosticd_virtualenv_python] + agnosticd_virtualenv_requirements] | hash('sha256')
+  }}

--- a/ansible/roles/agnosticd_virtualenv/defaults/main.yml
+++ b/ansible/roles/agnosticd_virtualenv/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # List of requirements to pass to pip module in name parameter
 agnosticd_virtualenv_requirements: >-
-  {{ lookup('file', playbook_dir ~ '/configs/' ~ env_type ~ '/requirements.txt').split() }}
+  {{ lookup('file', playbook_dir ~ '/configs/' ~ env_type ~ '/python-requirements.txt').split() }}
 
 # Where to create virtualenv directories
 agnosticd_virtualenv_base_dir: /tmp

--- a/ansible/roles/agnosticd_virtualenv/meta/main.yaml
+++ b/ansible/roles/agnosticd_virtualenv/meta/main.yaml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: Johnathan Kupferer <jkupfere@redhat.com>
+  description: AgnosticD Virtualenv Management
+  company: Red Hat
+  license: BSD
+  min_ansible_version: 2.9
+  galaxy_tags: []
+
+dependencies: []

--- a/ansible/roles/agnosticd_virtualenv/tasks/create.yml
+++ b/ansible/roles/agnosticd_virtualenv/tasks/create.yml
@@ -1,0 +1,25 @@
+---
+- name: Create temporary directory for {{ agnosticd_virtualenv }}
+  tempfile:
+    path: "{{ agnosticd_virtualenv_base_dir }}"
+    prefix: agnosticd-venv-
+    suffix: -tmp
+    state: directory
+  register: r_agnosticd_virtualenv_tmp
+
+- name: Install packages into agnosticd virtualenv tmp
+  pip:
+    name: "{{ agnosticd_virtualenv_requirements }}"
+    virtualenv: "{{ r_agnosticd_virtualenv_tmp.path }}"
+    virtualenv_python: "{{ agnosticd_virtualenv_python }}"
+
+# Ansible has no file move or rename module, so command will have to do
+- name: Move agnosticd virtualenv tmp to {{ agnosticd_virtualenv }}
+  command: mv {{ r_agnosticd_virtualenv_tmp.path }} {{ agnosticd_virtualenv }}
+  # Failed to mv virtualenv most likely means that another agnosticd run created it first
+  failed_when: false
+
+- name: Remove {{ agnosticd_virtualenv }}.tmp if not moved
+  file:
+    path: "{{ r_agnosticd_virtualenv_tmp.path }}"
+    state: absent

--- a/ansible/roles/agnosticd_virtualenv/tasks/main.yml
+++ b/ansible/roles/agnosticd_virtualenv/tasks/main.yml
@@ -1,5 +1,4 @@
-- debug: var=agnosticd_virtualenv_base_dir
-- debug: var=agnosticd_virtualenv
+---
 - name: Create virtualenv {{ agnosticd_virtualenv }}
   when: not agnosticd_virtualenv is directory
   include_tasks: create.yml

--- a/ansible/roles/agnosticd_virtualenv/tasks/main.yml
+++ b/ansible/roles/agnosticd_virtualenv/tasks/main.yml
@@ -1,0 +1,14 @@
+- debug: var=agnosticd_virtualenv_base_dir
+- debug: var=agnosticd_virtualenv
+- name: Create virtualenv {{ agnosticd_virtualenv }}
+  when: not agnosticd_virtualenv is directory
+  include_tasks: create.yml
+
+- name: Touch last-used in {{ agnosticd_virtualenv }}
+  file:
+    path: "{{ agnosticd_virtualenv }}/last-used"
+    state: touch
+
+- name: Set ansible_python_interpreter
+  set_fact:
+    ansible_python_interpreter: "{{ agnosticd_virtualenv }}/bin/python"

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -53,7 +53,7 @@
     when: >-
       agnosticd_virtualenv_requirements is defined
       or
-      (playbook_dir ~ '/configs/' ~ env_type ~ '/requirements.txt') is file
+      (playbook_dir ~ '/configs/' ~ env_type ~ '/python-requirements.txt') is file
 
 # Load galaxy roles of the config
 - import_playbook: install_galaxy_roles.yml

--- a/ansible/setup_runtime.yml
+++ b/ansible/setup_runtime.yml
@@ -42,6 +42,19 @@
 # include global vars from the config
 - import_playbook: include_vars.yml
 
+- name: Setup AgnosticD virtualenv
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  tasks:
+  - include_role:
+      name: agnosticd_virtualenv
+    when: >-
+      agnosticd_virtualenv_requirements is defined
+      or
+      (playbook_dir ~ '/configs/' ~ env_type ~ '/requirements.txt') is file
+
 # Load galaxy roles of the config
 - import_playbook: install_galaxy_roles.yml
   tags: galaxy_roles

--- a/docs/Variables.adoc
+++ b/docs/Variables.adoc
@@ -45,7 +45,7 @@ Default value `pass:[__meta__.callback.url]`.
 
 | `agnosticd_virtualenv_requirements`
 | Python requirements in list format as used by `pip` module `name` argument.
-Default value loaded from lines in `configs/{{ env_type }}/requirements.txt` if it exists.
+Default value loaded from lines in `configs/{{ env_type }}/python-requirements.txt` if it exists.
 
 | `agnosticd_virtualenv_base_dir`
 | Directory in which to create virtualenvs. Default `/tmp`.

--- a/docs/Variables.adoc
+++ b/docs/Variables.adoc
@@ -42,6 +42,18 @@ Default value `pass:[__meta__.callback.token]`.
 | API URL used to callback with information and data collected from `agnosticd_user_info`.
 This is used to integrate AgnosticD with external systems including Babylon and GUID Grabber.
 Default value `pass:[__meta__.callback.url]`.
+
+| `agnosticd_virtualenv_requirements`
+| Python requirements in list format as used by `pip` module `name` argument.
+Default value loaded from `configs/{{ env_type }}/requirements.txt` if it exists.
+
+| `agnosticd_virtualenv_base_dir`
+| Directory in which to create virtualenvs. Default `/tmp`.
+
+| `agnosticd_virtualenv_python`
+| Python interpreter used to create the virtual env.
+Default `{{ ansible_python_interpreter }}`.
+
 |============================
 
 === Other Variables

--- a/docs/Variables.adoc
+++ b/docs/Variables.adoc
@@ -45,7 +45,7 @@ Default value `pass:[__meta__.callback.url]`.
 
 | `agnosticd_virtualenv_requirements`
 | Python requirements in list format as used by `pip` module `name` argument.
-Default value loaded from `configs/{{ env_type }}/requirements.txt` if it exists.
+Default value loaded from lines in `configs/{{ env_type }}/requirements.txt` if it exists.
 
 | `agnosticd_virtualenv_base_dir`
 | Directory in which to create virtualenvs. Default `/tmp`.


### PR DESCRIPTION
##### SUMMARY

Add role `agnosticd_virtualenv` with hook in `setup_runtime.yml` to create a python virtualenv for ansible execution on localhost if configured and not already present.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`setup_runtime.yml` playbook
`agnosticd_virtualenv` role