### PR TITLE
[WIP] Sandbox: add check to ensure the NS entries exist

### DIFF
--- a/ansible/roles-infra/infra-aws-sandbox/tasks/ipa.yml
+++ b/ansible/roles-infra/infra-aws-sandbox/tasks/ipa.yml
@@ -34,6 +34,13 @@
       args:
         stdin: "{{ kerberos_password }}"
 
+    - name: Ensure NS records exist for this sandbox
+      command: host -t ns -W 60 -R 10 {{ account_name }}.{{ ipa_domain }}
+      register: r_host_ns
+      failed_when: >-
+        r_host_ns.rc != 0
+        or "not found" in r_host_ns.stdout
+
     - name: Fetch all NS records for this sandbox
       shell: >-
         host -t ns -W 60 -R 10 {{ account_name }}.{{ ipa_domain }}


### PR DESCRIPTION
When the NS entries are missing in IPA, the error in ansible is not very helpful:


```
TASK [infra-aws-sandbox : Delete all NS records that are not needed anymore] ***
Thursday 12 November 2020  08:01:27 -0500 (0:00:00.190)       0:02:57.012 ***** 
failed: [localhost] (item=found:) => {"_z": "found:", "changed": true, "cmd": ["ipa", "dnsrecord-del", "opentlc.com.", "sandbox89", "--ns-rec=found:."], "delta": "0:00:02.999323", "end": "2020-11-12 08:01:30.772189", "msg": "non-zero return code", "rc": 1, "start": "2020-11-12 08:01:27.772866", "stderr": "ipa: ERROR: NS record does not contain 'found:.'", "stderr_lines": ["ipa: ERROR: NS record does not contain 'found:.'"], "stdout": "", "stdout_lines": []}
```

This Change, if applied, adds a check before fetching the NS entries and make sure they exist.