### PR TITLE
Remove use of __meta__

### DIFF
--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -2,13 +2,8 @@
   gather_facts: false
   hosts: localhost
   vars:
-    # default __meta__ to prevent errors on older ansible versions
-    __meta__:
-      callback: {}
-    agnosticd_callback_url: >-
-      {{ __meta__.callback.url | default('') if __meta__ is defined and __meta__.callback is defined else '' }}
-    agnosticd_callback_token: >-
-      {{ __meta__.callback.token | default('') if __meta__ is defined and __meta__.callback is defined else '' }}
+    agnosticd_callback_url: ''
+    agnosticd_callback_token: ''
   tasks:
     - name: Attempt completion callback
       when:

--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -365,8 +365,7 @@ Resources:
 {% endif %}
 
 {% if sandbox_student_user is defined 
-   and (agnosticv_meta.sandboxed | bool
-   or __meta__.aws_sandboxed | bool) 
+   and sandbox_name is defined
 %}
   StudentUser:
     Type: AWS::IAM::User
@@ -411,8 +410,7 @@ Outputs:
 {% endif %}
 
 {% if sandbox_student_user is defined
-   and (agnosticv_meta.sandboxed | bool
-   or __meta__.aws_sandboxed | bool) 
+   and sandbox_name is defined
 %}
   StudentUser:
     Value:

--- a/docs/Variables.adoc
+++ b/docs/Variables.adoc
@@ -36,12 +36,10 @@ Required variable, but may be set to `none` where not applicable.
 | `agnosticd_callback_token`
 | Authentication Bearer token used to callback with information and data collected from `agnosticd_user_info`.
 This is used to integrate AgnosticD with external systems including Babylon and GUID Grabber.
-Default value `pass:[__meta__.callback.token]`.
 
 | `agnosticd_callback_url`
 | API URL used to callback with information and data collected from `agnosticd_user_info`.
 This is used to integrate AgnosticD with external systems including Babylon and GUID Grabber.
-Default value `pass:[__meta__.callback.url]`.
 |============================
 
 === Other Variables

--- a/training/03_Infrastructure/02_Advanced/03_Understanding_Main_File.adoc
+++ b/training/03_Infrastructure/02_Advanced/03_Understanding_Main_File.adoc
@@ -338,13 +338,8 @@ Which is a file also on `agnosticd/ansible directory`, not on our own config dir
  gather_facts: false
  hosts: localhost
  vars:
-   # default __meta__ to prevent errors on older ansible versions
-   __meta__:
-     callback: {}
-   agnosticd_callback_url: >-
-     {{ __meta__.callback.url | default('') if __meta__ is defined and __meta__.callback is defined else '' }}
-   agnosticd_callback_token: >-
-     {{ __meta__.callback.token | default('') if __meta__ is defined and __meta__.callback is defined else '' }}
+   agnosticd_callback_url: ''
+   agnosticd_callback_token: ''
  tasks:
    - name: Attempt completion callback
      when:


### PR DESCRIPTION
##### SUMMARY

Remove references to `__meta__` in AgnosticD execution. This is an internal variable that defines how AgnosticD execution should be managed by Babylon and is not meant to be referenced within AgnosticD execution.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

* completion callback
* ec2 cloud formation template generation