### PR TITLE
Jkupfere ocp4 workload xray pipeline lab userinfo

### DIFF
--- a/ansible/configs/osp-migration/pre_infra.yml
+++ b/ansible/configs/osp-migration/pre_infra.yml
@@ -12,7 +12,6 @@
     add_host:
       name: "{{ import_host }}"
       ansible_become: true
-      ansible_playbook_python: "{{ import_host_python | default('/opt/virtualenvs/python3/bin/python3') }}"
       ansible_ssh_private_key_file: "{{ migration_key_path | default(omit) }}"
       ansible_user: "opentlc-mgr"
       bastion: "{{ import_host }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/defaults/main.yaml
@@ -40,3 +40,7 @@ ocp4_workload_bookbag_user_pvc_size: 1Gi
 
 ocp4_workload_bookbag_user_custom_workshop_vars: false
 ocp4_workload_bookbag_user_custom_workshop_vars_data: ''
+
+# Multi-user workloads should set ocp4_workload_bookbag_user_userinfo_user
+ocp4_workload_bookbag_user_userinfo_enable: true
+#ocp4_workload_bookbag_user_userinfo_user:

--- a/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_bookbag_user/tasks/workload.yaml
@@ -86,10 +86,13 @@
   failed_when: r_route.resources | length != 1
 
 - name: Set agnosticd_user_info for Bookbag
+  when:
+  - ocp4_workload_bookbag_user_userinfo_enable | bool
   agnosticd_user_info:
     msg: "Your lab instructions are at: {{ _ocp4_workload_bookbag_user_url }}"
+    user: "{{ ocp4_workload_bookbag_user_userinfo_user | default(omit) }}"
     data:
-      ocp4_workload_bookbag_user_url: "{{ _ocp4_workload_bookbag_user_url }}"
+      bookbag_url: "{{ _ocp4_workload_bookbag_user_url }}"
   vars:
     _route: "{{ r_route.resources[0] }}"
     _ocp4_workload_bookbag_user_url: >-

--- a/ansible/roles_ocp_workloads/ocp4_workload_xray_pipeline_lab/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_xray_pipeline_lab/tasks/per_user_workload.yaml
@@ -203,6 +203,7 @@
     ocp4_workload_bookbag_user_role: admin
     ocp4_workload_bookbag_user_auth_username: "*"
     ocp4_workload_bookbag_user_create_pvc: false
+    ocp4_workload_bookbag_user_userinfo_user: "{{ t_user }}"
     ocp4_workload_bookbag_user_custom_workshop_vars:
       guid: "{{ t_user }}"
       web_console_url: "https://{{ r_console_route.resources[0].spec.host }}"


### PR DESCRIPTION
##### SUMMARY

Add controls to ocp4_workload_bookbag_user to set user in `agnosticd_user_info` call and use it in ocp4_workload_xray_pipeline_lab.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_xray_pipeline_lab
Role ocp4_workload_bookbag_user