### PR TITLE
Disable userinfo for first user in ocp4_workload_xray_pipeline_lab

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_xray_pipeline_lab/tasks/per_user_workload.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_xray_pipeline_lab/tasks/per_user_workload.yaml
@@ -203,6 +203,7 @@
     ocp4_workload_bookbag_user_role: admin
     ocp4_workload_bookbag_user_auth_username: "*"
     ocp4_workload_bookbag_user_create_pvc: false
+    ocp4_workload_bookbag_user_userinfo_enable: "{{ t_user_num | int > 1 }}"
     ocp4_workload_bookbag_user_userinfo_user: "{{ t_user }}"
     ocp4_workload_bookbag_user_custom_workshop_vars:
       guid: "{{ t_user }}"


### PR DESCRIPTION
##### SUMMARY

Set `ocp4_workload_bookbag_user_userinfo_enable` to fals for first user in `ocp4_workload_xray_pipeline_lab` to prevent it from being assigned to lab users.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_xray_pipeline_lab