### PR TITLE
empty-config: do not gather facts

### DIFF
--- a/ansible/configs/test-empty-config/destroy_env.yml
+++ b/ansible/configs/test-empty-config/destroy_env.yml
@@ -2,6 +2,7 @@
 - name: Destroy playbook
   hosts: localhost
   connection: local
+  gather_facts: false
   become: false
   tasks:
 


### PR DESCRIPTION
Gather ansible facts is unecessary in this play.
