### PR TITLE
Move ansible-tower-implementation to t3 v t2

### DIFF
--- a/ansible/configs/ansible-tower-implementation/default_vars_ec2.yml
+++ b/ansible/configs/ansible-tower-implementation/default_vars_ec2.yml
@@ -17,8 +17,8 @@ chomped_zone_internal_dns: "{{guid}}.internal"
 
 ## Environment Sizing
 # Instance Type
-__instance_type: "t2.medium" 
-tower_instance_type: "t2.large"
+__instance_type: "t3.medium" 
+tower_instance_type: "t3.large"
 # Image 
 __image: RHEL77GOLD
 


### PR DESCRIPTION

##### SUMMARY

ansible-tower-implementation uses the increasingly scarce t2s on AWS causing failures
This moves them to t3

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

config ansible-tower-implementation 

##### ADDITIONAL INFORMATION
