### PR TITLE
Added more retries - and ignore_errors to kn download

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_serverless/tasks/workload.yml
@@ -82,8 +82,9 @@
     kind: ConsoleCLIDownload
     name: kn
   register: r_kn_cli_download
-  retries: 12
+  retries: 20
   delay: 5
+  ignore_errors: true
   until:
   - r_kn_cli_download.resources is defined
   - r_kn_cli_download.resources | length > 0


### PR DESCRIPTION
##### SUMMARY

Add more retries - and then ignore_errors: true for the kn download in the server less workload.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_serverless