### PR TITLE
Removing catalog snapshot for the Grafana operator to avoid further i…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_grafana/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_grafana/defaults/main.yml
@@ -26,15 +26,6 @@ ocp4_workload_cnd_monitoring_grafana_starting_csv: ""
 # Use a catalog snapshot
 ocp4_workload_cnd_monitoring_grafana_use_catalog_snapshot: false
 
-# Catalog Source Name when using a catalog snapshot. This should be unique
-# in the cluster to avoid clashes
-ocp4_workload_cnd_monitoring_grafana_catalogsource_name: community-operators-snapshot-monitoring_grafana
-
-# Catalog snapshot image
-ocp4_workload_cnd_monitoring_grafana_catalog_snapshot_image: quay.io/gpte-devops-automation/olm_snapshot_community_catalog
-
-# Catalog snapshot image tag
-ocp4_workload_cnd_monitoring_grafana_catalog_snapshot_image_tag: "v4.6_2021_06_01"
 
 # for creating users in cnd_monitoring
 ocp4_workload_cnd_monitoring_grafana_create_users: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_grafana/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cnd_monitoring_grafana/tasks/workload.yml
@@ -13,13 +13,10 @@
     install_operator_manage_namespaces:
     - "{{ ocp4_workload_authentication_htpasswd_user_base }}{{ project_loop_var[0] }}-{{ project_loop_var[1] }}"
     install_operator_channel: "{{ ocp4_workload_cnd_monitoring_grafana_operator_channel }}"
-    install_operator_catalog: ""
+    install_operator_catalog: "community-operators"
     install_operator_automatic_install_plan_approval: "{{ ocp4_workload_cnd_monitoring_grafana_automatic_install_plan_approval | default(true) }}"
     install_operator_starting_csv: "{{ ocp4_workload_cnd_monitoring_grafana_starting_csv }}"
     install_operator_catalogsource_setup: "{{ ocp4_workload_cnd_monitoring_grafana_use_catalog_snapshot }}"
-    install_operator_catalogsource_name: "{{ ocp4_workload_cnd_monitoring_grafana_catalogsource_name }}"
-    install_operator_catalogsource_image: "{{ ocp4_workload_cnd_monitoring_grafana_catalog_snapshot_image }}"
-    install_operator_catalogsource_image_tag: "{{ ocp4_workload_cnd_monitoring_grafana_catalog_snapshot_image_tag }}"
   loop: "{{ users | product(ocp4_workload_cnd_monitoring_grafana_namespace_suffixes) | list }}"
   loop_control:
     loop_var: project_loop_var


### PR DESCRIPTION
SUMMARY:

Changing the Grafana Operator creation to not use the catalog snapshot. From time to time, the image changes and it's creating issues avoiding the catalog to be created.

Cause:
It's preventing the Adv. CND catalog to be created. For community operators we'll not be using the catalog snapshot.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
ilt-adv-cloud-native-development-prod