### PR TITLE
Inject cloud_tags to equinix device tags

### DIFF
--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -1,66 +1,174 @@
 #!/usr/bin/env python
 from ansible.errors import AnsibleFilterError
 from ansible.utils.display import Display
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import string_types, integer_types
 
 display = Display()
 
-def to_equinix_metal_tags(tags):
+def ec2_tags_to_dict(tags):
     '''Filter to convert agnosticd tags to Equinix Tags format'''
+
+    function_name="ec2_tags_to_dict"
+
     if not isinstance(tags, list):
         raise AnsibleFilterError(
-            '''Invalid type used with to_equinix_metal_tags filter,
-            expect a list, got %s''' %(type(tags)))
+            '''Invalid type used with %s filter,
+            expect a list, got %s''' %(function_name, type(tags)))
+
+    converted = {}
+    try:
+        for tag in tags:
+            keynocase = 'key'
+            if 'Key' in tag:
+                keynocase = 'Key'
+
+            valuenocase = 'value'
+            if 'Value' in tag:
+                valuenocase = 'Value'
+
+            if keynocase not in tag:
+                raise AnsibleFilterError(
+                    '%s: Invalid input, key keys expected in elements.'
+                    %(function_name)
+                )
+
+            if valuenocase not in tag:
+                raise AnsibleFilterError(
+                    '%s: Invalid input, value keys expected in elements.'
+                    %(function_name)
+                )
+
+            if not isinstance(tag[keynocase], string_types) or tag[keynocase] == "":
+                raise AnsibleFilterError(
+                    '%s: Invalid input, key must be a non-empty string.' %(function_name)
+                )
+            if not isinstance(tag[valuenocase], string_types) or tag[valuenocase] == "":
+                raise AnsibleFilterError(
+                    '%s: Invalid input, value must be a non-empty string.'
+                    %(function_name)
+                )
+
+            converted[tag[keynocase]] = tag[valuenocase]
+    except Exception as e:
+        raise AnsibleFilterError(e)
+
+    return converted
+
+
+def dict_to_equinix_metal_tags(tags):
+    '''Filter to convert dictionary to Equinix Tags format'''
+
+    function_name = "dict_to_equinix_metal_tags"
+
+    if not isinstance(tags, dict):
+        raise AnsibleFilterError(
+            '''Invalid type used with %s filter,
+            expect a dict, got %s''' %(function_name, type(tags)))
+
+    converted = []
+
+    try:
+        for key in tags:
+            if isinstance(tags[key], integer_types):
+                tags[key]=str(tags[key])
+
+            if not isinstance(key, string_types):
+                raise AnsibleFilterError(
+                    '%s: Invalid input, expect keys to be string, got key of type %s'
+                    %(function_name, type(key))
+                )
+            if not isinstance(tags[key], string_types):
+                raise AnsibleFilterError(
+                    '%s: Invalid input, expect dict of string, got value of type %s'
+                    %(function_name, type(tags[key]))
+                )
+
+            converted.append('%s=%s' %(key, tags[key]))
+
+    except Exception as e:
+        raise AnsibleFilterError(e)
+
+    return converted
+
+def ec2_tags_to_equinix_metal_tags(tags):
+    '''Filter to convert agnosticd tags to Equinix Tags format'''
+    function_name = "ec2_tags_to_equinix_metal_tags"
+
+    if not isinstance(tags, list):
+        raise AnsibleFilterError(
+            '''Invalid type used with %s filter,
+            expect a list, got %s''' %(function_name, type(tags)))
 
     converted = []
     try:
         for tag in tags:
             if not isinstance(tag, dict):
                 raise AnsibleFilterError(
-                    'Invalid input for to_equinix_metal_tag, expect list of dict, got list of %s'
-                    %(type(tag))
-                )
-            if 'key' not in tag or 'value' not in tag:
-                raise AnsibleFilterError(
-                    'Invalid input for to_equinix_metal_tag, key/value keys expected in elements.'
-                )
-            if not isinstance(tag['key'], string_types) or tag['key'] == "":
-                raise AnsibleFilterError(
-                    'Invalid input for to_equinix_metal_tag, key must be a non-empty string.'
-                )
-            if not isinstance(tag['value'], string_types) or tag['value'] == "":
-                raise AnsibleFilterError(
-                    'Invalid input for to_equinix_metal_tag, value must be a non-empty string.'
+                    '%s: Invalid input, expect list of dict, got list of %s'
+                    %(function_name, type(tag))
                 )
 
-            converted.append('%s=%s' %(tag['key'], tag['value']))
+            keynocase = 'key'
+            if 'Key' in tag:
+                keynocase = 'Key'
+
+            valuenocase = 'value'
+            if 'Value' in tag:
+                valuenocase = 'Value'
+
+            if keynocase not in tag:
+                raise AnsibleFilterError(
+                    '%s: Invalid input, key keys expected in elements.'
+                    %(function_name)
+                )
+
+            if valuenocase not in tag:
+                raise AnsibleFilterError(
+                    '%s: Invalid input, value keys expected in elements.'
+                    %(function_name)
+                )
+
+            if not isinstance(tag[keynocase], string_types) or tag[keynocase] == "":
+                raise AnsibleFilterError(
+                    '%s: Invalid input, key must be a non-empty string.'
+                    %(function_name)
+                )
+            if not isinstance(tag[valuenocase], string_types) or tag[valuenocase] == "":
+                raise AnsibleFilterError(
+                    '%s: Invalid input, value must be a non-empty string.'
+                    %(function_name)
+                )
+
+            converted.append('%s=%s' %(tag[keynocase], tag[valuenocase]))
     except Exception as e:
         raise AnsibleFilterError(e)
 
     return converted
 
-def from_equinix_metal_tags(tags):
+def equinix_metal_tags_to_dict(tags):
     '''Convert Equinix Tags to a dict'''
+
+    function_name = "equinix_metal_tags_to_dict"
 
     if not isinstance(tags, list):
         raise AnsibleFilterError(
-            '''Invalid type used with from_equinix_metal_tags filter,
-            expect a list, got %s''' %(type(tags)))
+            '''Invalid type used with %s filter,
+            expect a list, got %s''' %(function_name, type(tags)))
 
     converted = dict()
     try:
         for tag in tags:
             if not isinstance(tag, string_types):
                 raise AnsibleFilterError(
-                    '''Invalid type used with from_equinix_metal_tags filter,
-                    expect a string, got %s''' %(type(tag)))
+                    '''Invalid type used with %s filter,
+                    expect a string, got %s''' %(function_name, type(tag)))
 
             if '=' in tag:
                 splitted = tag.split("=")
                 if splitted[0] == "":
                     raise AnsibleFilterError(
-                        'Invalid type used with from_equinix_metal_tags filter, '
-                        'key is empty string.'
+                        'Invalid type used with %s filter, key is empty string.'
+                        %(function_name)
                     )
                 converted[splitted[0]] = splitted[1]
     except Exception as e:
@@ -73,6 +181,8 @@ class FilterModule(object):
 
     def filters(self):
         return {
-            'to_equinix_metal_tags': to_equinix_metal_tags,
-            'from_equinix_metal_tags': from_equinix_metal_tags,
+            'ec2_tags_to_equinix_metal_tags': ec2_tags_to_equinix_metal_tags,
+            'ec2_tags_to_dict': ec2_tags_to_dict,
+            'dict_to_equinix_metal_tags': dict_to_equinix_metal_tags,
+            'equinix_metal_tags_to_dict': equinix_metal_tags_to_dict,
         }

--- a/ansible/filter_plugins/tests/test_core.py
+++ b/ansible/filter_plugins/tests/test_core.py
@@ -9,7 +9,7 @@ import core
 
 
 
-def test_to_equinix_metal_tags():
+def test_ec2_tags_to_equinix_metal_tags():
     testcases = [
         [
             [
@@ -28,13 +28,46 @@ def test_to_equinix_metal_tags():
             ],
         ],
         [
+            [
+                {
+                    "Key":"AnsibleGroup",
+                    "Value":"bastions",
+                },
+            ],
+            [
+                "AnsibleGroup=bastions",
+            ],
+        ],
+        [
+            [
+                {
+                    "Key":"AnsibleGroup",
+                    "value":"bastions",
+                },
+            ],
+            [
+                "AnsibleGroup=bastions",
+            ],
+        ],
+        [
+            [
+                {
+                    "key":"AnsibleGroup",
+                    "Value":"bastions",
+                },
+            ],
+            [
+                "AnsibleGroup=bastions",
+            ],
+        ],
+        [
             [],
             [],
         ]
     ]
 
     for tc in testcases:
-        assert(core.to_equinix_metal_tags(tc[0]) == tc[1])
+        assert(core.ec2_tags_to_equinix_metal_tags(tc[0]) == tc[1])
 
     error_testcases = [
         [
@@ -71,9 +104,9 @@ def test_to_equinix_metal_tags():
 
     for tc in error_testcases:
         with pytest.raises(AnsibleFilterError):
-            core.to_equinix_metal_tags(tc)
+            core.ec2_tags_to_equinix_metal_tags(tc)
 
-def test_from_equinix_metal_tags():
+def test_equinix_metal_tags_to_dict():
     testcases = [
         [
             [
@@ -112,7 +145,7 @@ def test_from_equinix_metal_tags():
     ]
 
     for tc in testcases:
-        assert(core.from_equinix_metal_tags(tc[0]) == tc[1])
+        assert(core.equinix_metal_tags_to_dict(tc[0]) == tc[1])
 
     error_testcases = [
         [
@@ -130,4 +163,138 @@ def test_from_equinix_metal_tags():
 
     for tc in error_testcases:
         with pytest.raises(AnsibleFilterError):
-            core.from_equinix_metal_tags(tc)
+            core.equinix_metal_tags_to_dict(tc)
+
+def test_ec2_tags_to_dict():
+    testcases = [
+        [
+            [
+                {
+                    "key":"AnsibleGroup",
+                    "value":"bastions",
+                },
+                {
+                    "key":"ostype",
+                    "value":"linux",
+                }
+            ],
+            {
+                "AnsibleGroup":"bastions",
+                "ostype":"linux"
+            },
+        ],
+        [
+            [
+                {
+                    "Key":"AnsibleGroup",
+                    "Value":"bastions",
+                },
+            ],
+            {
+                "AnsibleGroup":"bastions",
+            },
+        ],
+        [
+            [
+                {
+                    "Key":"AnsibleGroup",
+                    "value":"bastions",
+                },
+            ],
+            {
+                "AnsibleGroup":"bastions",
+            },
+        ],
+        [
+            [
+                {
+                    "key":"AnsibleGroup",
+                    "Value":"bastions",
+                },
+            ],
+            {
+                "AnsibleGroup":"bastions",
+            },
+        ],
+        [
+            [],
+            {},
+        ]
+    ]
+
+    for tc in testcases:
+        assert(core.ec2_tags_to_dict(tc[0]) == tc[1])
+
+    error_testcases = [
+        [
+            {
+                "key":"key1",
+                "value":"value1",
+            },
+            {
+                "key":"key2",
+            }
+        ],
+        [
+            {
+                "key":"key1",
+            },
+        ],
+        [
+            {
+                "key":"",
+                "value":"value",
+            },
+        ],
+        [
+            {
+                "key":"key",
+                "value":"",
+            },
+        ],
+        [1,2,3],
+        "",
+        None,
+        {},
+    ]
+
+    for tc in error_testcases:
+        with pytest.raises(AnsibleFilterError):
+            core.ec2_tags_to_dict(tc)
+
+def test_dict_to_equinix_metal_tags():
+    testcases = [
+        [
+            {
+                    "AnsibleGroup":"bastions",
+                    "ostype":"linux",
+                    "number": 2,
+            },
+            [
+                "AnsibleGroup=bastions",
+                "ostype=linux",
+                "number=2"
+            ],
+        ],
+        [
+            {},
+            [],
+        ]
+    ]
+
+    for tc in testcases:
+        assert(core.dict_to_equinix_metal_tags(tc[0]) == tc[1])
+
+    error_testcases = [
+        {"key": {}},
+        {2: "value"},
+        {"key": []},
+        [1,2,3],
+        "",
+        None,
+        [],
+    ]
+
+    for tc in error_testcases:
+        with pytest.raises(AnsibleFilterError):
+            core.dict_to_equinix_metal_tags(tc)

--- a/ansible/roles-infra/infra-cloud-tags/defaults/main.yaml
+++ b/ansible/roles-infra/infra-cloud-tags/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 default_cloud_tags:
-  Stack: "project {{ project_tag }}"
+  Stack: "project {{ project_tag | default(env_type+'-'+guid) }}"
   owner: "{{ email | default(user) | default('unknown') }}"
   env_type: "{{ env_type }}"
   guid: "{{ guid }}"

--- a/ansible/roles-infra/infra-equinix-metal-create-inventory/tasks/main.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-create-inventory/tasks/main.yaml
@@ -38,8 +38,8 @@
     private_ip_address: "{{ item.private_ipv4 }}"
     public_ip_address: "{{ item.public_ipv4 }}"
     public_ip6_address: "{{ item.public_ipv6 }}"
-    groups: "{{ (item.tags | from_equinix_metal_tags).AnsibleGroup }}"
+    groups: "{{ (item.tags | equinix_metal_tags_to_dict).AnsibleGroup }}"
     bastion: "{{ local_bastion | default('') }}"
     isolated: >-
-      {{ (item.tags | from_equinix_metal_tags).isolated
+      {{ (item.tags | equinix_metal_tags_to_dict).isolated
       | default(false) }}

--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/create_instances.yaml
@@ -1,4 +1,8 @@
 ---
+- include_role:
+    name: infra-cloud-tags
+  when: cloud_tags_final is not defined
+
 # https://metal.equinix.com/developers/api/devices/
 - name: Create Devices
   register: r_equinix_metal_devices
@@ -20,7 +24,10 @@
     operating_system: "{{ _instance.os | default(equinix_metal_default_os) }}"
     plan: "{{ _instance.type }}"
     facility: "{{ _instance.facility }}"
-    tags: "{{ _instance.tags | to_equinix_metal_tags }}"
+    tags: >-
+      {{ cloud_tags_final
+      | combine(_instance.tags | ec2_tags_to_dict)
+      | dict_to_equinix_metal_tags }}
     user_data: |
       #cloud-config
       ssh_authorized_keys:

--- a/ansible/roles-infra/infra-equinix-metal-resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra-equinix-metal-resources/tasks/main.yaml
@@ -1,4 +1,5 @@
 ---
+
 - when: ACTION == 'provision'
   block:
     - include_tasks: create_project.yaml


### PR DESCRIPTION
GPTEINFRA-1858

Same as for the other cloud-providers, inject the tags defined in dict
cloud_tags.

In order to do that, i created 2 more filters:

* ec2_tags_to_dict
* dict_to_equinix_metal_tags

and the unit tests associated with those 2 new filters.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

- New config Pull Request