### PR TITLE
adding variable ignore errors when installing an operator.

### DIFF
--- a/ansible/roles/install_operator/defaults/main.yml
+++ b/ansible/roles/install_operator/defaults/main.yml
@@ -87,3 +87,8 @@ install_operator_catalogsource_image_tag: "v4.7_2021_04_12"
 # install_operator_catalogsource_secrets:
 # - my_pull_secret_name
 install_operator_catalogsource_pullsecrets: []
+
+# If issues with the operator, when creating the CSV, the playbook will continue executing.
+# Accepted values: true , false
+# Default value: false
+install_operator_install_csv_ignore_error: false

--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -134,3 +134,4 @@
   - r_csv.resources[0].status.phase is defined
   - r_csv.resources[0].status.phase | length > 0
   - r_csv.resources[0].status.phase == "Succeeded"
+  ignore_errors: "{{ install_operator_install_csv_ignore_error }}"

--- a/ansible/roles/install_operator/tasks/main.yml
+++ b/ansible/roles/install_operator/tasks/main.yml
@@ -5,6 +5,7 @@
   when: install_operator_action == "install"
   include_tasks:
     file: install.yml
+  ignore_errors: "{{ install_operator_install_csv_ignore_error }}"
 
 - name: Remove the operator
   when: install_operator_action == "remove"


### PR DESCRIPTION
SUMMARY

Adding a variable in the install_operator role to define if the playbook should finish its execution when encounter issues while creating an operator. As it is now, if there are issues encountered while creating an operator, the catalog will not be created.  We want to have control over this behaviour.  By default, the behaviour will continue as it's now, however, this new flag adds the availability to override this behaviour and avoid catalogs not being created.

- Feature Pull Request

ADDITIONAL INFORMATION
The ignore_error flag was included in the task: "Wait until CSV is Installed".
 For. example : Adv. CND Catalog which as 20 users and deploys more than 60 operators, in this case I want the catalog creation to continue if Prometheus fails, and the instructor can install/fix the operators missing.

ROLE: install_operator 

COMPONENT NAME:
This could affect all the operators using the install_operator role. 
This component will be directly affected in another PR (will override the current behaviour)
ilt-adv-cloud-native-development-prod
