### PR TITLE
Modify ansible-advanced-v2

### DIFF
--- a/ansible/configs/ansible-advanced-v2/default_vars_osp.yml
+++ b/ansible/configs/ansible-advanced-v2/default_vars_osp.yml
@@ -103,7 +103,13 @@ security_groups:
         protocol: tcp
         cidr: "0.0.0.0/0"
         rule_type: Ingress
-
+      - name: WebSGehaproxyPort
+        description: "Allow haproxy port"
+        from_port: 1936
+        to_port: 1936
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
 
   - name: HostSG
     rules:
@@ -120,6 +126,23 @@ security_groups:
         to_port: 65535
         protocol: udp
         from_group: HostSG
+        rule_type: Ingress
+
+  - name: UnregisterPortSG
+    rules:
+      - name: UrpSGTCP
+        description: "Open following unregister tcp port for all"
+        from_port: 49201
+        to_port: 49220
+        protocol: tcp
+        cidr: "0.0.0.0/0"
+        rule_type: Ingress
+      - name: UrpSGUDP
+        description: "Open following unregister udp port for all"
+        from_port: 49201
+        to_port: 49220
+        protocol: udp
+        cidr: "0.0.0.0/0"
         rule_type: Ingress
 
 # Default instance type
@@ -155,6 +178,7 @@ instances:
       - BastionSG
       - HostSG
       - WebSG
+      - UnregisterPortSG
     tags:
       - key: "AnsibleGroup"
         value: "bastions,{{ bastion_group_name | default('controls') }}"

--- a/ansible/configs/ansible-advanced-v2/post_software.yml
+++ b/ansible/configs/ansible-advanced-v2/post_software.yml
@@ -68,13 +68,10 @@
             opentlc_user_email: "{{ email }}"
             ssh_command: "ssh {{__control_user}}@{{ __control_node }}.{{ guid }}.{{ __subdomain }}"
             ssh_password: "{{ __control_password }}" 
-        dest: "{{ item }}"
+        dest: "/home/{{control_user_name}}/{{ control_user_resource_dir_name }}/access_details.yml"
         mode: 0644
         owner: root
         group: root
-      loop:
-        - "/home/{{control_user_name}}/{{ control_user_resource_dir_name }}/access_details.yml"
-        - "{{ lab_mgr_dir }}/vars/access_details.yml"
       delegate_to: "{{ groups['bastions'][0] }}"
 
     - name: Add variables to /etc/skel/.bashrc and ~{{ control_user_name }}/.bashrc
@@ -87,6 +84,9 @@
           export SUBDOMAIN={{ __subdomain }}
           export OPENTLC_USER_ID={{ __control_user }}
           export OPENTLC_USER_EMAIL={{ email }}
+          export LAB_MGR_DIR={{ lab_mgr_dir }}
+          export CLOUD_PROVIDER={{ cloud_provider }}
+          export INTERNAL_DOMAIN=example.com
       loop:
         - "/etc/skel/.bash_profile"
         - "~{{ control_user_name }}/.bash_profile"
@@ -107,10 +107,15 @@
         - "To Access Gitlab UI via browser:"
         - "Gitlab UI URL: https://{{ __gitlab_server }}.{{ guid }}.{{ __subdomain }}:8929"
         - ""
+        - "To Access Haproxy Statistics"
+        - "Haproxy WebUI: https://{{ __control_node }}.{{ guid }}.{{ __subdomain }}:1936/haproxy?stats"
+        - "Haproxy username: {{ __satellite_user }}"
+        - "Haproxy Password: {{ __satellite_password }}"
+        - ""
         - "To Access Control node via SSH:"
         - "ssh {{ __control_user }}@{{ __control_node }}.{{ guid }}.{{ __subdomain }}"
         - "Enter ssh password when prompted: {{ __control_password }}"
-        
+
     - name: Save user data
       agnosticd_user_info:
         data:


### PR DESCRIPTION
##### SUMMARY
Following are the changes made
1: Open tcp port 1936/tcp for haproxy statistics.
2: Created new Security group named UnregisteredPortSG.
3: Open Unregistered port range from 49200 to 49220 to create custom pods using lab-manager.
4: Added few environment variables required to run lab-manager.
5: Added Haproxy statistics url and access details.
6: Removed access details which were getting stored/saved in /srv/lab-manager/vars directory. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible advanced v2