### PR TITLE
Fix command args warn deprecated

### DIFF
--- a/ansible/roles/set-repositories/tasks/satellite-repos.yml
+++ b/ansible/roles/set-repositories/tasks/satellite-repos.yml
@@ -210,8 +210,6 @@
 
 - name: clean repositories
   command: "yum clean all"
-  args:
-    warn: false
   tags:
     - configure_repos
     - run_yum_repolist


### PR DESCRIPTION
##### SUMMARY

Removes the usage of warn args from the command module. From Ansibile docs:

_"This feature is deprecated and will be removed in 2.14. As of version 2.11, this option is now disabled by default."_

Fixes the ocp4-cluster deployment when running later versions of Ansible, for example, when running with the ee-multicloud:v0.0.6 execution environment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Role **set-repositores**.
