### PR TITLE
Extend Single AZ mode to bastion host

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
@@ -58,6 +58,6 @@
     - r_aws_type_offerings.rc == 0
     # Do not try to pick the AZ when the config uses several Subnets
     - __all_subnets | length <= 1
-    - agnosticd_aws_capacity_reservation_enable == false or 
-      aws_availability_zone | length <= 1 
+    - agnosticd_aws_capacity_reservation_enable == false or
+      aws_availability_zone | length <= 1
   include_tasks: locate_availability_zones_tasks.yml

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
@@ -58,4 +58,6 @@
     - r_aws_type_offerings.rc == 0
     # Do not try to pick the AZ when the config uses several Subnets
     - __all_subnets | length <= 1
+    - agnosticd_aws_capacity_reservation_enable == true
+    - aws_availability_zone | length == 0
   include_tasks: locate_availability_zones_tasks.yml

--- a/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/tasks/locate_availability_zones.yml
@@ -58,6 +58,6 @@
     - r_aws_type_offerings.rc == 0
     # Do not try to pick the AZ when the config uses several Subnets
     - __all_subnets | length <= 1
-    - agnosticd_aws_capacity_reservation_enable == true
-    - aws_availability_zone | length == 0
+    - agnosticd_aws_capacity_reservation_enable == false or 
+      aws_availability_zone | length <= 1 
   include_tasks: locate_availability_zones_tasks.yml


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This PR extends the "AWS Capacity Reservation in Single AZ" functionality to Cloudformation manifest generation, ensuring that all hosts including bastion are deployed into the same AZ.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
infra-ec2-template-generate 

##### ADDITIONAL INFORMATION
N/A
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->

