### PR TITLE
Revert "add community.aws collection to reqs"

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -20,5 +20,3 @@ collections:
   version: 2.7.0
 - name: google.cloud
   version: 1.0.2
-- name: community.aws
-  version: 4.1.1


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#5887

adding the aws community module causes ocp4-cluster fail