### PR TITLE
Update workload.yml adding more retries to central availability wait

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
@@ -107,7 +107,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 15
+  retries: 30
   delay: 20
 
 # ACS Secured Cluster Installation


### PR DESCRIPTION
rhjcd-patch-Update workload.yml adding more retries to central availability wait

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
