### PR TITLE
adding new sap_operations community collection in sap-hana

### DIFF
--- a/ansible/configs/sap-hana/requirements.yml
+++ b/ansible/configs/sap-hana/requirements.yml
@@ -4,8 +4,8 @@ roles:
   name: infra-ansible
   version: v2.0.8
 
-- name: redhat_sap.sap_rhsm
-  version: v1.1.2
+#- name: redhat_sap.sap_rhsm
+#  version: v1.1.2
 
 collections:
 - name: community.general
@@ -14,3 +14,5 @@ collections:
   version: 1.3.0
 - name: openstack.cloud
   version: 1.7.2
+- name: community.sap_operations
+  version: 0.9.0


### PR DESCRIPTION
SAP E2E failed due to missing ansible galaxy role

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
