### PR TITLE
Do not pull Ansible Galaxy dependencies

### DIFF
--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -26,6 +26,7 @@
     __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
   command: >-
     ansible-galaxy collection install
+    --no-deps
     -r "{{ tempfile_1.path }}"
     -p "{{ __collections_path | quote }}"
     --force-with-deps


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

We recently had a case where because of ansible galaxy collections listed as dependencies inside a collection, agnosticd replaced the collections already installed inside the Execution Environment (EE) image.

For example, if you add `ansible.workshops`  in `ansible/config/.../requirements.yml`, you get `amazon.aws` version **3.1.1** instead of version 6.x that is normally included with the EE. 

This occurs because the `ansible.workshops` collection specifies version 3.1.1 in its `galaxy.yml` file, as seen here: https://github.com/ansible/workshops/blob/devel/galaxy.yml#L56

That by-pass our process that ensures collections already installed in the EE are not overridden.

This is going to cause unpredictable issues and will be **very** hard to troubleshoot when it happens because the symptoms could be anything.
I think we want the list of dependencies to be exhaustive in the requirements.yml of the agnosticd config/.
I suggest we don't pull dependencies automatically.

This change will potentially break  some deployment and will require to fix the `requirements.yml` and explicitly add the required galaxy collections.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
agnosticd core

