### PR TITLE
Remove entrypoints labels from services

### DIFF
--- a/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
+++ b/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
@@ -30,7 +30,6 @@ showroom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.showroom.loadbalancer.server.port=80"
-    - "traefik.http.routers.entrypoints=showroomsecure"
     - "traefik.http.routers.showroom.tls.certresolver=le"
     - "traefik.http.routers.showroom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/showroom`)"
     - "traefik.http.routers.showroom.middlewares=showroom-stripprefix"

--- a/ansible/roles/showroom/templates/service_codeserver/service_codeserver.j2
+++ b/ansible/roles/showroom/templates/service_codeserver/service_codeserver.j2
@@ -7,7 +7,6 @@ codeserver:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.vscode.loadbalancer.server.port=8080"
-    - "traefik.http.routers.vscodeentrypoints=terminalsecure"
     - "traefik.http.routers.vscode.tls.certresolver=le"
     - "traefik.http.routers.vscode.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/codeserver`)"
     - "traefik.http.routers.vscode.middlewares=terminal-stripprefix"

--- a/ansible/roles/showroom/templates/service_double_tty/service_double_tty.j2
+++ b/ansible/roles/showroom/templates/service_double_tty/service_double_tty.j2
@@ -25,7 +25,6 @@ tty-top:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-top.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-topentrypoints=terminalsecure"
     - "traefik.http.routers.tty-top.tls.certresolver=le"
     - "traefik.http.routers.tty-top.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-top`)"
     - "traefik.http.routers.tty-top.middlewares=terminal-stripprefix"
@@ -60,7 +59,6 @@ tty-bottom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-bottom.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-bottomentrypoints=terminalsecure"
     - "traefik.http.routers.tty-bottom.tls.certresolver=le"
     - "traefik.http.routers.tty-bottom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-bottom`)"
     - "traefik.http.routers.tty-bottom.middlewares=terminal-stripprefix"

--- a/ansible/roles/showroom/templates/service_second_terminal/service_second_terminal.j2
+++ b/ansible/roles/showroom/templates/service_second_terminal/service_second_terminal.j2
@@ -13,7 +13,6 @@ terminal-02:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.terminal2.loadbalancer.server.port=3001"
-    - "traefik.http.routers.terminalentrypoints2=terminalsecure2"
     - "traefik.http.routers.terminal2.tls.certresolver=le"
     - "traefik.http.routers.terminal2.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty2`)"
     - "traefik.http.routers.terminal2.middlewares=terminal-stripprefix"

--- a/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
+++ b/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
@@ -25,7 +25,6 @@ terminal-01:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.terminal.loadbalancer.server.port=3000"
-    - "traefik.http.routers.terminalentrypoints=terminalsecure"
     - "traefik.http.routers.terminal.tls.certresolver=le"
     - "traefik.http.routers.terminal.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/wetty`)"
     - "traefik.http.routers.terminal.middlewares=terminal-stripprefix"

--- a/ansible/roles/showroom/templates/service_tty1/service_tty1.j2
+++ b/ansible/roles/showroom/templates/service_tty1/service_tty1.j2
@@ -25,7 +25,6 @@ tty1:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty1.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty1entrypoints=terminalsecure"
     - "traefik.http.routers.tty1.tls.certresolver=le"
     - "traefik.http.routers.tty1.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty1`)"
     - "traefik.http.routers.tty1.middlewares=terminal-stripprefix"

--- a/ansible/roles/showroom/templates/service_tty2/service_tty2.j2
+++ b/ansible/roles/showroom/templates/service_tty2/service_tty2.j2
@@ -25,7 +25,6 @@ tty2:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty2.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty2entrypoints=terminalsecure"
     - "traefik.http.routers.tty2.tls.certresolver=le"
     - "traefik.http.routers.tty2.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty2`)"
     - "traefik.http.routers.tty2.middlewares=terminal-stripprefix"


### PR DESCRIPTION
##### SUMMARY

Minor cleanup for the service's labels to remove entrypoints definitions since they're not used and some of them misprinted.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Showroom
