### PR TITLE
Add port support to wetty terminal on Showroom

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -51,6 +51,7 @@
           sshHost: "{{ _showroom_user_data.bastion_public_hostname }}"
           sshUser: "{{ _showroom_user_data.bastion_ssh_user_name }}"
           sshPass: "{{ _showroom_user_data.bastion_ssh_password }}"
+          sshPort: "{{ _showroom_user_data.bastion_ssh_port | default(22) }}"
       novnc:
         setup: "{{ (true if ocp4_workload_showroom_novnc_enable | bool else false) | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_novnc_image }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/application.yaml.j2
@@ -54,6 +54,7 @@ spec:
             sshAuth: password
             sshUser: {{ _showroom_user_data.bastion_ssh_user_name }}
             sshPass: {{ _showroom_user_data.bastion_ssh_password }}
+            sshPort: "{{ _showroom_user_data.bastion_ssh_port | default(22) }}"
         content:
           repoUrl: {{ ocp4_workload_showroom_content_git_repo }}
           repoRef: {{ ocp4_workload_showroom_content_git_repo_ref }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/templates/applicationset.yaml.j2
@@ -68,6 +68,7 @@ spec:
                 sshAuth: password
                 sshUser: {{ _showroom_user_data.bastion_ssh_user_name }}
                 sshPass: {{ _showroom_user_data.bastion_ssh_password }}
+                sshPort: "{{ _showroom_user_data.bastion_ssh_port | default(22) }}"
             content:
               repoUrl: {{ ocp4_workload_showroom_content_git_repo }}
               repoRef: {{ ocp4_workload_showroom_content_git_repo_ref }}


### PR DESCRIPTION
##### SUMMARY

Add support for non standard (22) ports to ssh into the bastion from showroom when using the wetty terminal.

Required for CNV environments.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom