### PR TITLE
Fix certificates issues in advanced controller

### DIFF
--- a/ansible/roles/aap_controller_cert_issue/tasks/main.yml
+++ b/ansible/roles/aap_controller_cert_issue/tasks/main.yml
@@ -109,21 +109,21 @@
     # If this fails check out status of certbot: https://letsencrypt.status.io/
     - name: Issue Lets Encrypt Cert for Ansible Automation Controller
       when: certbot_cert_manager_provider != 'zerossl'
-      ansible.builtin.shell: |
-        certbot certonly --no-bootstrap --standalone \
-          -d {{ ansible_host.split(".")[0] | lower }}.{{ subdomain_base }} \
-          --email ansible-network@redhat.com --noninteractive --agree-tos
+      ansible.builtin.command: >
+        certbot certonly --no-bootstrap --standalone
+        -d {{ ansible_host.split(".")[0] | lower }}.{{ subdomain_base }}
+        --email ansible-network@redhat.com --noninteractive --agree-tos
       register: r_issue_cert
       until: r_issue_cert is not failed
       retries: 5
 
     - name: Issue ZerosSL Cert for Ansible Automation Controller
       when: certbot_cert_manager_provider == 'zerossl'
-      ansible.builtin.shell: |
-        certbot certonly --no-bootstrap --standalone \
-          --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}" \
-          -d {{ ansible_host.split(".")[0] | lower }}.{{ subdomain_base }} \
-          --email ansible-network@redhat.com --noninteractive --agree-tos
+      ansible.builtin.command: >
+        certbot certonly --no-bootstrap --standalone
+        --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}"
+        -d {{ ansible_host.split(".")[0] | lower }}.{{ subdomain_base }}
+        --email ansible-network@redhat.com --noninteractive --agree-tos
       register: r_issue_cert
       until: r_issue_cert is not failed
       retries: 5

--- a/ansible/roles/aap_controller_cert_issue/tasks/main.yml
+++ b/ansible/roles/aap_controller_cert_issue/tasks/main.yml
@@ -110,7 +110,7 @@
     - name: Issue Lets Encrypt Cert for Ansible Automation Controller
       when: certbot_cert_manager_provider != 'zerossl'
       ansible.builtin.command: >
-        certbot certonly --no-bootstrap --standalone
+        certbot certonly --standalone
         -d {{ ansible_host.split(".")[0] | lower }}.{{ subdomain_base }}
         --email ansible-network@redhat.com --noninteractive --agree-tos
       register: r_issue_cert
@@ -120,7 +120,7 @@
     - name: Issue ZerosSL Cert for Ansible Automation Controller
       when: certbot_cert_manager_provider == 'zerossl'
       ansible.builtin.command: >
-        certbot certonly --no-bootstrap --standalone
+        certbot certonly --standalone
         --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}"
         -d {{ ansible_host.split(".")[0] | lower }}.{{ subdomain_base }}
         --email ansible-network@redhat.com --noninteractive --agree-tos

--- a/ansible/roles/aap_pah_cert_issue/tasks/main.yml
+++ b/ansible/roles/aap_pah_cert_issue/tasks/main.yml
@@ -33,10 +33,10 @@
 - name: issue certificate (ZeroSSL)
   when: certbot_cert_manager_provider == 'zerossl'
   command: >
-    certbot certonly --nginx --noninteractive --agree-tos
+    certbot certonly --no-bootstrap --nginx
     --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}"
     -d {{ aap_pah_cert_hostname }}
-    --email {{ __aap_pah_cert_encrypt_mail }}
+    --email {{ __aap_pah_cert_encrypt_mail }} --noninteractive --agree-tos
   register: issue_cert
   until: issue_cert is not failed
   retries: 5

--- a/ansible/roles/aap_pah_cert_issue/tasks/main.yml
+++ b/ansible/roles/aap_pah_cert_issue/tasks/main.yml
@@ -22,9 +22,9 @@
 - name: issue certificate (Let's Encrypt)
   when: certbot_cert_manager_provider != 'zerossl'
   command: >
-    certbot certonly --nginx --noninteractive --agree-tos
+    certbot certonly --nginx
     -d {{ aap_pah_cert_hostname }}
-    --email {{ __aap_pah_cert_encrypt_mail }}
+    --email {{ __aap_pah_cert_encrypt_mail }} --noninteractive --agree-tos
   register: issue_cert
   until: issue_cert is not failed
   retries: 5
@@ -33,7 +33,7 @@
 - name: issue certificate (ZeroSSL)
   when: certbot_cert_manager_provider == 'zerossl'
   command: >
-    certbot certonly --no-bootstrap --nginx
+    certbot certonly --nginx
     --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}"
     -d {{ aap_pah_cert_hostname }}
     --email {{ __aap_pah_cert_encrypt_mail }} --noninteractive --agree-tos
@@ -52,7 +52,7 @@
 
 - name: Copy letsencrypt certificate
   copy:
-    src: /etc/letsencrypt/live/{{ aap_pah_cert_hostname }}/cert.pem
+    src: /etc/letsencrypt/live/{{ aap_pah_cert_hostname }}/fullchain.pem
     dest: /etc/pulp/certs/pulp_webserver.crt
     remote_src: true
     owner: nginx

--- a/ansible/roles/vscode-server/defaults/main.yml
+++ b/ansible/roles/vscode-server/defaults/main.yml
@@ -69,4 +69,11 @@ vscode_server_encrypt_mail: "{{ email | default('devops@opentlc.com') }}"
 #     "**/.ansible": true,
 #     "**/.cache": true
 #   }
+
+# Certbot generic variables for generating certificates
+certbot_cert_manager_provider: letsencrypt  # or 'zerossl'
+# Below only applies to ZeroSSL
+certbot_cert_manager_zerossl_eab_key_id: unknown
+certbot_cert_manager_zerossl_hmac_key: unknown
+certbot_cert_manager_acme_url: https://acme.zerossl.com/v2/DV90
 ...

--- a/ansible/roles/vscode-server/tasks/nginx-server.yml
+++ b/ansible/roles/vscode-server/tasks/nginx-server.yml
@@ -9,12 +9,20 @@
     enabled: yes
     state: started
 
-- name: nginx | generate certbot
+- name: nginx | generate certbot certificate (Let's Encrypt)
+  when: certbot_cert_manager_provider != 'zerossl'
   command: >-
     certbot certonly --nginx
     -m {{ vscode_server_encrypt_mail | regex_replace('example.com$','opentlc.com') }}
-    --agree-tos
-    -d {{ vscode_server_hostname }} -n
+    -d {{ vscode_server_hostname }} --noninteractive --agree-tos
+
+- name: nginx | generate certbot certificate (ZeroSSL)
+  when: certbot_cert_manager_provider == 'zerossl'
+  command: >-
+    certbot certonly --nginx
+    --eab-kid "{{ certbot_cert_manager_zerossl_eab_key_id }}" --eab-hmac-key "{{ certbot_cert_manager_zerossl_hmac_key }}" --server "{{ certbot_cert_manager_acme_url }}"
+    -m {{ vscode_server_encrypt_mail | regex_replace('example.com$','opentlc.com') }}
+    -d {{ vscode_server_hostname }} --noninteractive --agree-tos
 
 - name: nginx | create nginx certificate directory
   file:
@@ -25,7 +33,7 @@
 
 - name: nginx | copy letsencrypt key
   copy:
-    src: /etc/letsencrypt/live/{{ vscode_server_hostname }}/cert.pem
+    src: /etc/letsencrypt/live/{{ vscode_server_hostname }}/fullchain.pem
     dest: /etc/pki/nginx/server.crt
     remote_src: yes
     owner: nginx

--- a/ansible/software_playbooks/none.yml
+++ b/ansible/software_playbooks/none.yml
@@ -32,7 +32,7 @@
     ansible.builtin.file:
       path: /etc/ansible
       state: directory
-      mode: "0664"
+      mode: "0775"
 
   - name: Copy over ansible hosts file
     tags:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

* Remove outdated --no-bootstrap from certbot call
* Use ZeroSSL for certificates generation
* Also use fullchain.pem as server certificate to avoid SSL certificate problem: unable to get local issuer certificate
* Align PAH and controller certificates issuing roles
* Make /etc/ansible executable so that it can be used by non-root users

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible-automation-platform

##### ADDITIONAL INFORMATION

See [#advanced-features-of-ansible-automation-controller-troubleshooting](https://redhat.enterprise.slack.com/archives/C07U2D9R39B) for details