### PR TITLE
Add empty password for ocp4_workload_shared_cluster_access

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/setup_users.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/tasks/setup_users.yml
@@ -6,9 +6,11 @@
     ocp4_workload_shared_cluster_username | length == 0
     or ocp4_workload_shared_cluster_username | regex_search('[@.]') is not none
 
-- name: set ocp4_workload_shared_cluster_password
+- name: Set effective value for ocp4_workload_shared_cluster_password
+  # Use __ocp4_workload_shared_cluster_password so that the extra var may be set
+  # to empty string to indicate password generation is desired.
   ansible.builtin.set_fact:
-    ocp4_workload_shared_cluster_password: >-
+    __ocp4_workload_shared_cluster_password: >-
       {{
       ocp4_workload_shared_cluster_password
       | ternary(ocp4_workload_shared_cluster_password, lookup('password', '/dev/null length=8 chars=ascii_letters'))
@@ -36,4 +38,4 @@
     data:
       # yamllint disable rule:line-length
       ocp4_shared_username: "{{ ocp4_workload_shared_cluster_username }}"
-      ocp4_shared_password: "{{ ocp4_workload_shared_cluster_password }}"
+      ocp4_shared_password: "{{ __ocp4_workload_shared_cluster_password }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/templates/users/keycloak_user.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_shared_cluster_access/templates/users/keycloak_user.yaml.j2
@@ -11,7 +11,7 @@ spec:
     username: {{ ocp4_workload_shared_cluster_username }}
     credentials:
       - type: password
-        value: {{ ocp4_workload_shared_cluster_password }}
+        value: {{ __ocp4_workload_shared_cluster_password | to_json }}
     email: {{ ocp4_workload_shared_cluster_email }}
     emailVerified: true
     enabled: true


### PR DESCRIPTION
##### SUMMARY

Allow `ocp4_workload_shared_cluster_password` to be set to empty string as an extra var to indicate that password generation is requested. This will allow a parameter on the order for to allow an optional password to be provided by the user or leave it blank for generation.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role `ocp4_workload_shared_cluster_access`