### PR TITLE
feat: support passing a group description to GitLab

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_gitlab/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_gitlab/defaults/main.yml
@@ -44,6 +44,7 @@ ocp4_workload_gitops_gitlab_import_repos: []
 
 # ocp4_workload_gitops_gitlab_import_repos:
 # - name: janus-idp
+#   description: The IDP management group
 #   repo:
 #   - name: software-templates
 #     url: https://github.com/treddy08/software-templates.git

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_gitlab/templates/application-gitlab.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_gitlab/templates/application-gitlab.yml.j2
@@ -59,6 +59,8 @@ spec:
           {% set grouploop = loop %}
         - name: gitlab.groups[{{ grouploop.index - 1 }}].name
           value: {{ group.name }}
+        - name: gitlab.groups[{{ grouploop.index - 1 }}].description
+          value: {{ group.description }}
 {% for repo in group.repo %}
         - name: gitlab.groups[{{ grouploop.index - 1 }}].repo[{{ loop.index - 1 }}].name
           value: {{ repo.name }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_gitlab/templates/application-gitlab.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_gitlab/templates/application-gitlab.yml.j2
@@ -60,7 +60,7 @@ spec:
         - name: gitlab.groups[{{ grouploop.index - 1 }}].name
           value: {{ group.name }}
         - name: gitlab.groups[{{ grouploop.index - 1 }}].description
-          value: {{ group.description }}
+          value: {{ group.description | default('') }}
 {% for repo in group.repo %}
         - name: gitlab.groups[{{ grouploop.index - 1 }}].repo[{{ loop.index - 1 }}].name
           value: {{ repo.name }}


### PR DESCRIPTION
##### SUMMARY

Adding a group description is helpful in providing context. It also looks better in demos, since we won't have as many empty columns in RHDH.

*Note: that this screenshot was taken after enabling the GitLab Org Discovery plugin. This is something that will require a change to our default RHDH config.*

<img width="1719" alt="Screenshot 2024-12-19 at 12 24 57 PM" src="https://github.com/user-attachments/assets/a5c1bef5-2164-4997-861d-e7ee9a8efeae" />

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4_workload_gitops_gitlab

##### ADDITIONAL INFORMATION

Requires a change in [cm-gitlab-init.yaml](https://github.com/redhat-gpte-devopsautomation/agnosticg/blob/main/charts/gitlab/templates/cm-gitlab-init.yaml#L111) to pass the description to the POST to the GitLab API. Will open a PR for that shortly.
