### PR TITLE
[WIP] Fix incorrect AMI filter was '_' should be '-', breaks RHEL95 filter

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -20,7 +20,7 @@ infra_images_predefined:
 
   RHEL95GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
-    name: RHEL-9.5.*_HVM_*Access*
+    name: RHEL-9.5.*_HVM-*Access*
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false


### PR DESCRIPTION
##### SUMMARY

Incorrect AMI filter breaking RHEL95

RHEL-9.5.*_HVM_*Access* corrected to RHEL-9.5.*_HVM-*Access*

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

roles-infra/infra-images

##### ADDITIONAL INFORMATION

