### PR TITLE
WiP:  ocp4_workload_gitops_bootstrap: if desired, combine user_data with deployer_values

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/defaults/main.yml
@@ -11,6 +11,11 @@ ocp4_workload_gitops_bootstrap_namespace: openshift-gitops
 # Helm values to override in the ArgoCD bootstrap application.
 ocp4_workload_gitops_bootstrap_helm_values: []
 
+# WiP tasks to send all the user_data to the bootstrap application
+# so it can be used in an app to be passed onto addon/showroom
+ocp4_workload_gitops_bootstrap_include_user_data: false
+ocp4_workload_gitops_bootstrap_passthrough_user_data: false
+
 ocp4_workload_gitops_bootstrap_health_retries: 60
 ocp4_workload_gitops_bootstrap_health_ignore: true
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/prepare_multi_user_variables.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/prepare_multi_user_variables.yaml
@@ -1,0 +1,17 @@
+---
+- name: Set passthrough variables into per-user data, if desired
+  when:
+  - agnosticd_passthrough_user_data is defined
+  - ocp4_workload_gitops_bootstrap_passthrough_user_data is true | default(false) | bool
+  agnosticd_user_info:
+    data: "{{ agnosticd_passthrough_user_data | default('', true) }}"
+    user: "user{{ n }}"
+  loop: "{{ range(1, num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: n
+
+- name: Combine with all user_data
+  ansible.builtin.set_fact:
+    _ocp4_workload_gitops_bootstrap_deployer_values: |
+     {{ _ocp4_workload_gitops_bootstrap_deployer_values |
+        combine( _gitops_user_lookup('agnosticd_user_data', '*') )}}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/workload.yml
@@ -20,6 +20,11 @@
         domain: "{{ r_ingress.resources[0].status.domain }}"
         apiUrl: "{{ r_infra.resources[0].status.apiServerURL }}"
 
+- name: Prepare multi-user variables
+  when: ocp4_workload_gitops_bootstrap_include_user_data | bool
+  ansible.bulitin.include_tasks:
+    file: prepare_multi_user_variables.yaml
+
 - name: print _ocp4_workload_gitops_bootstrap_deployer_values
   ansible.builtin.debug:
     msg: "{{ _ocp4_workload_gitops_bootstrap_deployer_values | to_yaml }}"


### PR DESCRIPTION
Used to enable showroom via gitops bootstrap

* Uses a feature flag and an include tasks file.
* disabled by default
* merges passthrough_user_data into user_data for each user
* combines user_data dict with _ocp4_workload_gitops_boostrap_deployer_values
