### PR TITLE
ee-multicloud: upgrade python to 3.11

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/Containerfile
+++ b/tools/execution_environments/ee-multicloud-public/Containerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi
 USER root
 WORKDIR /root
 
-RUN dnf install -y python39-pip \
+RUN dnf install -y \
         bind-utils \
         findutils \
         gcc \
@@ -16,8 +16,9 @@ RUN dnf install -y python39-pip \
         libxml2-devel \
         openssl \
         openssl-devel \
-        python39 \
-        python39-devel \
+        python3.11 \
+        python3.11-devel \
+        python3.11-pip \
         rsync \
         sshpass \
         tar \
@@ -29,9 +30,9 @@ RUN dnf install -y python39-pip \
 
 # Python
 
-RUN alternatives --set python /usr/bin/python3.9 \
-    && alternatives --set python3 /usr/bin/python3.9 \
-    && alternatives --install /usr/bin/pip pip /usr/bin/pip3.9 1
+RUN alternatives --set python /usr/bin/python3.11 \
+    && alternatives --set python3 /usr/bin/python3.11 \
+    && alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 1
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt


### PR DESCRIPTION
python 3.9 is deprecated.

Upgrade python to 3.11
