### PR TITLE
Update image repo and image for tap sno setup

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_tap_wks_sno_setup/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tap_wks_sno_setup/defaults/main.yml
@@ -11,7 +11,7 @@ ocp4_workload_tap_wks_sno_setup_docker_password: "{{ common_password }}"
 
 ocp4_workload_tap_wks_sno_setup_stackrox_namespace: stackrox
 
-ocp4_workload_tap_wks_sno_rhtas_cli_image: quay.io/redhat-user-workloads/rhtas-tenant/cli/client-server-re:93d568a3001d8d6adca9ed79bac59ce1ae8fab8f
+ocp4_workload_tap_wks_sno_rhtas_cli_image: registry.redhat.io/rhtas/ec-rhel9:0.5-1740511231
 ocp4_workload_tap_wks_sno_cosign_url: https://github.com/sigstore/cosign/releases/download/v2.0.0/cosign-linux-amd64
 
 ocp4_workload_tap_wks_sno_setup_dev_apps_domain: x


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_tap_wks_sno_setup main.yml quay image no longer exists so replacing it with registry.redhat.io image

##### ADDITIONAL INFORMATION
Error: Error: initializing source docker://quay.io/redhat-user-workloads/rhtas-tenant/cli/client-server-re:93d568a3001d8d6adca9ed79bac59ce1ae8fab8f

Log: https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/1179175/output
