### PR TITLE
Fix role ocp4_workload_le_certificates

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/files/deploy_certs.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/files/deploy_certs.yaml
@@ -8,9 +8,9 @@
   gather_facts: false
   become: false
   vars:
-  - _certbot_install_dir: "~/certificates"
-  - _certbot_remote_dir: "~"
-  - _certbot_dir: "~/certbot"
+    _certbot_install_dir: "~/certificates"
+    _certbot_remote_dir: "~"
+    _certbot_dir: "~/certbot"
   tasks:
   - name: Determine API server URL
     kubernetes.core.k8s_info:
@@ -46,7 +46,7 @@
     register: server_key
 
   - name: Ensure Ansible Date/Time Facts are set
-    setup:
+    ansible.builtin.setup:
       filter: "ansible_date_time*"
 
   - name: Set new Ingress Controller Certificate Name

--- a/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_le_certificates/tasks/workload.yml
@@ -54,20 +54,20 @@
       ansible.builtin.include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
-      - _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
-      - _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
-      - _certbot_dns_provider: "route53"
-      - _certbot_remote_dir: "/home/{{ ansible_user }}"
-      - _certbot_remote_dir_owner: "{{ ansible_user }}"
-      - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
-      - _certbot_install_dir_owner: "{{ ansible_user }}"
-      - _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
-      - _certbot_renew_automatically: true
-      - _certbot_use_cache: true
-      - _certbot_force_issue: false
-      - _certbot_production: true
-      - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
-      - use_python3: "{{ all_use_python3 | default(true) | bool }}"
+        _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
+        _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
+        _certbot_dns_provider: "route53"
+        _certbot_remote_dir: "/home/{{ ansible_user }}"
+        _certbot_remote_dir_owner: "{{ ansible_user }}"
+        _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
+        _certbot_install_dir_owner: "{{ ansible_user }}"
+        _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
+        _certbot_renew_automatically: true
+        _certbot_use_cache: true
+        _certbot_force_issue: false
+        _certbot_production: true
+        _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+        use_python3: "{{ all_use_python3 | default(true) | bool }}"
       # production false results in unusable certificates
       # (not possible to login to OCP)
       # - _certbot_production: "{{ lets_encrypt_production | default(false) | bool}}"
@@ -86,20 +86,20 @@
       ansible.builtin.include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
-      - _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
-      - _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
-      - _certbot_dns_provider: "azure"
-      - _certbot_remote_dir: "/home/{{ ansible_user }}"
-      - _certbot_remote_dir_owner: "{{ ansible_user }}"
-      - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
-      - _certbot_install_dir_owner: "{{ ansible_user }}"
-      - _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
-      - _certbot_renew_automatically: true
-      - _certbot_use_cache: true
-      - _certbot_force_issue: false
-      - _certbot_production: true
-      - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
-      - use_python3: "{{ all_use_python3 | default(true) | bool }}"
+        _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
+        _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
+        _certbot_dns_provider: "azure"
+        _certbot_remote_dir: "/home/{{ ansible_user }}"
+        _certbot_remote_dir_owner: "{{ ansible_user }}"
+        _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
+        _certbot_install_dir_owner: "{{ ansible_user }}"
+        _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
+        _certbot_renew_automatically: true
+        _certbot_use_cache: true
+        _certbot_force_issue: false
+        _certbot_production: true
+        _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+        use_python3: "{{ all_use_python3 | default(true) | bool }}"
 
   - name: Get Certificates for GCP
     when: cloud_provider == "gcp"
@@ -108,20 +108,20 @@
       ansible.builtin.include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
-      - _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
-      - _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
-      - _certbot_dns_provider: "gcp"
-      - _certbot_remote_dir: "/home/{{ ansible_user }}"
-      - _certbot_remote_dir_owner: "{{ ansible_user }}"
-      - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
-      - _certbot_install_dir_owner: "{{ ansible_user }}"
-      - _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
-      - _certbot_renew_automatically: true
-      - _certbot_use_cache: true
-      - _certbot_force_issue: false
-      - _certbot_production: true
-      - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
-      - use_python3: "{{ all_use_python3 | default(true) | bool }}"
+        _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
+        _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
+        _certbot_dns_provider: "gcp"
+        _certbot_remote_dir: "/home/{{ ansible_user }}"
+        _certbot_remote_dir_owner: "{{ ansible_user }}"
+        _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
+        _certbot_install_dir_owner: "{{ ansible_user }}"
+        _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
+        _certbot_renew_automatically: true
+        _certbot_use_cache: true
+        _certbot_force_issue: false
+        _certbot_production: true
+        _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+        use_python3: "{{ all_use_python3 | default(true) | bool }}"
 
   - name: Get Certificates for OpenStack
     when: cloud_provider in ["osp"]
@@ -137,20 +137,20 @@
       ansible.builtin.include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
-      - _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
-      - _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
-      - _certbot_dns_provider: "rfc2136"
-      - _certbot_remote_dir: "/home/{{ ansible_user }}"
-      - _certbot_remote_dir_owner: "{{ ansible_user }}"
-      - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
-      - _certbot_install_dir_owner: "{{ ansible_user }}"
-      - _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
-      - _certbot_renew_automatically: true
-      - _certbot_use_cache: true
-      - _certbot_force_issue: false
-      - _certbot_production: true
-      - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
-      - use_python3: "{{ all_use_python3 | default(true) | bool }}"
+        _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
+        _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
+        _certbot_dns_provider: "rfc2136"
+        _certbot_remote_dir: "/home/{{ ansible_user }}"
+        _certbot_remote_dir_owner: "{{ ansible_user }}"
+        _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
+        _certbot_install_dir_owner: "{{ ansible_user }}"
+        _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
+        _certbot_renew_automatically: true
+        _certbot_use_cache: true
+        _certbot_force_issue: false
+        _certbot_production: true
+        _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+        use_python3: "{{ all_use_python3 | default(true) | bool }}"
       # production false results in unusable certificates
       # (not possible to login to OCP)
       # - _certbot_production: "{{ lets_encrypt_production | default(false) | bool }}"
@@ -175,20 +175,20 @@
       ansible.builtin.include_role:
         name: host-lets-encrypt-certs-certbot
       vars:
-      - _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
-      - _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
-      - _certbot_dns_provider: "rfc2136"
-      - _certbot_remote_dir: "/home/{{ ansible_user }}"
-      - _certbot_remote_dir_owner: "{{ ansible_user }}"
-      - _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
-      - _certbot_install_dir_owner: "{{ ansible_user }}"
-      - _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
-      - _certbot_renew_automatically: true
-      - _certbot_use_cache: true
-      - _certbot_force_issue: false
-      - _certbot_production: true
-      - _certbot_cron_job_name: LETS_ENCRYPT_RENEW
-      - use_python3: "{{ all_use_python3 | default(true) | bool }}"
+        _certbot_domain: "{{ ocp4_workload_le_certificates_api_hostname }}"
+        _certbot_wildcard_domain: "*.{{ r_ingress_controller.resources[0].status.domain }}"
+        _certbot_dns_provider: "rfc2136"
+        _certbot_remote_dir: "/home/{{ ansible_user }}"
+        _certbot_remote_dir_owner: "{{ ansible_user }}"
+        _certbot_install_dir: "/home/{{ ansible_user }}/certificates"
+        _certbot_install_dir_owner: "{{ ansible_user }}"
+        _certbot_cache_archive_file: "{{ output_dir | default('/tmp') }}/{{ guid }}-certs.tar.gz"
+        _certbot_renew_automatically: true
+        _certbot_use_cache: true
+        _certbot_force_issue: false
+        _certbot_production: true
+        _certbot_cron_job_name: LETS_ENCRYPT_RENEW
+        use_python3: "{{ all_use_python3 | default(true) | bool }}"
 
     - name: Remove credentials once LE certs have been created
       ansible.builtin.file:


### PR DESCRIPTION
##### SUMMARY

Fixed:
 - vars were defined as a list of dicts with one item instead of dict with multiple keys
 - FQCN was missing on one instance of module ansible.builtin.setup. Made a change since in all other occurrences FQCN was used

New code should work on all Ansible versions that it worked before. But now also on Ansible 2.18.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
role  ocp4_workload_le_certificates

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
