### PR TITLE
Add workload ocp4_workload_cluster_admin_service_account

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Control for creating a cluster-admin service account
+ocp4_workload_cluster_admin_service_account_name: cluster-admin
+ocp4_workload_cluster_admin_service_account_namespace: openshift-config

--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/readme.adoc
@@ -1,0 +1,18 @@
+= ocp4_workload_cluster_admin_service_account - Create service account with cluster admin privileges
+
+== Role overview
+
+* This workload role manages a service account with cluster admin privileges which is useful to maintain credentials with full access on the cluster even when cluster authentication is reconfigured in a demo or lab.
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Configures service account and cluster role binding.
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Removes service account and cluster role binding.
+
+The provisioning infrastructure will set a variable `ACTION` to be either `provision` or `destroy` depending on the operation.
+
+== The defaults variable file
+
+=== Variables
+
+* `ocp4_workload_cluster_admin_service_account_name`: Name for the service account, defaults to `cluster-admin`
+* `ocp4_workload_cluster_admin_service_account_namespace`: The namespace for the service account, defaults to `openshift-config`

--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/remove_workload.yml
@@ -1,0 +1,19 @@
+---
+- name: Remove cluster-admin service account
+  kubernetes.core.k8s:
+    state: absent
+    api_version: v1
+    kind: ServiceAccount
+    name: "{{ ocp4_workload_cluster_admin_service_account_name }}"
+    namespace: "{{ ocp4_workload_cluster_admin_service_account_namespace }}"
+
+- name: Remove cluster-admin service account privileges
+  kubernetes.core.k8s:
+    state: absent
+    api_version: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    name: >-
+      {{ 'cluster-admin:serviceaccount:%s:%s' | format(
+        ocp4_workload_cluster_admin_service_account_namespace,
+        ocp4_workload_cluster_admin_service_account_name
+      ) }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
@@ -119,4 +119,4 @@
 - name: Report ocp4_workload_cluster_admin_token as user data
   agnosticd_user_info:
     data:
-      ocp4_workload_cluster_admin_token: "{{ ocp4_workload_cluster_admin_token }}"
+      openshift_cluster_admin_token: "{{ ocp4_workload_cluster_admin_token }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
@@ -1,0 +1,105 @@
+---
+- name: Create cluster-admin service account
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: "{{ ocp4_workload_cluster_admin_service_account_name }}"
+        namespace: "{{ ocp4_workload_cluster_admin_service_account_namespace }}"
+
+- name: Grant cluster-admin service account cluster-admin privileges
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: >-
+          {{ 'cluster-admin:serviceaccount:%s:%s' | format(
+            ocp4_workload_cluster_admin_service_account_namespace,
+            ocp4_workload_cluster_admin_service_account_name
+          ) }}
+      roleRef:
+        apiGroup: rbac.authorization.k8s.io
+        kind: ClusterRole
+        name: cluster-admin
+      subjects:
+      - kind: ServiceAccount
+        name: "{{ ocp4_workload_cluster_admin_service_account_name }}"
+        namespace: "{{ ocp4_workload_cluster_admin_service_account_namespace }}"
+
+- name: Create cluster-admin service account token
+  command: >-
+    oc -v9 create token --duration=99999h
+    -n {{ ocp4_workload_cluster_admin_service_account_namespace | quote }}
+    {{ ocp4_workload_cluster_admin_service_account_name | quote }}
+  register: r_create_service_account_token
+  ignore_errors: true
+
+- name: Set ocp4_workload_cluster_admin_token
+  when: r_create_service_account_token is successful
+  set_fact:
+    ocp4_workload_cluster_admin_token: "{{ r_create_service_account_token.stdout }}"
+
+- name: Get OpenShift API server CA cert
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: loadbalancer-serving-ca
+    namespace: openshift-kube-apiserver-operator
+  failed_when: r_get_api_server_ca.resources | length != 1
+  register: r_get_api_server_ca
+  ignore_errors: true
+
+- name: Set openshift_api_ca_cert
+  when: r_get_api_server_ca is successful
+  set_fact:
+    openshift_api_ca_cert: >-
+      {{ r_get_api_server_ca.resources[0].data['ca-bundle.crt'] }}
+
+- name: Get cluster-admin service account token
+  when: ocp4_workload_cluster_admin_token is undefined
+  vars:
+    __token_secret_query: >-
+      [?
+        type == 'kubernetes.io/service-account-token' &&
+        length(metadata.name) == `{{ 12 + ocp4_workload_cluster_admin_service_account_name | length }}` &&
+        starts_with(metadata.name, '{{ ocp4_workload_cluster_admin_service_account_name }}-token-')
+      ]|[0]
+    __token_secret: >-
+      {{ r_get_token_secret.resources | to_json | from_json | json_query(__token_secret_query) }}
+  block:
+  - name: Wait for cluster-admin service account token
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Secret
+      namespace: "{{ ocp4_workload_cluster_admin_service_account_namespace }}"
+    register: r_get_token_secret
+    failed_when: not __token_secret
+    until: r_get_token_secret is success
+    retries: 5
+    delay: 1
+
+  - name: Set ocp4_workload_cluster_admin_token
+    set_fact:
+      ocp4_workload_cluster_admin_token: >-
+        {{ __token_secret.data.token | b64decode }}
+
+  - name: Set openshift_api_ca_cert
+    when: openshift_api_ca_cert is undefined
+    set_fact:
+      openshift_api_ca_cert: >-
+        {{ __token_secret.data['ca.crt'] | b64decode }}
+
+- name: Report openshift_api_ca_cert as user data
+  when: openshift_api_ca_cert is defined
+  agnosticd_user_info:
+    data:
+      openshift_api_ca_cert: "{{ openshift_api_ca_cert }}"
+
+- name: Report ocp4_workload_cluster_admin_token as user data
+  agnosticd_user_info:
+    data:
+      ocp4_workload_cluster_admin_token: "{{ ocp4_workload_cluster_admin_token }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
@@ -93,6 +93,23 @@
       openshift_api_ca_cert: >-
         {{ __token_secret.data['ca.crt'] | b64decode }}
 
+- name: Fall back to shell command to get api signing cert
+  when: openshift_api_ca_cert is undefined
+  block:
+  - name: Get api signing cert by shell command
+    ansible.builtin.shell: >-
+      openssl s_client -showcerts -connect api.rosa-wjbjm.7njo.p3.openshiftapps.com:443 </dev/null 2>/dev/null
+      | sed -ze 's/^.*-----BEGIN CERTIFICATE-----/-----BEGIN CERTIFICATE-----/' -e 's/-----END CERTIFICATE-----.*/-----END CERTIFICATE-----\n/'
+    ignore_errors: true
+    changed_when: false
+    register: r_get_signing_cert
+
+  - name: Set openshift_api_ca_cert
+    when: r_get_signing_cert is successful
+    set_fact:
+      openshift_api_ca_cert: >-
+        {{ r_get_signing_cert.stdout }}
+
 - name: Report openshift_api_ca_cert as user data
   when: openshift_api_ca_cert is defined
   agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY

Add workload ocp4_workload_cluster_admin_service_account to facilitate creating service accounts with cluster-admin privileges to maintain access during labs and workshops where authentication may be reconfigured.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Workload ocp4_workload_cluster_admin_service_account