### PR TITLE
Fix hard-coded hostname in ocp4_workload_cluster_admin_service_account

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cluster_admin_service_account/tasks/workload.yml
@@ -98,7 +98,7 @@
   block:
   - name: Get api signing cert by shell command
     ansible.builtin.shell: >-
-      openssl s_client -showcerts -connect api.rosa-wjbjm.7njo.p3.openshiftapps.com:443 </dev/null 2>/dev/null
+      openssl s_client -showcerts -connect $(oc whoami --show-server | sed 's|https://||') </dev/null 2>/dev/null
       | sed -ze 's/^.*-----BEGIN CERTIFICATE-----/-----BEGIN CERTIFICATE-----/' -e 's/-----END CERTIFICATE-----.*/-----END CERTIFICATE-----\n/'
     ignore_errors: true
     changed_when: false


### PR DESCRIPTION
##### SUMMARY

- Change to get api hostname from oc command.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_cluster_admin_service_account