### PR TITLE
ocp4_workload_openshift_data_foundations: add additional node selector

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/defaults/main.yml
@@ -36,3 +36,8 @@ ocp4_workload_openshift_data_foundation_tolerations: []
 # ocp4_workload_openshift_data_foundation_tolerations:
 # - key: metal
 #   operator: Exists
+
+# --------------------------------
+# Add a node selector to be more selective about nodes
+# --------------------------------
+# ocp4_workload_openshift_data_foundation_add_selector: "beta.kubernetes.io/instance-type=i3.metal"

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -3,13 +3,22 @@
   ansible.builtin.debug:
     msg: "Setting up OpenShift Data Foundation"
 
+- name: Define label_selector list
+  ansible.builtin.set_fact:
+    label_selector_list:
+      - node-role.kubernetes.io/worker
+      - "!node-role.kubernetes.io/infra"
+
+- name: Add to label_selector list
+  when: ocp4_workload_openshift_data_foundation_add_selector is defined
+  ansible.builtin.set_fact:
+    label_selector_list: "{{ label_selector_list + [ ocp4_workload_openshift_data_foundation_add_selector ] }}"
+
 - name: Discovering worker nodes
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Node
-    label_selectors:
-    - node-role.kubernetes.io/worker
-    - "!node-role.kubernetes.io/infra"
+    label_selectors: "{{ label_selector_list }}"
   register: r_worker_nodes
 
 - name: Fail for less than 3 worker nodes

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -6,8 +6,8 @@
 - name: Define label_selector list
   ansible.builtin.set_fact:
     label_selector_list:
-      - node-role.kubernetes.io/worker
-      - "!node-role.kubernetes.io/infra"
+    - node-role.kubernetes.io/worker
+    - "!node-role.kubernetes.io/infra"
 
 - name: Add to label_selector list
   when: ocp4_workload_openshift_data_foundation_add_selector is defined


### PR DESCRIPTION
Adds an optional label selector to the defaults in the workload to better identify the specific nodes you need.

- Feature Pull Request
