### PR TITLE
ocp4_workload_trilio... retry license install

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_trilio_backup_restore_vms/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trilio_backup_restore_vms/tasks/workload.yml
@@ -61,6 +61,11 @@
     state: present
     definition: "{{ lookup('template', 'templates/tvk-license-file.yaml.j2') | from_yaml }}"
     namespace: "{{ ocp4_workload_trilio_backup_restore_vms_namespace }}"
+  register: r_trilio_license
+  retries: 120
+  delay: 5
+  until:
+  - r_trilio_license | length > 0
 
 - name: Setup OAuth for Trilio
   ansible.builtin.include_tasks:

--- a/ansible/roles_ocp_workloads/ocp4_workload_trilio_backup_restore_vms/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trilio_backup_restore_vms/tasks/workload.yml
@@ -61,11 +61,8 @@
     state: present
     definition: "{{ lookup('template', 'templates/tvk-license-file.yaml.j2') | from_yaml }}"
     namespace: "{{ ocp4_workload_trilio_backup_restore_vms_namespace }}"
-  register: r_trilio_license
   retries: 120
   delay: 5
-  until:
-  - r_trilio_license | length > 0
 
 - name: Setup OAuth for Trilio
   ansible.builtin.include_tasks:

--- a/ansible/roles_ocp_workloads/ocp4_workload_trilio_backup_restore_vms/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trilio_backup_restore_vms/tasks/workload.yml
@@ -61,6 +61,8 @@
     state: present
     definition: "{{ lookup('template', 'templates/tvk-license-file.yaml.j2') | from_yaml }}"
     namespace: "{{ ocp4_workload_trilio_backup_restore_vms_namespace }}"
+  register: r_trilio_license
+  until: r_trilio_license is succeeded
   retries: 120
   delay: 5
 


### PR DESCRIPTION
Trilio is taking a long time to get itself ready.  Keep retrying to create the first custom resource, the license.

- Bugfix Pull Request
