### PR TITLE
Rosa_add_support_for_ip_ranges

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -11,6 +11,9 @@ guid: notset
 # Project Tag for all generated resources
 project_tag: "{{ env_type }}-{{ guid }}"
 
+# Only Satellite is supported
+repo_method: satellite
+
 # Do you want to run a full yum update
 update_packages: false
 
@@ -40,14 +43,14 @@ bastion_remove_insights_motd: false
 # This file (on RHEL 9.3) prevents password logins to the bastion
 bastion_remove_cloud_init_conf: true
 
-# Deploy Rosa - set to false for manual installation
+# Deploy ROSA - set to false for manual installation
 rosa_deploy: true
+
+# Cluster name to use when deploying ROSA
+rosa_cluster_name: "rosa-{{ guid }}"
 
 # Deploy ROSA using Hosted Control Planes
 rosa_deploy_hcp: false
-
-# ROSA Cluster Name
-rosa_cluster_name: "rosa-{{ guid }}"
 
 # Version of ROSA to deploy
 # ONLY change if you know what you're doing
@@ -64,7 +67,7 @@ rosa_version: default
 # Set the base of the version to be upgraded from when using `latest-upgrade` for rosa_version.
 # The logic will search for the latest version within that base
 # version that has available_upgrades set (use 'rosa list versions -o json' for examples)
-rosa_version_base: "openshift-v4.14"
+rosa_version_base: "openshift-v4.16"
 
 # ROSA CLI version
 rosa_installer_version: latest
@@ -116,6 +119,27 @@ rosa_setup_cluster_admin_delete_after_workloads: false
 # rosa_compute_autoscaling_min_replicas: 2
 # rosa_compute_autoscaling_max_replicas: 4
 
+# ROSA Machine CIDR. When not set the parameter is not passed leaving the default
+# Block of IP addresses used by OpenShift while installing the cluster, for example "10.0.0.0/16".
+# rosa_machine_cidr: "10.0.0.0/16"
+rosa_machine_cidr: ""
+
+# ROSA Service CIDR. When not set the parameter is not passed leaving the default
+# Block of IP addresses for services, for example "172.30.0.0/16".
+# rosa_service_cidr: "172.30.0.0/16"
+rosa_service_cidr: ""
+
+# ROSA Pod CIDR. When not set the parameter is not passed leaving the default
+# Block of IP addresses from which Pod IP addresses are allocated, for example "10.128.0.0/14".
+# rosa_pod_cidr: "110.128.0.0/14"
+rosa_pod_cidr: ""
+
+# Rosa Host Prefix
+# Subnet prefix length to assign to each individual node.
+# For example, if host prefix is set to "23", then each node is assigned a /23 subnet out of the given CIDR.
+# rosa_host_prefix: 23
+rosa_host_prefix: ""
+
 # Install helm on the bastion
 rosa_install_helm: true
 
@@ -130,6 +154,30 @@ rosa_terraform_repo_branch: main
 # Lockdown the Security Group for the Bastion to allow
 # ssh only from itself (showroom)
 rosa_lock_bastion_security_group: false
+
+# List of allowed IPs to connect to the bastion via SSH
+# in addition to the bastion IP address
+rosa_bastion_allowed_ssh_ips: []
+# rosa_bastion_allowed_ssh_ips:
+# - 44.211.19.138
+
+rosa_bastion_security_group_ingress_rules: []
+# Allow Showroom from everywhere
+# rosa_bastion_security_group_ingress_rules:
+# - ports:
+#   - 80
+#   - 443
+#   proto: tcp
+#   cidr_ip: "0.0.0.0/0"
+
+# Bastion is always allowed to SSH to itself
+rosa_bastion_security_group_egress_rules: []
+# Allow communication with ROSA
+# rosa_bastion_security_group_egress_rules:
+# - ports:
+#   - 443
+#   proto: tcp
+#   cidr_ip: "0.0.0.0/0"
 
 # Lockdown the Worker Node Security Group for the Cluster
 rosa_lock_cluster_security_group: false

--- a/ansible/configs/rosa-consolidated/destroy_env.yml
+++ b/ansible/configs/rosa-consolidated/destroy_env.yml
@@ -108,6 +108,5 @@
     vars:
       ACTION: destroy
 
-
 - name: Import cloud provider specific destroy playbook
   ansible.builtin.import_playbook: "../../cloud_providers/{{ cloud_provider }}_destroy_env.yml"

--- a/ansible/configs/rosa-consolidated/install_additional_tools.yml
+++ b/ansible/configs/rosa-consolidated/install_additional_tools.yml
@@ -9,7 +9,7 @@
       url: https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/latest/tkn-linux-amd64.tar.gz
       validate_certs: false
       dest: /tmp/tkn-linux-amd64.tar.gz
-      mode: "0660"
+      mode: ug=rw
     register: r_tkn
     until: r_tkn is success
     retries: 10
@@ -20,7 +20,7 @@
       src: /tmp/tkn-linux-amd64.tar.gz
       remote_src: true
       dest: /usr/bin
-      mode: "0775"
+      mode: ug=rwx,o=rx
       owner: root
       group: root
     args:
@@ -74,7 +74,7 @@
       url: "https://github.com/argoproj/argo-cd/releases/download/{{ argocd_cli_version }}/argocd-linux-amd64"
       validate_certs: false
       dest: /usr/bin/argocd
-      mode: "0775"
+      mode: ug=rwx,o=rx
     register: r_argocd
     until: r_argocd is success
     retries: 10

--- a/ansible/configs/rosa-consolidated/install_aws_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_aws_cli.yml
@@ -33,7 +33,7 @@
   ansible.builtin.blockinfile:
     path: ~/.aws/credentials
     create: true
-    mode: "0600"
+    mode: u=rw
     block: |-
       [default]
       aws_access_key_id={{ hostvars.localhost.rosa_access_key_id }}

--- a/ansible/configs/rosa-consolidated/install_helm.yml
+++ b/ansible/configs/rosa-consolidated/install_helm.yml
@@ -12,7 +12,7 @@
       src: "{{ helm_url }}"
       remote_src: true
       dest: /usr/local/bin
-      mode: "0775"
+      mode: ug=rwx,o=rx
       owner: root
       group: root
     retries: 10

--- a/ansible/configs/rosa-consolidated/install_ocp_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_ocp_cli.yml
@@ -24,7 +24,7 @@
     src: "{{ ocp4_client_url }}"
     remote_src: true
     dest: /usr/local/bin
-    mode: "0775"
+    mode: ug=rwx,o=rx
     owner: root
     group: root
   register: r_client

--- a/ansible/configs/rosa-consolidated/install_rosa_cluster_login.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cluster_login.yml
@@ -50,11 +50,11 @@
     path: "~{{ ansible_user }}/.kube"
     owner: "{{ ansible_user }}"
     state: directory
-    mode: "0755"
+    mode: u=rwx,og=rx
 
 - name: Generate kubeconfig file
   ansible.builtin.template:
     src: templates/kubeconfig.j2
     dest: "~{{ ansible_user }}/.kube/config"
     owner: "{{ ansible_user }}"
-    mode: "0600"
+    mode: u=rw

--- a/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
@@ -26,7 +26,9 @@
       /usr/local/bin/terraform plan
         -out rosa.tfplan
         -var region={{ aws_region }}
-        -var cluster_name=rosa-{{ guid }}
+        -var cluster_name={{ rosa_cluster_name }}
+        {% if rosa_machine_cidr | default("") | length > 0 %}-var vpc_cidr={{ rosa_machine_cidr }}{% endif %}
+        {% if rosa_host_prefix | default("") | length > 0 %}-var subnet_cidr_prefix={{ rosa_host_prefix | int }}{% endif %}
     chdir: "~{{ ansible_user }}/terraform-vpc"
 
 - name: Run terraform apply
@@ -90,28 +92,31 @@
       --hosted-cp \
       --mode auto \
       --yes \
-      --region {{ aws_region }}
-      --prefix rosa-{{ guid }} \
+      --prefix {{ rosa_cluster_name }} \
       --oidc-config-id {{ rosa_oidc_id }} \
       --installer-role-arn arn:aws:iam::{{ hostvars.localhost.sandbox_account_id }}:role/ManagedOpenShift-HCP-ROSA-Installer-Role
 
 - name: Create ROSA HCP Cluster
   ansible.builtin.command: >-
     {{ rosa_binary_path }}/rosa create cluster
-      --cluster-name=rosa-{{ guid }}
+      --cluster-name {{ rosa_cluster_name }}
       --billing-account {{ aws_billing_account_id }}
       --sts
-      --mode=auto
+      --mode auto
       --yes
       --hosted-cp
       --region {{ aws_region }}
-      --operator-roles-prefix rosa-{{ guid }}
+      --operator-roles-prefix {{ rosa_cluster_name }}
       --oidc-config-id {{ rosa_oidc_id }}
-      --subnet-ids={{ rosa_subnets }}
+      --subnet-ids {{ rosa_subnets }}
       {% if _rosa_version_to_install | default("") | length > 0 %}--version {{ _rosa_version_to_install }}{% endif %}
       {% if rosa_compute_machine_type is defined %}--compute-machine-type {{ rosa_compute_machine_type }}{% endif %}
       {% if rosa_compute_worker_disk_size is defined %}--worker-disk-size {{ rosa_compute_worker_disk_size }}{% endif %}
       {% if rosa_compute_replicas is defined %}--replicas {{ rosa_compute_replicas | int }}{% endif %}
+      {% if rosa_machine_cidr | default("") | length > 0 %}--machine-cidr {{ rosa_machine_cidr }}{% endif %}
+      {% if rosa_service_cidr | default("") | length > 0 %}--service-cidr {{ rosa_service_cidr }}{% endif %}
+      {% if rosa_pod_cidr | default("") | length > 0 %}--pod-cidr {{ rosa_pod_cidr }}{% endif %}
+      {% if rosa_host_prefix | default("") | length > 0 %}--host-prefix {{ rosa_host_prefix | int }}{% endif %}
   register: r_rosa_create_status
   until: r_rosa_create_status.rc == 0
   retries: 3

--- a/ansible/configs/rosa-consolidated/install_rosa_sts.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_sts.yml
@@ -18,6 +18,10 @@
     {% if rosa_compute_machine_type is defined %}--compute-machine-type {{ rosa_compute_machine_type }}{% endif %}
     {% if rosa_compute_worker_disk_size is defined %}--worker-disk-size {{ rosa_compute_worker_disk_size }}{% endif %}
     {% if rosa_compute_replicas is defined %}--replicas {{ rosa_compute_replicas | int }}{% endif %}
+    {% if rosa_machine_cidr | default("") | length > 0 %}--machine-cidr {{ rosa_machine_cidr }}{% endif %}
+    {% if rosa_service_cidr | default("") | length > 0 %}--service-cidr {{ rosa_service_cidr }}{% endif %}
+    {% if rosa_pod_cidr | default("") | length > 0 %}--pod-cidr {{ rosa_pod_cidr }}{% endif %}
+    {% if rosa_host_prefix | default("") | length > 0 %}--host-prefix {{ rosa_host_prefix | int }}{% endif %}
     {% if rosa_compute_enable_autoscaling | default(false) | bool %}
     --enable-autoscaling
     {% if rosa_compute_enable_autoscaling | default(false) | bool %}--autoscaler-scale-down-enabled{% endif %}

--- a/ansible/configs/rosa-consolidated/install_rosa_user.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_user.yml
@@ -7,13 +7,14 @@
       state: directory
       path: "~{{ bastion_user_name }}/.config/ocm"
       owner: "{{ bastion_user_name }}"
+      mode: u=rwx
 
   - name: Copy ROSA token to rosa user dir
     ansible.builtin.copy:
       src: /home/ec2-user/.config/ocm/ocm.json
       dest: "~{{ bastion_user_name }}/.config/ocm/ocm.json"
       owner: "{{ bastion_user_name }}"
-      mode: '0600'
+      mode: u=rw
       remote_src: true
 
   - name: Create .aws directory in rosa user homedir
@@ -21,6 +22,7 @@
       path: "~{{ bastion_user_name }}/.aws"
       owner: "{{ bastion_user_name }}"
       state: directory
+      mode: u=rwx
 
   - name: Copy AWS credentials to rosa user dir
     ansible.builtin.copy:
@@ -28,3 +30,4 @@
       dest: "~{{ bastion_user_name }}/.aws/credentials"
       owner: "{{ bastion_user_name }}"
       remote_src: true
+      mode: u=rw

--- a/ansible/configs/rosa-consolidated/lock_bastion_security_group.yml
+++ b/ansible/configs/rosa-consolidated/lock_bastion_security_group.yml
@@ -27,41 +27,56 @@
   ansible.builtin.debug:
     msg: "{{ r_security_groups.security_groups[0].group_name }}"
 
-# Lock Security group to just the bastion IP
-# and the two ports for Showroom (80 for Let's Encrypt, 443 for Traefik)
+- name: Compute base SSH ingress rules (allow bastion to connect to itself)
+  ansible.builtin.set_fact:
+    _ssh_ingress_rules:
+      - ports: [22]
+        proto: tcp
+        cidr_ip: "{{ ocp4_workload_rosa_lockdown_bastion_bastion_ip_address }}/32"
+
+- name: Append allowed SSH IPs to ingress rules
+  when: rosa_bastion_allowed_ssh_ips | default([]) | length > 0
+  ansible.builtin.set_fact:
+    _ssh_ingress_rules: "{{ _ssh_ingress_rules + [{'ports': [22], 'proto': 'tcp', 'cidr_ip': ip + '/32'}] }}"
+  loop: "{{ rosa_bastion_allowed_ssh_ips }}"
+  loop_control:
+    loop_var: ip
+
+- name: Append predefined security group rules to ingress rules
+  when: rosa_bastion_security_group_ingress_rules | default([]) | length > 0
+  ansible.builtin.set_fact:
+    _ssh_ingress_rules: "{{ _ssh_ingress_rules + rosa_bastion_security_group_ingress_rules }}"
+
+- name: Debug SSH ingress rules
+  ansible.builtin.debug:
+    msg: "{{ _ssh_ingress_rules }}"
+
+- name: Compute base SSH egress rules (allow bastion to connect to itself)
+  ansible.builtin.set_fact:
+    _ssh_egress_rules:
+      - ports: [22]
+        proto: tcp
+        cidr_ip: "{{ ocp4_workload_rosa_lockdown_bastion_bastion_ip_address }}/32"
+
+- name: Append predefined security group rules to egress rules
+  when: rosa_bastion_security_group_egress_rules | default([]) | length > 0
+  ansible.builtin.set_fact:
+    _ssh_egress_rules: "{{ _ssh_egress_rules + rosa_bastion_security_group_egress_rules }}"
+
+- name: Debug SSH egress rules
+  ansible.builtin.debug:
+    msg: "{{ _ssh_egress_rules }}"
+
 - name: Update Security Group
   amazon.aws.ec2_security_group:
     state: present
     name: "{{ r_security_groups.security_groups[0].group_name }}"
     description: "{{ r_security_groups.security_groups[0].description }}"
     vpc_id: "{{ r_vpcs.vpcs[0].vpc_id }}"
-    # Ingress Rules
     purge_rules: true
-    rules:
-    # Allow SSH only from the bastion itself
-    - ports:
-      - 22
-      proto: tcp
-      cidr_ip: "{{ ocp4_workload_rosa_lockdown_bastion_bastion_ip_address }}/32"
-    # Allow Showroom from everywhere
-    - ports:
-      - 80
-      - 443
-      proto: tcp
-      cidr_ip: "0.0.0.0/0"
-    # Egress Rules
+    rules: "{{ _ssh_ingress_rules }}"
     purge_rules_egress: true
-    rules_egress:
-    # Allow SSH connections to bastion itself
-    - ports:
-      - 22
-      proto: tcp
-      cidr_ip: "{{ ocp4_workload_rosa_lockdown_bastion_bastion_ip_address }}/32"
-    # Allow communication with rosa
-    - ports:
-      - 443
-      proto: tcp
-      cidr_ip: "0.0.0.0/0"
+    rules_egress: "{{ _ssh_egress_rules }}"
   register: r_sg
 
 - name: Debug SG

--- a/ansible/configs/rosa-consolidated/lock_cluster_security_group.yml
+++ b/ansible/configs/rosa-consolidated/lock_cluster_security_group.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Retrieve VPC for worker nodes
   amazon.aws.ec2_vpc_net_info:
     filters:
@@ -14,13 +13,15 @@
   amazon.aws.ec2_security_group_info:
     filters:
       vpc-id: "{{ r_vpcs.vpcs[0].vpc_id }}"
-      # tag:Name: BastionSG
   register: r_security_groups
 
 - name: Print security group name
   ansible.builtin.debug:
-    # msg: "{{ r_security_groups }}"
     msg: "{{ r_security_groups.security_groups[0].group_name }}"
+
+- name: Debug Security Group before change
+  ansible.builtin.debug:
+    msg: "{{ r_security_groups.security_groups[0] }}"
 
 # Lock Security group
 - name: Update Security Group to block port 22
@@ -34,7 +35,7 @@
     - ports:
       - 1-21
       - 23-65535
-      proto: udp
+      proto: tcp
       cidr_ip: "0.0.0.0/0"
   register: r_sg
 

--- a/ansible/configs/rosa-consolidated/lock_cluster_security_group.yml
+++ b/ansible/configs/rosa-consolidated/lock_cluster_security_group.yml
@@ -3,7 +3,7 @@
 - name: Retrieve VPC for worker nodes
   amazon.aws.ec2_vpc_net_info:
     filters:
-      tag:Name: "rosa-{{ guid }}-vpc"
+      tag:Name: "{{ rosa_cluster_name }}-vpc"
   register: r_vpcs
 
 - name: Print VPC id and name
@@ -23,7 +23,7 @@
     msg: "{{ r_security_groups.security_groups[0].group_name }}"
 
 # Lock Security group
-- name: Update Security Group
+- name: Update Security Group to block port 22
   amazon.aws.ec2_security_group:
     state: present
     name: "{{ r_security_groups.security_groups[0].group_name }}"
@@ -32,15 +32,8 @@
     purge_rules_egress: true
     rules_egress:
     - ports:
-      - 53
-      - 80
-      - 443
-      - 1024-65535
-      proto: tcp
-      cidr_ip: "0.0.0.0/0"
-    - ports:
-      - 53
-      - 1024-65535
+      - 1-21
+      - 23-65535
       proto: udp
       cidr_ip: "0.0.0.0/0"
   register: r_sg

--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -8,6 +8,8 @@
   - step004
   - common_tasks
   roles:
+  - when: repo_method is defined
+    role: set-repositories
   - role: common
     when: install_common | default( true ) | bool
   tasks:
@@ -75,5 +77,5 @@
       dest: /etc/motd.d/agnosticd
       owner: root
       group: root
-      mode: "o=rw,g=rw,o=r"
+      mode: ug=rw,o=r
       content: "{{ bastion_custom_motd }}"

--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -18,7 +18,7 @@
       src: "{{ rosa_terraform_url }}"
       remote_src: true
       dest: /usr/local/bin
-      mode: "0775"
+      mode: ug=rwx,o=rx
       owner: root
       group: root
     retries: 10
@@ -76,7 +76,7 @@
       ansible.builtin.shell:
         cmd: >-
           {{ rosa_binary_path }}/rosa logs install \
-            --cluster rosa-{{ guid }} > /home/{{ ansible_user }}/rosa_install.log
+            --cluster {{ rosa_cluster_name }} > /home/{{ ansible_user }}/rosa_install.log
 
     - name: Gzip ROSA install log
       ansible.builtin.archive:

--- a/ansible/configs/rosa-consolidated/uninstall_rosa.yml
+++ b/ansible/configs/rosa-consolidated/uninstall_rosa.yml
@@ -35,7 +35,7 @@
       src: "{{ rosa_terraform_url }}"
       remote_src: true
       dest: /usr/local/bin
-      mode: "0775"
+      mode: ug=rwx,o=rx
       owner: root
       group: root
     retries: 10
@@ -52,30 +52,12 @@
       extra_opts:
       - --no-same-owner
 
-  # - name: Remove old providers
-  #   ansible.builtin.file:
-  #     state: absent
-  #     path: "{{ item }}"
-  #   loop:
-  #   - /tmp/terraform-vpc/.terraform
-  #   - /tmp/terraform-vpc/.terraform.lock.hcl
-
-  # - name: Run terraform init
-  #   ansible.builtin.command:
-  #     cmd: /usr/local/bin/terraform init
-  #     chdir: "/tmp/terraform-vpc/"
-  #   register: r_output
-
-  # - name: Print output
-  #   ansible.builtin.debug:
-  #     msg: "{{ r_output }}"
-
   - name: Run Terraform destroy
     ansible.builtin.command:
       cmd: >-
         /usr/local/bin/terraform destroy
           -var region={{ aws_region }}
-          -var cluster_name=rosa-{{ guid }}
+          -var cluster_name={{ rosa_cluster_name }}
           -auto-approve
       chdir: "/tmp/terraform-vpc/"
     ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Add support to the rosa-consolidated config for:

* specifying IP ranges for machines,services,pods and prefix
* Make Security Group rules customizable via variables
* Add support to add additional allowed ingress SSH IP addresses
* Code cleanup

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
rosa-consolidated