### PR TITLE
Add filter to pick correct Security Group

### DIFF
--- a/ansible/configs/rosa-consolidated/lock_cluster_security_group.yml
+++ b/ansible/configs/rosa-consolidated/lock_cluster_security_group.yml
@@ -13,6 +13,8 @@
   amazon.aws.ec2_security_group_info:
     filters:
       vpc-id: "{{ r_vpcs.vpcs[0].vpc_id }}"
+      tag:red-hat-clustertype: rosa
+
   register: r_security_groups
 
 - name: Print security group name


### PR DESCRIPTION
##### SUMMARY

There are two security groups for the same VPC. Adding filter to pick the worker security group for sure.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated