### PR TITLE
Add_second_rosa

### DIFF
--- a/ansible/configs/rosa-consolidated/software.yml
+++ b/ansible/configs/rosa-consolidated/software.yml
@@ -111,13 +111,16 @@
   - name: Save ROSA user data
     agnosticd_user_info:
       data:
+        guid: "{{ guid }}"
         rosa_token_warning: "{{ rosa_token_warning }}"
         rosa_subdomain_base: "{{ subdomain_base }}"
         ssh_command: "ssh {{ bastion_user_name }}@bastion.{{ subdomain_base }}"
-        ssh_password: "{{ _bastion_user_password }}"
         ssh_username: "{{ bastion_user_name }}"
+        ssh_password: "{{ _bastion_user_password }}"
         targethost: "bastion.{{ subdomain_base }}"
-        guid: "{{ guid }}"
+        bastion_public_hostname: "bastion.{{ subdomain_base }}"
+        bastion_ssh_user_name: "{{ bastion_user_name }}"
+        bastion_ssh_password: "{{ _bastion_user_password }}"
 
   - name: Save ROSA user data when ROSA has been installed
     when: rosa_deploy | default(true) | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+ocp4_workload_lb2739_second_rosa_name: "dr-{{ guid }}"
+ocp4_workload_lb2739_second_rosa_cidr: "10.10.0.0/16"
+ocp4_workload_lb2739_second_rosa_compute_replicas: 2
+ocp4_workload_lb2739_second_rosa_version: "4.16.37"
+
+ocp4_workload_lb2739_second_rosa_binary_path: "/usr/local/bin"
+ocp4_workload_lb2739_second_rosa_installer_version: latest
+ocp4_workload_lb2739_second_rosa_installer_url: >-
+  https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/{{ rosa_installer_version }}/rosa-linux.tar.gz

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_lb2739_second_rosa
+  author: Red Hat, Wolfgang Kulhanek (wkulhane@redhat.com)
+  description: |
+    Deploy a second ROSA cluster alongside a primary one
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/readme.adoc
@@ -1,0 +1,3 @@
+= ocp4_workload_lb2739_second_rosa - Deploy a second rosa alongside the primary one
+
+For Summit 2025 lab LB2739

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/remove_workload.yml
@@ -1,0 +1,8 @@
+---
+# ------------------------------------------
+# Implement your workload removal tasks here
+# ------------------------------------------
+
+- name: Remove_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/workload.yml
@@ -1,5 +1,6 @@
 ---
 # Account roles should already exist from the primary ROSA cluster
+# yamllint disable rule:line-length
 - name: Create secondary ROSA Classic (STS) Cluster
   ansible.builtin.command: >-
     {{ ocp4_workload_lb2739_second_rosa_binary_path }}/rosa create cluster
@@ -15,6 +16,7 @@
   until: r_rosa2_create_status.rc == 0
   retries: 5
   delay: 10
+# yamllint enable rule:line-length
 
 - name: Wait for ROSA installer completion
   ansible.builtin.command: >-

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739_second_rosa/tasks/workload.yml
@@ -1,0 +1,66 @@
+---
+# Account roles should already exist from the primary ROSA cluster
+- name: Create secondary ROSA Classic (STS) Cluster
+  ansible.builtin.command: >-
+    {{ ocp4_workload_lb2739_second_rosa_binary_path }}/rosa create cluster
+    --cluster-name {{ ocp4_workload_lb2739_second_rosa_name }}
+    --region {{ aws_region }}
+    --sts
+    --mode auto
+    --yes
+    --version {{ ocp4_workload_lb2739_second_rosa_version }}
+    {% if ocp4_workload_lb2739_second_rosa_compute_replicas is defined %}--replicas {{ ocp4_workload_lb2739_second_rosa_compute_replicas | int }}{% endif %}
+    {% if ocp4_workload_lb2739_second_rosa_cidr | default("") | length > 0 %}--machine-cidr {{ ocp4_workload_lb2739_second_rosa_cidr }}{% endif %}
+  register: r_rosa2_create_status
+  until: r_rosa2_create_status.rc == 0
+  retries: 5
+  delay: 10
+
+- name: Wait for ROSA installer completion
+  ansible.builtin.command: >-
+    {{ ocp4_workload_lb2739_second_rosa_binary_path }}/rosa describe cluster
+    --cluster {{ ocp4_workload_lb2739_second_rosa_name }}
+    --output json
+  register: r_rosa2_installer_status
+  until:
+  - (r_rosa2_installer_status.stdout | from_json).status is defined
+  - (r_rosa2_installer_status.stdout | from_json).status.state is defined
+  - (r_rosa2_installer_status.stdout | from_json).status.state == "ready"
+  - (r_rosa2_installer_status.stdout | from_json).api is defined
+  - (r_rosa2_installer_status.stdout | from_json).api.url is defined
+  - (r_rosa2_installer_status.stdout | from_json).console is defined
+  - (r_rosa2_installer_status.stdout | from_json).console.url is defined
+  ignore_errors: true
+  retries: 120
+  delay: 60
+
+- name: Get ROSA API URL
+  ansible.builtin.set_fact:
+    rosa2_openshift_api_url: "{{ (r_rosa2_installer_status.stdout | from_json).api.url }}"
+
+- name: Get ROSA console URL
+  ansible.builtin.set_fact:
+    rosa2_openshift_console_url: "{{ (r_rosa2_installer_status.stdout | from_json).console.url }}"
+
+# yamllint disable rule:line-length
+- name: Create ROSA admin user
+  ansible.builtin.shell: "{{ ocp4_workload_lb2739_second_rosa_binary_path }}/rosa create admin --cluster {{ ocp4_workload_lb2739_second_rosa_name }} | grep 'oc login' | awk '{print $7}'"
+  register: r_rosa2_admin_result
+# yamllint enable rule:line-length
+
+- name: Save ROSA admin user password
+  ansible.builtin.set_fact:
+    _rosa2_cluster_admin_password: "{{ r_rosa2_admin_result.stdout }}"
+
+- name: Print cluster-admin password
+  ansible.builtin.debug:
+    msg: "Password for ROSA 2 cluster-admin is '{{ _rosa2_cluster_admin_password }}'"
+
+- name: Save AgnosticD ROSA user data
+  agnosticd_user_info:
+    data:
+      rosa2_cluster_name: "{{ ocp4_workload_lb2739_second_rosa_name }}"
+      rosa2_openshift_console_url: "{{ rosa2_openshift_console_url }}"
+      rosa2_openshift_api_url: "{{ rosa2_openshift_api_url }}"
+      rosa2_openshift_admin_user: "cluster-admin"
+      rosa2_openshift_admin_password: "{{ _rosa2_cluster_admin_password }}"


### PR DESCRIPTION
##### SUMMARY

Showroom workload needed additional info in the AgD User data. Added.

Added workload to deploy a second rosa cluster into an existing environment for LB2739.

##### ISSUE TYPE
- Feature Pull Request
- New role Pull Request

##### COMPONENT NAME
rosa-consolidated
ocp4_workload_lb2739_second_rosa