### PR TITLE
[ocp4_workload_rhacs] Specify the api_version to k8s_json_patch

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacs/tasks/workload.yml
@@ -108,6 +108,7 @@
     - name: Update Route central with reencrypt and CA Cert from Central
       kubernetes.core.k8s_json_patch:
         kind: Route
+        api_version: route.openshift.io/v1
         namespace: stackrox
         name: central
         patch:


### PR DESCRIPTION
##### SUMMARY

Fix failed task: An exception occurred during task execution. To see the full traceback, use -vvv. The error was: kubernetes.dynamic.exceptions.ResourceNotFoundError: No matches found for {'prefix': None, 'api_version': 'v1', 'short_names': ['Route']}


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_rhacs role
