### PR TITLE
Add agnosticd_save_output_dir_access_archive

### DIFF
--- a/ansible/roles/agnosticd_save_output_dir/defaults/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/defaults/main.yml
@@ -1,8 +1,17 @@
 ---
 # Archive object to create in S3 storage.
 #agnosticd_save_output_dir_archive: "{{ guid }}_{{ uuid }}.tar.gz"
+
+# Enable upload of archive with access credentials only.
+#agnosticd_save_output_dir_access_archive:  "{{ guid }}_{{ uuid }}.access.tar.gz"
+
+# File glob patterns to match for access file archive if enabled
+agnosticd_save_output_dir_access_fileglobs:
+  - '*ssh*'
+  - '*kubeconfig*'
+
 # Protect archive with password, it can be useful if the S3 bucket is shared between multiple users.
-# agnosticd_save_output_dir_archive_password: ...
+#agnosticd_save_output_dir_archive_password: ...
 
 # S3 storage bucket access information, should be provided by a secret.
 #agnosticd_save_output_dir_s3_bucket: agnosticd-output-dir

--- a/ansible/roles/agnosticd_save_output_dir/tasks/create-access-archive.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/create-access-archive.yml
@@ -1,0 +1,31 @@
+---
+- name: Create tempfile for archive
+  ansible.builtin.tempfile:
+    state: file
+    prefix: "{{ guid }}-access-"
+    suffix: .tar.gz
+  register: r_output_dir_archive_tempfile
+
+- name: Set agnosticd_save_output_dir_archive_tempfile
+  ansible.builtin.set_fact:
+    agnosticd_save_output_dir_archive_tempfile: "{{ r_output_dir_archive_tempfile.path }}"
+
+
+- name: Create output_dir archive
+  ansible.builtin.command:
+    cmd: >-
+      tar -czf {{ agnosticd_save_output_dir_archive_tempfile }}
+      {{ agnosticd_save_output_dir_access_files | map('quote') | join(' ')}}
+  args:
+    chdir: "{{ output_dir }}"
+
+- name: Encrypt tarball using password
+  when: agnosticd_save_output_dir_archive_password is defined
+  ansible.builtin.command: >-
+    gpg --symmetric --batch --yes --passphrase-fd 0
+    --output {{ (agnosticd_save_output_dir_archive_tempfile ~ '.gpg') | quote }}
+    {{ agnosticd_save_output_dir_archive_tempfile | quote }}
+  args:
+    chdir: "{{ output_dir }}"
+    stdin: "{{ agnosticd_save_output_dir_archive_password }}"
+...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/main.yml
@@ -7,4 +7,15 @@
       delegate_to: localhost
       run_once: true
       become: false
+
+- name: Save output dir if archive file is defined
+  when:
+  - agnosticd_save_output_dir_access_archive is defined
+  - agnosticd_save_output_dir_access_files | length > 0
+  ansible.builtin.include_tasks:
+    file: save-access-archive.yml
+    apply:
+      delegate_to: localhost
+      run_once: true
+      become: false
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/save-access-archive.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/save-access-archive.yml
@@ -1,15 +1,15 @@
 ---
 - block:
-  - name: Create output_dir archive
+  - name: Create access archive
     ansible.builtin.include_tasks:
-      file: create-output-dir-archive.yml
+      file: create-access-archive.yml
 
   - name: Upload output_dir archive to S3
     when: agnosticd_save_output_dir_s3_bucket is defined
     vars:
       __s3_object: >-
         {{
-          agnosticd_save_output_dir_archive ~
+          agnosticd_save_output_dir_access_archive ~
           ('.gpg' if agnosticd_save_output_dir_archive_password is defined else '')
         }}
     ansible.builtin.include_tasks:

--- a/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3-aws_s3.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3-aws_s3.yml
@@ -10,8 +10,6 @@
       {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
     region: "{{ agnosticd_save_output_dir_s3_region }}"
     bucket: "{{ agnosticd_save_output_dir_s3_bucket }}"
-    object: >-
-      {{ agnosticd_save_output_dir_archive }}
-      {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
+    object: "{{ __s3_object }}"
     tags: "{{ cloud_tags_final }}"
 ...

--- a/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3-s3_object.yml
+++ b/ansible/roles/agnosticd_save_output_dir/tasks/upload-archive-s3-s3_object.yml
@@ -10,9 +10,7 @@
       {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
     region: "{{ agnosticd_save_output_dir_s3_region }}"
     bucket: "{{ agnosticd_save_output_dir_s3_bucket }}"
-    object: >-
-      {{ agnosticd_save_output_dir_archive }}
-      {{- '.gpg' if agnosticd_save_output_dir_archive_password is defined else '' -}}
+    object: "{{ __s3_object }}"
     overwrite: always
     tags: "{{ cloud_tags_final }}"
 ...

--- a/ansible/roles/agnosticd_save_output_dir/vars/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/vars/main.yml
@@ -1,0 +1,10 @@
+---
+agnosticd_save_output_dir_access_files: >-
+  {{
+    query("ansible.builtin.fileglob", *(
+        query('ansible.builtin.nested', [output_dir], agnosticd_save_output_dir_access_fileglobs)
+        | map('ansible.builtin.path_join')
+      )
+    ) | map('ansible.builtin.basename') | ansible.builtin.unique
+  }}
+...


### PR DESCRIPTION
##### SUMMARY

Add `agnosticd_save_output_dir_access_archive` support to `agnosticd_save_output_dir` role to save archive which only contains access information for the environment.

This is useful for security monitoring and other tasks where we need to access to credentials generated during the installation that are not exposed to the user via `agnosticd_user_info`.

Feature is disabled by default and requires setting `agnosticd_save_output_dir_access_archive` on items where a separate access archive is desired due to the size of the primary access archive file.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role `agnosticd_save_output_dir`