### PR TITLE
Ai setup cuda extend versioning 01

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/defaults/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/defaults/main.yml
@@ -5,6 +5,8 @@
 
 setup_nvidia_cuda_python_version: '3.11'
 setup_nvidia_cuda_cuda_version: '12.4'
+setup_nvidia_cuda_cuda_major_version: '12'
+setup_nvidia_cuda_cuda_minor_version: '4'
 setup_nvidia_cuda_debug: false
 
 setup_nvidia_cuda_common_dnf_packages:

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
@@ -32,7 +32,7 @@
     - name: Set CUDA alternatives/cuda
       community.general.alternatives:
         name: cuda
-        path: "/usr/local/cuda-{{ setup_nvidia_cuda_cuda_version }}"
+        path: "/usr/local/cuda-{{ setup_nvidia_cuda_cuda_major_version }}-{{ setup_nvidia_cuda_cuda_minor_version }}"'
         link: /etc/alternatives/cuda
       tags:
         - nvidia-alternatives

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
@@ -32,7 +32,7 @@
     - name: Set CUDA alternatives/cuda
       community.general.alternatives:
         name: cuda
-        path: "/usr/local/cuda-{{ setup_nvidia_cuda_cuda_major_version }}-{{ setup_nvidia_cuda_cuda_minor_version }}"'
+        path: "/usr/local/cuda-{{ setup_nvidia_cuda_cuda_major_version }}-{{ setup_nvidia_cuda_cuda_minor_version }}"
         link: /etc/alternatives/cuda
       tags:
         - nvidia-alternatives


### PR DESCRIPTION
##### SUMMARY

Increase the flexibility of the CUDA setup collection role
Nvidia annoyingly uses both `x.y` and `x-y` in their versioning, this accommodates that

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

agnosticd.ai.setup_nvidia_cuda

##### ADDITIONAL INFORMATION
