### PR TITLE
ocp4-cluster: Don't set up isolated VMs with repos etc.

### DIFF
--- a/ansible/configs/ocp4-cluster/pre_software.yml
+++ b/ansible/configs/ocp4-cluster/pre_software.yml
@@ -13,7 +13,7 @@
 
 - name: Step 003.1 Configure all hosts with repositories, common files and set environment key
   hosts:
-  - all:!windows
+  - all:!windows!isolated
   become: true
   gather_facts: false
   tags:


### PR DESCRIPTION
##### SUMMARY

OCP4-cluster: Add the option to not set up additional VMs in CNV (or elsewhere) with repositories and common packages.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-cluster