### PR TITLE
[host-ocp4-assisted-installer] Set mac address to main interface

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -5,6 +5,7 @@
       - masquerade: {}
         model: virtio
         name: default
+        macAddress: "{{ ai_masters_macs[_index|int-1] }}"
       - name: "{{ network }}"
         macAddress: "{{ ai_masters_macs2[_index|int-1] }}"
         bridge: {}


### PR DESCRIPTION
##### SUMMARY

The mac address for the main interface was not set properly

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
