### PR TITLE
Add cloud tags to ROSA clusters

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
@@ -73,6 +73,18 @@
       _rosa_version_to_install: "{{ _latest_version.raw_id }}"
       _rosa_ocp_cli_version: "{{ _latest_version.raw_id }}"
 
+- name: Set cloud_tags_final if not already set
+  when: cloud_tags_final is not defined
+  ansible.builtin.include_role:
+    name: infra-cloud-tags
+
+# yamllint disable rule:line-length
+- name: Convert cloud tags_final to comma-separated list
+  ansible.builtin.set_fact:
+    cloud_tags_list: >-
+      {{ cloud_tags_final | dict2items | map(attribute='key') | zip(cloud_tags_final | dict2items | map(attribute='value')) | map('join', ' ') | join(', ') }}
+# yamllint enable rule:line-length
+
 - name: Print ROSA version to install
   ansible.builtin.debug:
     msg: "{{ item }}"
@@ -80,3 +92,4 @@
   - "ROSA Version to be installed: {{ _rosa_version_to_install }}"
   - "ROSA Version available to be upgraded to: {{ _rosa_version_next | default('not set') }}"
   - "OCP CLI to be installed: {{ _rosa_ocp_cli_version}}"
+  - "Cloud Tags to be added: {{ cloud_tags_list }}"

--- a/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_hcp.yml
@@ -109,6 +109,7 @@
       --operator-roles-prefix {{ rosa_cluster_name }}
       --oidc-config-id {{ rosa_oidc_id }}
       --subnet-ids {{ rosa_subnets }}
+      -- tags {{ cloud_tags_list }}
       {% if _rosa_version_to_install | default("") | length > 0 %}--version {{ _rosa_version_to_install }}{% endif %}
       {% if rosa_compute_machine_type is defined %}--compute-machine-type {{ rosa_compute_machine_type }}{% endif %}
       {% if rosa_compute_worker_disk_size is defined %}--worker-disk-size {{ rosa_compute_worker_disk_size }}{% endif %}

--- a/ansible/configs/rosa-consolidated/install_rosa_sts.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_sts.yml
@@ -6,6 +6,7 @@
     --mode auto
     --yes
 
+# cloud_tags_final
 - name: Create ROSA Classic (STS) Cluster
   ansible.builtin.command: >-
     {{ rosa_binary_path }}/rosa create cluster
@@ -14,6 +15,7 @@
     --sts
     --mode auto
     --yes
+    -- tags {{ cloud_tags_list }}
     {% if _rosa_version_to_install | default("") | length > 0 %}--version {{ _rosa_version_to_install }}{% endif %}
     {% if rosa_compute_machine_type is defined %}--compute-machine-type {{ rosa_compute_machine_type }}{% endif %}
     {% if rosa_compute_worker_disk_size is defined %}--worker-disk-size {{ rosa_compute_worker_disk_size }}{% endif %}


### PR DESCRIPTION
##### SUMMARY

ROSA clusters should have cloud_tags on their AWS instances just like ocp4-cluster.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated