### PR TITLE
[host-ocp4-assisted-installer] Update create_workers.yaml

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -5,6 +5,7 @@
       - masquerade: {}
         model: virtio
         name: default
+        macAddress: "{{ ai_workers_macs[_index|int-1] }}"
       - name: "{{ network }}"
         macAddress: "{{ ai_workers_macs2[_index|int-1] }}"
         bridge: {}


### PR DESCRIPTION
Set mac address to main interface

##### SUMMARY

new assisted installer is enforcing mac address for all interfaces

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer component

