### PR TITLE
ocp4_workload_odf: make label selector more robust

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -10,7 +10,9 @@
     - "!node-role.kubernetes.io/infra"
 
 - name: Add to label_selector list
-  when: ocp4_workload_openshift_data_foundation_add_selector is defined
+  when:
+  - ocp4_workload_openshift_data_foundation_add_selector is defined
+  - ocp4_workload_openshift_data_foundation_add_selector != ""
   ansible.builtin.set_fact:
     label_selector_list: "{{ label_selector_list + [ ocp4_workload_openshift_data_foundation_add_selector ] }}"
 


### PR DESCRIPTION
If common.yaml sets this, but dev.yaml wants to override it, allow use of selector ="".

don't append the value to the list when the variable is ""

- Bugfix Pull Request
