### PR TITLE
Add user data to output-dir access archive

### DIFF
--- a/ansible/roles/agnosticd_save_output_dir/defaults/main.yml
+++ b/ansible/roles/agnosticd_save_output_dir/defaults/main.yml
@@ -7,8 +7,9 @@
 
 # File glob patterns to match for access file archive if enabled
 agnosticd_save_output_dir_access_fileglobs:
-  - '*ssh*'
   - '*kubeconfig*'
+  - '*ssh*'
+  - 'provision-user-data.yaml'
 
 # Protect archive with password, it can be useful if the S3 bucket is shared between multiple users.
 #agnosticd_save_output_dir_archive_password: ...


### PR DESCRIPTION
##### SUMMARY

Add `provision-user-data.yaml` to access archive for `agnosticd_save_output_dir` as this data often includes important details for environment access.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role `agnosticd_save_output_dir`.