### PR TITLE
Fix collect_sos_report to not fail play on connection failure

### DIFF
--- a/ansible/roles/collect_sos_report/tasks/main.yml
+++ b/ansible/roles/collect_sos_report/tasks/main.yml
@@ -5,9 +5,11 @@
     prefix: sosreport-
     state: directory
   become: true
+  ignore_errors: true
   register: r_sos_tempdir
 
 - name: Collect sosreport
+  when: r_sos_tempdir is successful
   ansible.builtin.command:
     cmd: >-
       sos report --batch --tmp-dir {{ r_sos_tempdir.path }}
@@ -16,7 +18,9 @@
   register: r_sos_report
 
 - name: Fetch sos report when successfully generated
-  when: r_sos_report is successful
+  when:
+  - r_sos_report is successful
+  - r_sos_tempdir is successful
   block:
   - name: Find sos report file name
     ansible.builtin.find:


### PR DESCRIPTION
##### SUMMARY

- Fix collect_sos_report to not fail on failure to create tempdir so as allow destroy to complete other tasks.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role `collect_sos_report`