### PR TITLE
[infra-openshift-cnv-resources] Update create_routes.yaml

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_routes.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_routes.yaml
@@ -8,11 +8,12 @@
         name: "{{ route.name }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        host: "{{ route.host|default(route.name) }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}"
+          host: |-
+              {{ route.host|default(route.name) }}{% if route.tls_termination | default('passthrough') == 'passthrough' %}.{% else %}-{% endif %}{{ guid }}.{{ sandbox_openshift_apps_domain }}
         port:
           targetPort: "{{ route.targetPort }}"
         tls:
-          termination: passthrough
+          termination: "{{ route.tls_termination | default('passthrough') }}"
           insecureEdgeTerminationPolicy: None
         to:
           kind: Service


### PR DESCRIPTION
##### SUMMARY

This PR allows the option to to specify tls_termination for the routes, currently default is passthrough. But for many cases we want to use Edge.

Currently is generating the route as name.guid.apps.ocp_domain, if the termination is Edge will be name-guid.apps.ocp_domain to use the SSL certificate from the OCP cluster

Example:

```
  routes:
  - name: bastion-http
    host: bastion
    service: bastion
    targetPort: 80
    tls: true
    tls_termination: Edge
```

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources

