### PR TITLE
Add include_vars.yml in rosa-consolidated destroy

### DIFF
--- a/ansible/configs/rosa-consolidated/destroy_env.yml
+++ b/ansible/configs/rosa-consolidated/destroy_env.yml
@@ -28,6 +28,9 @@
   - name: Start instances
     ansible.builtin.include_tasks: ec2_instances_start.yaml
 
+- name: Include vars after adding hosts
+  ansible.builtin.import_playbook: ../../include_vars.yml
+
 - name: Destroy tasks on hosts
   hosts: all
   gather_facts: false


### PR DESCRIPTION
##### SUMMARY

- Add import of include_vars.yml playbook in rosa-consolidated destroy.
- Fixes issue with `agnosticd_collect_forensics` being undefined.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config rosa-consolidated