### PR TITLE
open-env-azure-add-user-to-subscription - Move from deprecated Azure …

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -30,7 +30,7 @@
     state: 'present'
     tenant: "{{ azure_tenant }}"
     present_members:
-      - "https://graph.windows.net/{{ azure_tenant }}/directoryObjects/{{ azuser.ad_users[0].object_id }}"
+      - "/directoryObjects/{{ azuser.ad_users[0].object_id }}"
 
 - name: Retrieving an available pool ID and locking it in CosmosDB
   ansible.builtin.uri:


### PR DESCRIPTION
This task is failing with a bad request. Looking at the task it seems to be using deprecated syntax. Updating and testing for a fix.
