### PR TITLE
[base-infra] Exclude isolated group from satellite config

### DIFF
--- a/ansible/configs/base-infra/pre_software.yml
+++ b/ansible/configs/base-infra/pre_software.yml
@@ -38,7 +38,7 @@
         name: create_ssh_provision_key
 
 - name: Configure all hosts with Repositories, and Common Files
-  hosts: all:!windows:!rhelai
+  hosts: all:!windows:!rhelai:!isolated
   become: true
   gather_facts: false
   tags:


### PR DESCRIPTION
##### SUMMARY

AnsibleGroup isolated should be specified to avoid the nodes to be registered to satellite. Similar as we do on ocp4-cluster config

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
base-infra config
