### PR TITLE
[host-ocp4-assisted-installer] Add maxSockets to workers

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -126,6 +126,7 @@
           cores: {{ ai_workers_cores | int }}
           sockets: 1
           threads: 1
+          maxSockets: 2
           model: host-passthrough
         devices:
           disks: {{ _instance_disks | replace('INSTANCENAME', vmname) }}


### PR DESCRIPTION

##### SUMMARY

Setting 64 vCPU causes the VM to dont start and throw this error:

            "message": "server error. command SyncVMI failed: \"LibvirtError(Code=67, Domain=10, Message='unsupported configuration: more than 255 vCPUs require extended interrupt mode enabled on the iommu device')\"",

KB: https://access.redhat.com/solutions/7086635

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer  role
