### PR TITLE
[WIP] Update Showroom role for private repos

### DIFF
--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -46,6 +46,8 @@ showroom_parasol_tab_title: Parasol
 # ----------------------------------------------------------------------
 showroom_git_repo: https://github.com/tonykay/showroom-poc-2023-06.git
 showroom_git_ref: main
+showroom_git_username: null           # if defined with showroom_git_token, pulls from private repo
+showroom_git_token: null              # if defined with showroom_git_username, pulls from private repo
 showroom_primary_path: "showroom/"    # this is the postfix to the URL where the UI is available
 showroom_ui: default                  # rhdev (RH Developer old UI) and zero-touch are options, extensible
 showroom_ui_zero_bundle: https://github.com/rhpds/nookbag/releases/download/nookbag-v0.0.4/nookbag-v0.0.4.zip

--- a/ansible/roles/showroom/tasks/30-showroom-clone-and-inject.yml
+++ b/ansible/roles/showroom/tasks/30-showroom-clone-and-inject.yml
@@ -6,7 +6,8 @@
       ansible.builtin.git:
         repo: >-  # Provides ability to clone private showroom repos
           {% if showroom_git_username is defined and showroom_git_token is defined %}
-          https://{{ showroom_git_username }}:{{ showroom_git_token }}@{{ showroom_git_repo | regex_replace('^https://', '') }}
+          https://{{ showroom_git_username }}:{{ showroom_git_token }}@\
+          {{ showroom_git_repo | regex_replace('^https://', '') }}
           {% else %}
           {{ showroom_git_repo }}
           {% endif %}

--- a/ansible/roles/showroom/tasks/30-showroom-clone-and-inject.yml
+++ b/ansible/roles/showroom/tasks/30-showroom-clone-and-inject.yml
@@ -4,7 +4,12 @@
 
     - name: Clone showroom primary repo - lab content in adoc
       ansible.builtin.git:
-        repo: "{{ showroom_git_repo }}"
+        repo: >-  # Provides ability to clone private showroom repos
+          {% if showroom_git_username is defined and showroom_git_token is defined %}
+          https://{{ showroom_git_username }}:{{ showroom_git_token }}@{{ showroom_git_repo | regex_replace('^https://', '') }}
+          {% else %}
+          {{ showroom_git_repo }}
+          {% endif %}
         dest: "{{ showroom_user_content_dir }}"
         force: true
         version: "{{ showroom_git_ref | default(showroom_git_tag) | default('main') }}"


### PR DESCRIPTION
##### SUMMARY

Adds two new vars to the showroom role to enable pulling from a private repo. This allows a lab developer to include some not-yet-public information in the lab guides for events.

The default value of these is set to `null`, so everything should continue working normally. If you do configure `showroom_git_username` and `showroom_git_token`, it will clone the private repo using this authentication.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
https://github.com/redhat-cop/agnosticd/tree/development/ansible/roles/showroom
