### PR TITLE
Add IBM Cloud binary to ee-multicloud

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/install_binaries.sh
+++ b/tools/execution_environments/ee-multicloud-public/install_binaries.sh
@@ -51,3 +51,6 @@ rm -rf aws
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 chmod 700 get_helm.sh
 ./get_helm.sh
+
+# IBM Cloud binary
+curl -fsSL https://clis.cloud.ibm.com/install/linux | sh


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY


Add the IBM Cloud binary to ee-multicloud execution environment.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- EE Pull Request
