### PR TITLE
[host-ocp4-assisted-installer] Update static_network_config_full.j2

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
+++ b/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
@@ -19,10 +19,10 @@
       type: ethernet
 {% for _network in ai_attach_masters_networks %}
     - ipv4:
-        dhcp: true
-        enabled: true
+        dhcp: false
+        enabled: false
       name: enp{{ loop.index+2 }}s0
-      state: up
+      state: down
       type: ethernet
 {% endfor %}
     routes:
@@ -62,10 +62,10 @@
       type: ethernet
 {% for _network in ai_attach_workers_networks %}
     - ipv4:
-        dhcp: true
-        enabled: true
+        dhcp: false
+        enabled: false
       name: enp{{ loop.index+2 }}s0
-      state: up
+      state: down
       type: ethernet
 {% endfor %}
     routes:


### PR DESCRIPTION
##### SUMMARY

Set extra interfaces as down, without dhcp request and without IP config. Version 4.18 requires to have an IP associated, so this PR solves installation issues.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role