### PR TITLE
Speed up EE creation by parallelizing the build in GitHub Action

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ The approvers and mergers shouldn't have to interpret and guess by jumping right
 - Feature Pull Request
 - New config Pull Request
 - New role Pull Request
+- EE Pull Request
 
 ##### COMPONENT NAME
 <!--- Write the short name of the config, roles, task or feature below -->

--- a/.github/workflows/build-ee-pr.yml
+++ b/.github/workflows/build-ee-pr.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - tools/execution_environments/ee-multicloud-public/**
+      - .github/workflows/build-ee*
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-ee.yml
+++ b/.github/workflows/build-ee.yml
@@ -26,6 +26,11 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
+    strategy:
+      # Run the same job on multiple platforms, amd64 and arm64
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -57,7 +62,7 @@ jobs:
           image: ee-multicloud
           tags: ${{inputs.tag}} ${{ github.sha }}
           labels: ${{ inputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           context: tools/execution_environments/ee-multicloud-public
           containerfiles: |-
             tools/execution_environments/ee-multicloud-public/Containerfile


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Speed up improvement: Parallelize the build of EE for the 2 platform amd64 and arm64.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- EE Pull Request
