### PR TITLE
Fix and modernize workload rhacm

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/defaults/main.yml
@@ -1,8 +1,4 @@
 ---
-become_override: false
-ocp_username: opentlc-mgr
-silent: false
-
 ocp4_workload_rhacm_acm_channel: release-2.11
 ocp4_workload_rhacm_acm_starting_csv: ""
 ocp4_workload_rhacm_use_catalog_snapshot: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/aws_credentials.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/aws_credentials.yml
@@ -8,13 +8,13 @@
   agnosticd_user_info:
     msg: "{{ item }}"
   loop:
-    - ""
-    - "Use the following credentials to deploy in the AWS sandbox account where your Hub is running."
-    - ""
-    - "  AWS_ACCESS_KEY_ID: {{ student_access_key_id }}"
-    - "  AWS_SECRET_ACCESS_KEY: {{ student_secret_access_key }}"
-    - "  Top level domain: {{ subdomain_base_suffix }}"
-    - ""
+  - ""
+  - "Use the following credentials to deploy in the AWS sandbox account where your Hub is running."
+  - ""
+  - "  AWS_ACCESS_KEY_ID: {{ student_access_key_id }}"
+  - "  AWS_SECRET_ACCESS_KEY: {{ student_secret_access_key }}"
+  - "  Top level domain: {{ subdomain_base_suffix }}"
+  - ""
 
 - name: Save AWS credentials in user data
   agnosticd_user_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/main.yml
@@ -1,30 +1,13 @@
 ---
+# --------------------------------------------------
 # Do not modify this file
-
-- name: Running Pre Workload Tasks
-  when: ACTION == "create" or ACTION == "provision"
+# --------------------------------------------------
+- name: Running workload provision tasks
+  when: ACTION == "provision"
   ansible.builtin.include_tasks:
-    file: ./pre_workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
+    file: workload.yml
 
-- name: Running Workload Tasks
-  when: ACTION == "create" or ACTION == "provision"
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
   ansible.builtin.include_tasks:
-    file: ./workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
-
-- name: Running Post Workload Tasks
-  when: ACTION == "create" or ACTION == "provision"
-  ansible.builtin.include_tasks:
-    file: ./post_workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
-
-- name: Running Workload removal Tasks
-  when: ACTION == "destroy" or ACTION == "remove"
-  ansible.builtin.include_tasks:
-    file: ./remove_workload.yml
-    apply:
-      become: "{{ become_override | bool }}"
+    file: remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/post_workload.yml
@@ -1,7 +1,0 @@
----
-# Leave this as the last task in the playbook.
-
-- name: post_workload tasks complete
-  ansible.builtin.debug:
-    msg: "Post-Workload Tasks completed successfully."
-  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/pre_workload.yml
@@ -1,8 +1,0 @@
----
-# Implement your Pre Workload deployment tasks here
-
-# Leave this as the last task in the playbook.
-- name: pre_workload tasks complete
-  ansible.builtin.debug:
-    msg: "Pre-Workload tasks completed successfully."
-  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/remove_workload.yml
@@ -1,10 +1,4 @@
 ---
-# Implement your Workload removal tasks here
-
-- name: Setting up workload for user
-  ansible.builtin.debug:
-    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
-
 - name: Remove RHACM MultiClusterHub
   kubernetes.core.k8s:
     state: absent
@@ -38,9 +32,3 @@
     install_operator_catalogsource_namespace: open-cluster-management
     install_operator_catalogsource_image: "{{ ocp4_workload_rhacm_catalog_source_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_rhacm_catalog_source_tag | default('') }}"
-
-# Leave this as the last task in the playbook.
-- name: remove_workload tasks complete
-  ansible.builtin.debug:
-    msg: "Remove Workload tasks completed successfully."
-  when: not silent|bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhacm/tasks/workload.yml
@@ -1,13 +1,4 @@
 ---
-# Implement your Workload deployment tasks here
-
-- name: Setting up workload for user
-  ansible.builtin.debug:
-    msg: "Setting up workload for user ocp_username = {{ ocp_username }}"
-
-# oc patch ingresscontroller -n openshift-ingress-operator default
-# --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission",
-# "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 - name: Update Router for Wildcards for HCP Hosted Clusters
   when: ocp4_workload_rhacm_enable_wildcards | bool
   kubernetes.core.k8s_json_patch:
@@ -16,10 +7,10 @@
     namespace: openshift-ingress-operator
     name: default
     patch:
-      - op: add
-        path: '/spec/routeAdmission'
-        value:
-          wildcardPolicy: WildcardsAllowed
+    - op: add
+      path: '/spec/routeAdmission'
+      value:
+        wildcardPolicy: WildcardsAllowed
 
 - name: Install RHACM operator
   ansible.builtin.include_role:
@@ -38,7 +29,7 @@
     install_operator_catalogsource_image: "{{ ocp4_workload_rhacm_catalog_source_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_rhacm_catalog_source_tag | default('') }}"
     install_operator_manage_namespaces:
-      - open-cluster-management
+    - open-cluster-management
 
 - name: Ensure RHACM MultiClusterHub is present
   kubernetes.core.k8s:
@@ -59,21 +50,12 @@
   retries: 120
   delay: 10
   until:
-    - rhacm_multiclusterhub is defined
-    - rhacm_multiclusterhub.resources is defined
-    - rhacm_multiclusterhub.resources | length > 0
-    - rhacm_multiclusterhub.resources[0].status is defined
-    - rhacm_multiclusterhub.resources[0].status.phase is defined
-    - rhacm_multiclusterhub.resources[0].status.phase == "Running"
-
-# RHACM Console route only exists for RHACM 2.6 and earlier
-- name: Get the RHACM console route
-  kubernetes.core.k8s_info:
-    api_version: route.openshift.io/v1
-    kind: Route
-    name: multicloud-console
-    namespace: open-cluster-management
-  register: r_acm_console_route
+  - rhacm_multiclusterhub is defined
+  - rhacm_multiclusterhub.resources is defined
+  - rhacm_multiclusterhub.resources | length > 0
+  - rhacm_multiclusterhub.resources[0].status is defined
+  - rhacm_multiclusterhub.resources[0].status.phase is defined
+  - rhacm_multiclusterhub.resources[0].status.phase == "Running"
 
 - name: Get Web Console route
   kubernetes.core.k8s_info:
@@ -90,28 +72,6 @@
     name: cluster
   register: r_api_url
 
-- name: For RHACM 2.6 and earlier save route to RHACM Console
-  when: r_acm_console_route.resources | length > 0
-  block:
-    - name: Set fact for RHACM route
-      ansible.builtin.set_fact:
-        acm_route: "{{ r_acm_console_route | json_query(route_query) }}"
-      vars:
-        - route_query: resources[].spec.host|[0]
-
-    - name: Print user info
-      agnosticd_user_info:
-        msg: "{{ item }}"
-      loop:
-        - ""
-        - "Your RHACM console is available at:"
-        - "  https://{{ acm_route }}"
-
-    - name: Save user data (RHACM Console)
-      agnosticd_user_info:
-        data:
-          acm_route: "https://{{ r_acm_console_route.resources[0].spec.host }}"
-
 - name: Save user data
   agnosticd_user_info:
     data:
@@ -120,13 +80,7 @@
 
 - name: Write out AWS credentials if deployed to EC2 sandbox
   when:
-    - cloud_provider == 'ec2'
-    - hostvars.localhost.cloudformation_out_final.stack_outputs.StudentUserAccessKey is defined
-    - hostvars.localhost.cloudformation_out_final.stack_outputs.StudentUserSecretAccessKey is defined
+  - cloud_provider == 'ec2'
+  - hostvars.localhost.cloudformation_out_final.stack_outputs.StudentUserAccessKey is defined
+  - hostvars.localhost.cloudformation_out_final.stack_outputs.StudentUserSecretAccessKey is defined
   ansible.builtin.include_tasks: aws_credentials.yml
-
-# Leave this as the last task in the playbook.
-- name: workload tasks complete
-  ansible.builtin.debug:
-    msg: "Workload Tasks completed successfully."
-  when: not silent|bool


### PR DESCRIPTION
##### SUMMARY

Logic for 2.6 and earlier broke in latest Ansible versions. Removing since no-one should be deploying 2.6 and earlier these days.

Update logic to new workload standard.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_rhacm