### PR TITLE
[ocp4_workload_5gran_deployments_lab] Add vd* to the possible disks available

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -22,7 +22,7 @@
     _diskname: "{{ '/dev/' + item.key }}"
   when:
     - not item.value.partitions
-    - item.key is search ("nvme*")
+    - item.key is search ("nvme*") or item.key is search ("vd*")
     - min_value|int <= item.value.sectors|int * item.value.sectorsize|int
     - extra_disk_libvirt_images is true
   vars:


### PR DESCRIPTION

##### SUMMARY

Moving from Equinix to CNV requires to use vdb as secondary disk

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_5gran_deployments_lab role
