### PR TITLE
Add EPEL to ensure certbot can be added

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/service_vm_jupyter_lab/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/service_vm_jupyter_lab/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Install EPEL for certbot
+  ansible.builtin.dnf:
+    name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+    state: present
+    validate_certs: no
+    disable_gpg_check: yes
+
 - name: Install required Python pip packages in virtualenv
   when: 
     service_vm_jupyter_lab_jupyter_pip_packages is defined 


### PR DESCRIPTION
##### SUMMARY

Jupyter needs certbot for zerossl

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

role: agnosticd.ai.service_vm_jupyter_lab

##### ADDITIONAL INFORMATION
