### PR TITLE
[ocp4_workload_virt_roadshow_vmware] Move to vmware.vmware.content_library_item_info

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_prerequisites.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_prerequisites.yml
@@ -111,20 +111,9 @@
       VMWARE_PASSWORD: "{{ vcenter_password }}"
       VMWARE_VALIDATE_CERTS: "{{ ocp4_workload_virt_roadshow_vmware_enable_cert_validation }}"
     block:
-    - name: Get all local content libraries
-      vmware.vmware_rest.content_locallibrary_info:
-      register: r_all_content_libraries
-
-    - name: Set template library ID fact
-      ansible.builtin.set_fact:
-        _ocp4_workload_virt_roadshow_vmware_template_library_id: >-
-          {{ (r_all_content_libraries.value |
-              selectattr('name', 'equalto', ocp4_workload_virt_roadshow_vmware_template_content_library) |
-              first).id }}
-
     - name: List all the items in the template library
       vmware.vmware.content_library_item_info:
-        library_item_id: "{{ _ocp4_workload_virt_roadshow_vmware_template_library_id }}"
+        library_name: "{{ ocp4_workload_virt_roadshow_vmware_template_content_library }}"
       register: r_templates
 
     - name: Set fact for list of templates

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_prerequisites.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/tasks/vcenter_setup_prerequisites.yml
@@ -123,10 +123,10 @@
               first).id }}
 
     - name: List all the items in the template library
-      vmware.vmware_rest.content_library_item_info:
-        library_id: "{{ _ocp4_workload_virt_roadshow_vmware_template_library_id }}"
+      vmware.vmware.content_library_item_info:
+        library_item_id: "{{ _ocp4_workload_virt_roadshow_vmware_template_library_id }}"
       register: r_templates
 
     - name: Set fact for list of templates
       ansible.builtin.set_fact:
-        _ocp4_workload_virt_roadshow_vmware_templates: "{{ r_templates.value }}"
+        _ocp4_workload_virt_roadshow_vmware_templates: "{{ r_templates.library_item_info }}"


### PR DESCRIPTION
##### SUMMARY

vmware.vmware_rest.content_library_item_info is throwing error: ""Unsupported property with name: library_id?library_id." with new version

Please refer to: https://github.com/ansible-collections/vmware.vmware_rest/issues/540

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_virt_roadshow_vmware role
