### PR TITLE
fix: mad roadshow rhdh pull secret

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/rhdh/application_rhdh_backstage.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mad_roadshow/templates/rhdh/application_rhdh_backstage.yaml.j2
@@ -52,8 +52,6 @@ spec:
         - name: upstream.backstage.appConfig.backend.database.connection.port
           value: "{{ ocp4_workload_redhat_developer_hub_postgresql_databasePort }}"
           forceString: true
-        - name: upstream.backstage.image.pullSecrets[0]
-          value: "mad-developer-hub-pull-secret"
         - name: upstream.backstage.image.registry
           value: {{ ocp4_workload_mad_roadshow_rhdh_image_registry }}
         - name: upstream.backstage.image.repository

--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
@@ -45,6 +45,8 @@
 
 - name: Update resources for openshift-gitops ArgoCD instance
   when: ocp4_workload_platform_engineering_workshop_openshift_gitops_update_resources | bool
+  retries: 10
+  delay: 30
   kubernetes.core.k8s:
     state: patched
     definition: "{{ lookup('template', 'openshift-gitops/openshift-gitops.yaml.j2') | from_yaml }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/openshift_gitops.yml
@@ -45,8 +45,6 @@
 
 - name: Update resources for openshift-gitops ArgoCD instance
   when: ocp4_workload_platform_engineering_workshop_openshift_gitops_update_resources | bool
-  retries: 10
-  delay: 30
   kubernetes.core.k8s:
     state: patched
     definition: "{{ lookup('template', 'openshift-gitops/openshift-gitops.yaml.j2') | from_yaml }}"


### PR DESCRIPTION
##### SUMMARY

MAD Roadshow developer track fails to deploy since this pullSecret is undefined, I think. When I remove this from the ArgoCD manifest in my environment the deployment is fixed. 
issue. CC @varodrig @danieloh30 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_mad_roadshow

##### ADDITIONAL INFORMATION
If you provision the current workshop the rhdhub namespace has a failed deployment for RHDH. Removing this line from the manifest resolves it. The secret is not required to pull the image.