### PR TITLE
Fix FSX Post Install

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-ocp4_workload_lb2739_first_rosa_cidr: ""
+ocp4_workload_lb2739_first_rosa_cidr: "10.0.0.0/16"
 
 ocp4_workload_lb2739_second_rosa_name: "dr-{{ guid }}"
 ocp4_workload_lb2739_second_rosa_cidr: "10.10.0.0/16"
@@ -10,6 +10,8 @@ ocp4_workload_lb2739_second_rosa_binary_path: "/usr/local/bin"
 ocp4_workload_lb2739_second_rosa_installer_version: latest
 ocp4_workload_lb2739_second_rosa_installer_url: >-
   https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/{{ rosa_installer_version }}/rosa-linux.tar.gz
+
+ocp4_workload_lb2739_bastion_cidr: "192.168.0.0/16"
 
 ocp4_workload_lb2739_fsx_name1: PROD-FSXONTAP
 ocp4_workload_lb2739_fsx_name2: DR-FSXONTAP

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
@@ -10,7 +10,8 @@
 
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
-      password_fsx_admin_combined: "{{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') | trim }}"
+      password_fsx_admin_combined: |-
+        {{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') | trim }}
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
@@ -42,7 +43,8 @@
 
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
-      password_svm_admin_combined: "{{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') | trim }}"
+      password_svm_admin_combined: |-
+        {{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') | trim }}
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
@@ -10,15 +10,15 @@
 
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
-      password_fsx_admin_combined: "{{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') }}"
+      password_fsx_admin_combined: "{{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') | trim }}"
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
-      _ocp4_workload_lb2739_fsx_admin_password: >-
+      _ocp4_workload_lb2739_fsx_admin_password: |-
         {% if password_fsx_admin_combined[0].isdigit() %}
-        {{ password_fsx_admin_combined[1:] + password_fsx_admin_combined[0] }}
+        {{ (password_fsx_admin_combined[1:] + password_fsx_admin_combined[0]) | trim }}
         {% else %}
-        {{ password_fsx_admin_combined }}
+        {{ password_fsx_admin_combined | trim }}
         {% endif %}
 
   - name: Debug the generated fsx admin password
@@ -28,8 +28,8 @@
 - name: Use provided fsx admin password
   when: ocp4_workload_lb2739_fsx_admin_password | default('') | length > 0
   ansible.builtin.set_fact:
-    _ocp4_workload_lb2739_fsx_admin_password: >-
-      {{ ocp4_workload_lb2739_fsx_admin_password }}
+    _ocp4_workload_lb2739_fsx_admin_password: |-
+      {{ ocp4_workload_lb2739_fsx_admin_password | trim }}
 
 - name: Generate svm admin password and make sure it contains numbers
   when: ocp4_workload_lb2739_svm_admin_password | default('') | length == 0
@@ -42,15 +42,15 @@
 
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
-      password_svm_admin_combined: "{{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') }}"
+      password_svm_admin_combined: "{{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') | trim }}"
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
-      _ocp4_workload_lb2739_svm_admin_password: >-
+      _ocp4_workload_lb2739_svm_admin_password: |-
         {% if password_svm_admin_combined[0].isdigit() %}
-        {{ password_svm_admin_combined[1:] + password_svm_admin_combined[0] }}
+        {{ (password_svm_admin_combined[1:] + password_svm_admin_combined[0]) | trim }}
         {% else %}
-        {{ password_svm_admin_combined }}
+        {{ password_svm_admin_combined | trim }}
         {% endif %}
 
   - name: Debug the generated svm admin password
@@ -60,8 +60,8 @@
 - name: Use provided svm admin password
   when: ocp4_workload_lb2739_svm_admin_password | default('') | length > 0
   ansible.builtin.set_fact:
-    _ocp4_workload_lb2739_svm_admin_password: >-
-      {{ ocp4_workload_lb2739_svm_admin_password }}
+    _ocp4_workload_lb2739_svm_admin_password: |-
+      {{ ocp4_workload_lb2739_svm_admin_password | trim }}
 
 - name: Get subnet ID for first ROSA cluster
   amazon.aws.ec2_vpc_subnet_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap_post_config.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap_post_config.yml
@@ -2,19 +2,19 @@
 - name: Get Prod VPC
   amazon.aws.ec2_vpc_net_info:
     filters:
-      "cidr": 10.0.0.0/16
+      "cidr": "{{ ocp4_workload_lb2739_first_rosa_cidr }}"
   register: prod_vpc
 
 - name: Get DR VPC
   amazon.aws.ec2_vpc_net_info:
     filters:
-      "cidr": 10.10.0.0/16
+      "cidr": "{{ ocp4_workload_lb2739_second_rosa_cidr }}"
   register: dr_vpc
 
 - name: Get Bastion VPC
   amazon.aws.ec2_vpc_net_info:
     filters:
-      "cidr": 192.168.0.0/16
+      "cidr": "{{ ocp4_workload_lb2739_bastion_cidr }}"
   register: bastion_vpc
 
 - name: Create VPC Peering Connection between ROSA VPCs
@@ -75,6 +75,7 @@
   amazon.aws.ec2_vpc_route_table_info:
     filters:
       "tag:Stack": "rosa-consolidated*"
+      vpc-id: "{{ bastion_vpc.vpcs[0].vpc_id }}"
   register: bastion_route
 
 - name: Setup route tables for prod
@@ -86,7 +87,7 @@
     purge_routes: false
     route_table_id: "{{ prod_route.route_tables[0].route_table_id }}"
     routes:
-    - dest: 10.10.0.0/16
+    - dest: "{{ ocp4_workload_lb2739_second_rosa_cidr | default('10.10.0.0/16') }}"
       vpc_peering_connection_id: "{{ vpc_peering.vpc_peering_connection.vpc_peering_connection_id }}"
     - dest: 192.168.0.0/16
       vpc_peering_connection_id: "{{ vpc_peering_bastion1.vpc_peering_connection.vpc_peering_connection_id }}"
@@ -100,10 +101,14 @@
     purge_routes: false
     route_table_id: "{{ dr_route.route_tables[0].route_table_id }}"
     routes:
-    - dest: 10.0.0.0/16
+    - dest: "{{ ocp4_workload_lb2739_first_rosa_cidr | default('10.0.0.0/16') }}"
       vpc_peering_connection_id: "{{ vpc_peering.vpc_peering_connection.vpc_peering_connection_id }}"
     - dest: 192.168.0.0/16
       vpc_peering_connection_id: "{{ vpc_peering_bastion2.vpc_peering_connection.vpc_peering_connection_id }}"
+
+- name: Debug bastion output route table
+  ansible.builtin.debug:
+    msg: "Bastion Route Table ID is: {{ bastion_route.route_tables[0].route_table_id }}. Route table content: {{ bastion_route.route_tables }}"
 
 - name: Setup route tables for Bastion
   amazon.aws.ec2_vpc_route_table:
@@ -114,9 +119,9 @@
     purge_routes: false
     route_table_id: "{{ bastion_route.route_tables[0].route_table_id }}"
     routes:
-    - dest: 10.0.0.0/16
+    - dest: "{{ ocp4_workload_lb2739_first_rosa_cidr }}"
       vpc_peering_connection_id: "{{ vpc_peering_bastion1.vpc_peering_connection.vpc_peering_connection_id }}"
-    - dest: 10.10.0.0/16
+    - dest: "{{ ocp4_workload_lb2739_second_rosa_cidr }}"
       vpc_peering_connection_id: "{{ vpc_peering_bastion2.vpc_peering_connection.vpc_peering_connection_id }}"
 
 - name: Get Prod FSxN Security Group
@@ -145,22 +150,22 @@
     - proto: tcp
       ports:
       - 3260
-      cidr_ip: 10.0.0.0/16
+      cidr_ip: "{{ ocp4_workload_lb2739_first_rosa_cidr }}"
       rule_desc: iSCSI
     - proto: tcp
       ports:
       - 11104
-      cidr_ip: 10.0.0.0/8
+      cidr_ip: "{{ ocp4_workload_lb2739_first_rosa_cidr | replace('/16', '/8') }}"
       rule_desc: Peering1
     - proto: tcp
       ports:
       - 11105
-      cidr_ip: 10.0.0.0/8
+      cidr_ip: "{{ ocp4_workload_lb2739_first_rosa_cidr | replace('/16', '/8') }}"
       rule_desc: Peering2
     - proto: tcp
       ports:
       - 443
-      cidr_ip: 192.168.0.0/16
+      cidr_ip: "{{ ocp4_workload_lb2739_bastion_cidr }}"
       rule_desc: API
 
 - name: Setup DR FSXN Security Group
@@ -175,22 +180,22 @@
     - proto: tcp
       ports:
       - 3260
-      cidr_ip: 10.10.0.0/16
+      cidr_ip: "{{ ocp4_workload_lb2739_second_rosa_cidr }}"
       rule_desc: iSCSI
     - proto: tcp
       ports:
       - 11104
-      cidr_ip: 10.0.0.0/8
+      cidr_ip: "{{ ocp4_workload_lb2739_first_rosa_cidr | replace('/16', '/8') }}"
       rule_desc: Peering1
     - proto: tcp
       ports:
       - 11105
-      cidr_ip: 10.0.0.0/8
+      cidr_ip: "{{ ocp4_workload_lb2739_first_rosa_cidr | replace('/16', '/8') }}"
       rule_desc: Peering2
     - proto: tcp
       ports:
       - 443
-      cidr_ip: 192.168.0.0/16
+      cidr_ip: "{{ ocp4_workload_lb2739_bastion_cidr }}"
       rule_desc: API
 
 - name: Get data of first FsxN
@@ -270,6 +275,10 @@
       host: "{{ _rosa_openshift_api_url }}"
       api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
       state: absent
+
+- name: Debug FSX password
+  ansible.builtin.debug:
+    msg: "FSX Admin Password: '{{ _ocp4_workload_lb2739_fsx_admin_password }}'"
 
 - name: Create FSxN cluster peering Prod --> DR
   ansible.builtin.uri:


### PR DESCRIPTION
##### SUMMARY

Multiple bugfixes:
- Not specific enough filter to get Bastion VPC
- Generated passwords had leading and trailing spaces
- Make all CIDRs variables.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_lb2739