### PR TITLE
Fixes bootonce for hcp lab

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_telco_hypershift_lab/tasks/pre_workload.yml
@@ -214,7 +214,7 @@
 
 - name: Ensure ksushy is installed
   ansible.builtin.shell:
-    cmd: kcli create sushy-service --ssl --port 9000
+    cmd: kcli create sushy-service --ssl --port 9000 --bootonce
 
 - name: Ensure lab VMs exist
   ansible.builtin.shell:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Fixes bootonce so nodes can be rebooted from CD.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_telco_hypershift_lab
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
