### PR TITLE
Remove newline from end of the password

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
@@ -10,12 +10,12 @@
 
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
-      password_fsx_admin_combined: |-
+      password_fsx_admin_combined: >-
         {{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') | trim }}
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
-      _ocp4_workload_lb2739_fsx_admin_password: |-
+      _ocp4_workload_lb2739_fsx_admin_password: >-
         {% if password_fsx_admin_combined[0].isdigit() %}
         {{ (password_fsx_admin_combined[1:] + password_fsx_admin_combined[0]) | trim }}
         {% else %}
@@ -29,7 +29,7 @@
 - name: Use provided fsx admin password
   when: ocp4_workload_lb2739_fsx_admin_password | default('') | length > 0
   ansible.builtin.set_fact:
-    _ocp4_workload_lb2739_fsx_admin_password: |-
+    _ocp4_workload_lb2739_fsx_admin_password: >-
       {{ ocp4_workload_lb2739_fsx_admin_password | trim }}
 
 - name: Generate svm admin password and make sure it contains numbers
@@ -43,12 +43,12 @@
 
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
-      password_svm_admin_combined: |-
+      password_svm_admin_combined: >-
         {{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') | trim }}
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
-      _ocp4_workload_lb2739_svm_admin_password: |-
+      _ocp4_workload_lb2739_svm_admin_password: >-
         {% if password_svm_admin_combined[0].isdigit() %}
         {{ (password_svm_admin_combined[1:] + password_svm_admin_combined[0]) | trim }}
         {% else %}
@@ -62,7 +62,7 @@
 - name: Use provided svm admin password
   when: ocp4_workload_lb2739_svm_admin_password | default('') | length > 0
   ansible.builtin.set_fact:
-    _ocp4_workload_lb2739_svm_admin_password: |-
+    _ocp4_workload_lb2739_svm_admin_password: >-
       {{ ocp4_workload_lb2739_svm_admin_password | trim }}
 
 - name: Get subnet ID for first ROSA cluster


### PR DESCRIPTION
##### SUMMARY

|- filter added '\n' to end of line. Changing back to \>-' which should (in combination with | trim) remove that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_lb2739