### PR TITLE
Fix trim

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ibm_fusion/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ibm_fusion/defaults/main.yml
@@ -14,7 +14,7 @@ ocp4_workload_ibm_fusion_installplan_approval: false
 ocp4_workload_ibm_fusion_entitlement_key: ""
 
 # Enable Global Data Platform
-ocp4_workload_ibm_fusion_deploy_global_data_platform: true
+ocp4_workload_ibm_fusion_deploy_global_data_platform: false
 
 # --------------------------------
 # ODF Manager system parameters

--- a/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_lb2739/tasks/setup_fsxontap.yml
@@ -11,20 +11,24 @@
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
       password_fsx_admin_combined: >-
-        {{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') | trim }}
+        {{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') }}
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
-      _ocp4_workload_lb2739_fsx_admin_password: >-
+      _ocp4_workload_lb2739_fsx_admin_password_tmp: >-
         {% if password_fsx_admin_combined[0].isdigit() %}
-        {{ (password_fsx_admin_combined[1:] + password_fsx_admin_combined[0]) | trim }}
+        {{ (password_fsx_admin_combined[1:] + password_fsx_admin_combined[0]) }}
         {% else %}
-        {{ password_fsx_admin_combined | trim }}
+        {{ password_fsx_admin_combined }}
         {% endif %}
+
+  - name: Trim fsx password
+    ansible.builtin.set_fact:
+      _ocp4_workload_lb2739_fsx_admin_password: "{{ _ocp4_workload_lb2739_fsx_admin_password_tmp | trim }}"
 
   - name: Debug the generated fsx admin password
     ansible.builtin.debug:
-      msg: "Generated Password: {{ _ocp4_workload_lb2739_fsx_admin_password }}"
+      msg: "Generated Password: '{{ _ocp4_workload_lb2739_fsx_admin_password }}'"
 
 - name: Use provided fsx admin password
   when: ocp4_workload_lb2739_fsx_admin_password | default('') | length > 0
@@ -44,20 +48,24 @@
   - name: Combine and shuffle password components
     ansible.builtin.set_fact:
       password_svm_admin_combined: >-
-        {{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') | trim }}
+        {{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') }}
 
   - name: Ensure the first character is not a digit
     ansible.builtin.set_fact:
-      _ocp4_workload_lb2739_svm_admin_password: >-
+      _ocp4_workload_lb2739_svm_admin_password_tmp: >-
         {% if password_svm_admin_combined[0].isdigit() %}
-        {{ (password_svm_admin_combined[1:] + password_svm_admin_combined[0]) | trim }}
+        {{ (password_svm_admin_combined[1:] + password_svm_admin_combined[0]) }}
         {% else %}
-        {{ password_svm_admin_combined | trim }}
+        {{ password_svm_admin_combined }}
         {% endif %}
+
+  - name: Trim svm password
+    ansible.builtin.set_fact:
+      _ocp4_workload_lb2739_svm_admin_password: "{{ _ocp4_workload_lb2739_svm_admin_password_tmp | trim }}"
 
   - name: Debug the generated svm admin password
     ansible.builtin.debug:
-      msg: "Generated Password: {{ _ocp4_workload_lb2739_svm_admin_password }}"
+      msg: "Generated Password: '{{ _ocp4_workload_lb2739_svm_admin_password }}'"
 
 - name: Use provided svm admin password
   when: ocp4_workload_lb2739_svm_admin_password | default('') | length > 0


### PR DESCRIPTION
##### SUMMARY

Somehow the logic still created passwords with leading/trailing space. Setting a temp variable and using trim on that one to fix.

Also changing default in IBM Fusion workload to not deploy data protection platform.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_lb2739
ocp4_workload_ibm_fusion