### PR TITLE
ibmcloud improvements: user-data, cloud-config, multi-region fix

### DIFF
--- a/ansible/cloud_providers/ibm_resource_group_destroy_env.yml
+++ b/ansible/cloud_providers/ibm_resource_group_destroy_env.yml
@@ -11,26 +11,37 @@
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
     ibm.cloudcollection.ibm_is_ssh_key:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_vpc:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_subnet:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_security_group:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_security_group_rule:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_instance:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_images_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_floating_ip:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_instances_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_vpc_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_ssh_key_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
   tasks:
     - name: Run infra-ibm-resource-group-resources
       ansible.builtin.include_role:

--- a/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
@@ -15,22 +15,33 @@
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
     ibm.cloudcollection.ibm_is_ssh_key:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
+    ibm.cloudcollection.ibm_is_ssh_key_info:
+      ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_vpc:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_subnet:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_security_group:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_security_group_rule:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_instance:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_images_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
     ibm.cloudcollection.ibm_is_floating_ip:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_instances_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
   tasks:
     - name: Create ssh provision key
       ansible.builtin.include_role:
@@ -58,8 +69,10 @@
   module_defaults:
     ibm.cloudcollection.ibm_is_instances_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
     ibm.cloudcollection.ibm_is_floating_ips_info:
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+      region: "{{ ibmcloud_region }}"
   tasks:
 
     - name: Run infra-dns Role

--- a/ansible/configs/rosa-consolidated/pre_software.yml
+++ b/ansible/configs/rosa-consolidated/pre_software.yml
@@ -24,6 +24,7 @@
       path: "~{{ ansible_user }}/.bashrc"
       regexp: "^export GUID"
       line: "export GUID={{ guid }}"
+      create: true
 
   - name: Use provided user password
     when: bastion_user_password | default("") | length > 0

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
@@ -3,6 +3,7 @@
   ibm.cloudcollection.ibm_is_floating_ips_info:
     name: "{{ instance.name }}-fip"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
+    region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_floating_ips
 
 - name: Initialize tags_dict variable

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/create_inventory.yaml
@@ -2,6 +2,7 @@
 - name: Get list of the instances
   ibm.cloudcollection.ibm_is_instances_info:
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
+    region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_instances
 
 - name: Include add host task for each instance

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -60,6 +60,7 @@
     state: available
     target: "{{ ibmcloud_vs_instance_create.resource.primary_network_interface[0]['id'] }}"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
+    region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_fip
 
 - name: Print Floating IP Address

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -48,6 +48,7 @@
       - enabled: true
         protocol: https
         response_hop_limit: 5
+    user_data: "{{ instance.user_data | default(omit, true) }}"
 
 - name: Save fact for IBM Cloud Virtual Server (VS) instance
   ansible.builtin.set_fact:

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_networks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_networks.yaml
@@ -7,6 +7,25 @@
     state: available
     region: "{{ ibmcloud_region }}"
 
+- name: Pick an availability zone
+  set_fact:
+    ibmcloud_availability_zones: >-
+      {{ ibmcloud_vpc_create.resource.cse_source_addresses
+      | default ([])
+      | map(attribute='zone_name')
+      | list
+      | shuffle }}
+
+- when: ibmcloud_availability_zones | length == 0
+  name: Set default availability zone if none found
+  set_fact:
+    ibmcloud_availability_zones:
+      - "{{ ibmcloud_region }}-1"
+
+- name: Set availability zone
+  set_fact:
+    ibmcloud_availability_zone: "{{ ibmcloud_availability_zones[0] }}"
+
 - name: Create VPC Subnet
   register: ibmcloud_vpc_subnet_create
   ibm.cloudcollection.ibm_is_subnet:

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
@@ -2,6 +2,7 @@
 - name: Delete IBM Cloud Virtual Server (VS) instance
   register: ibmcloud_vs_instance_create
   ibm.cloudcollection.ibm_is_instance:
+    region: "{{ ibmcloud_region }}"
     state: absent
     name: "{{ instance.name }}"
     id: "{{ instance.id }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instances.yaml
@@ -2,6 +2,7 @@
 - name: Get list of the instances
   ibm.cloudcollection.ibm_is_instances_info:
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
+    region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_instances
 
 - name: Delete Instances

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/start_instances.yaml
@@ -1,11 +1,13 @@
 ---
 - name: List all IBM Cloud instances
   ibm.cloudcollection.instance_info:
+    region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_instances
 
 - name: Start all running instances
   ibm.cloudcollection.instance:
     id: "{{ item['id'] }}"
+    region: "{{ ibmcloud_region }}"
     state: running
   with_items: "{{ r_ibmcloud_instances.instances }}"
   when: item['status'] == 'stopped'

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/stop_instances.yaml
@@ -1,11 +1,13 @@
 ---
 - name: List all IBM Cloud instances
   ibm.cloudcollection.instance_info:
+    region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_instances
 
 - name: Start all stopped instances
   ibm.cloudcollection.instance:
     id: "{{ item['id'] }}"
     state: running
+    region: "{{ ibmcloud_region }}"
   with_items: "{{ r_ibmcloud_instances }}"
   when: item['status'] == 'stopped'

--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -39,6 +39,7 @@
     path: "~{{ ansible_user }}/.bashrc"
     regexp: "^export GUID"
     line: "export GUID={{ guid }}"
+    create: true
 
   # TODO: Is there any value in doing the below?
   #       Discuss with team and consider "per cloud" includes

--- a/ansible/roles/bastion-lite/tasks/main.yml
+++ b/ansible/roles/bastion-lite/tasks/main.yml
@@ -49,6 +49,7 @@
     path: "~{{ ansible_user }}/.bashrc"
     regexp: "^export GUID"
     line: "export GUID={{ guid }}"
+    create: true
 
 - name: Add CLOUDUSER to /etc/skel/.bashrc
   ansible.builtin.lineinfile:

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -106,6 +106,7 @@
         bastion_public_hostname: "{{ bastion_public_hostname }}"
         bastion_ssh_password: "{{ student_password }}"
         bastion_ssh_user_name: "{{ student_name }}"
+        bastion_ssh_command: "ssh {{ student_name }}@{{ bastion_public_hostname }}"
 
   - name: Set bastion port for CNV
     when: cloud_provider == "openshift_cnv"


### PR DESCRIPTION
##### SUMMARY

- Allow user to pass user-data to configure each instance. It can be a bash script or a cloud-config yaml. See https://cloud.ibm.com/docs/vpc?topic=vpc-user-data
- Fix ibmcloud cloud provider to be multi-region. Add the region parameter to modules everywhere
- small fix in the bastion modules: add `create` to `lineinfile` for case when the file doesn't exist.
- add `bastion_ssh_command` to babylon user data, to display in info-template

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- ibmcloud  cloud provider

