### PR TITLE
[ocp4_workload_virt_roadshow_vms] Add a variable to decide if create services and routes for imported VMs

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/defaults/main.yml
@@ -23,3 +23,6 @@ ocp4_workload_virt_roadshow_vms_base_namespace: vmimported-
 # work until instructions are followed.
 # When false the application will work out of the box without changes
 ocp4_workload_virt_roadshow_vms_roadshow_setup: true
+
+# Configure services and routes for imported VMs or not
+ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/tasks/workload.yml
@@ -9,6 +9,17 @@
   - single_user/vm_database.yaml.j2
   - single_user/vm_winweb01.yaml.j2
   - single_user/vm_winweb02.yaml.j2
+  loop_control:
+    loop_var: resource
+
+- name: Set up services and routes for admin user
+  when: 
+    - ocp4_workload_virt_roadshow_vms_num_users | default("1") | int == 1
+    - ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route | default(true)
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', resource | from_yaml) }}"
+  loop:
   - single_user/service_database.yaml.j2
   - single_user/service_webapp.yaml.j2
   - single_user/route_webapp.yaml.j2
@@ -26,6 +37,17 @@
   - multi_user/vm_database.yaml.j2
   - multi_user/vm_winweb01.yaml.j2
   - multi_user/vm_winweb02.yaml.j2
+  loop_control:
+    loop_var: resource
+
+- name: Set up services and routes for multiple users
+  when: 
+    - ocp4_workload_virt_roadshow_vms_num_users | default("1") | int > 1
+    - ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route | default(true)
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', resource | from_yaml) }}"
+  loop:
   - multi_user/service_database.yaml.j2
   - multi_user/service_webapp.yaml.j2
   - multi_user/route_webapp.yaml.j2

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vms/tasks/workload.yml
@@ -13,9 +13,9 @@
     loop_var: resource
 
 - name: Set up services and routes for admin user
-  when: 
-    - ocp4_workload_virt_roadshow_vms_num_users | default("1") | int == 1
-    - ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route | default(true)
+  when:
+  - ocp4_workload_virt_roadshow_vms_num_users | default("1") | int == 1
+  - ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route | default(true)
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', resource | from_yaml) }}"
@@ -41,9 +41,9 @@
     loop_var: resource
 
 - name: Set up services and routes for multiple users
-  when: 
-    - ocp4_workload_virt_roadshow_vms_num_users | default("1") | int > 1
-    - ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route | default(true)
+  when:
+  - ocp4_workload_virt_roadshow_vms_num_users | default("1") | int > 1
+  - ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route | default(true)
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', resource | from_yaml) }}"


### PR DESCRIPTION
##### SUMMARY

Add new variable called ocp4_workload_virt_roadshow_vms_imported_configure_svc_and_route to decide if the Servcie and the Route for the pre-imported VMs are created or not

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_virt_roadshow_vms role
