### PR TITLE
[infra-openshift-cnv-resources] Add the option of Type LoadBalancer to assign external IP

### DIFF
--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -28,43 +28,9 @@
     - post_software
 
   tasks:
-    - name: report access information for cnv (Dedicated IP)
-      when:
-        - cloud_provider == "openshift_cnv"
-        - openshift_cnv_instance_external_ip | default("") != ""
-      vars:
-        _bastion_inventory_name: "{{ groups['bastions'][0] }}"
-        _bastion_ssh_password: "{{ hostvars[bastion_hostname]['student_password'] }}"
-        _kubeadmin_password: "{{ hostvars[bastion_hostname]['kubeadmin_password']['content'] | b64decode }}"
-      block:
-        - name: print access user info
-          agnosticd_user_info:
-            msg: |
-              you can access your bastion via ssh:
-              ssh {{ student_name }}@{{ openshift_cnv_instance_external_ip }}
-
-              enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
-
-        - name: save user data
-          agnosticd_user_info:
-            data:
-              cloud_provider: "{{ cloud_provider }}"
-              ssh_command: "ssh {{ student_name }}@{{ openshift_cnv_instance_external_ip }}"
-              ssh_password: "{{ student_password }}"
-              ssh_username: "{{ student_name }}"
-              guid: "{{ guid }}"
-              targethost: "{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
-              targetport: "{{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
-              subdomain: "{{ guid }}{{ subdomain_base_suffix }}"
-              subdomain_internal: "{{ chomped_zone_internal_dns | default('') }}"
-          vars:
-            student_name: "{{ ansible_service_account_user_name }}"
-          register: r_user_data
-
     - name: report access information for cnv
       when:
         - cloud_provider == "openshift_cnv"
-        - openshift_cnv_instance_external_ip | default("") == ""
       vars:
         _bastion_inventory_name: "{{ groups['bastions'][0] }}"
         _bastion_ssh_password: "{{ hostvars[bastion_hostname]['student_password'] }}"
@@ -77,6 +43,14 @@
               ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
 
               enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
+
+        - name: Print the external instance IP
+          agnosticd_user_info:
+            msg: |
+
+              Use the IP {{ openshift_cnv_instance_external_ip }} to access port 80, 443 and 8080
+          when:
+            - openshift_cnv_instance_external_ip | default("") != ""
 
         - name: save user data
           agnosticd_user_info:

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -28,7 +28,7 @@
     - post_software
 
   tasks:
-    - name: report access information for cnv
+    - name: Report access information for cnv
       when:
         - cloud_provider == "openshift_cnv"
       vars:
@@ -36,13 +36,13 @@
         _bastion_ssh_password: "{{ hostvars[bastion_hostname]['student_password'] }}"
         _kubeadmin_password: "{{ hostvars[bastion_hostname]['kubeadmin_password']['content'] | b64decode }}"
       block:
-        - name: print access user info
+        - name: Print access user info
           agnosticd_user_info:
             msg: |
-              you can access your bastion via ssh:
+              You can access your bastion via ssh:
               ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
 
-              enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
+              Enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
 
         - name: Print the external instance IP
           agnosticd_user_info:

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -48,9 +48,9 @@
           agnosticd_user_info:
             msg: |
 
-              Use the IP {{ openshift_cnv_instance_external_ip }} to access port 80, 443 and 8080
+              Use the IP {{ hostvars[bastion_hostname]['external_ip']}} to access ports: {{ hostvars[bastion_hostname]['external_ports'] }}
           when:
-            - openshift_cnv_instance_external_ip | default("") != ""
+            - hostvars[bastion_hostname]['external_ip']
 
         - name: save user data
           agnosticd_user_info:

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -28,23 +28,57 @@
     - post_software
 
   tasks:
-    - name: Report Access Information for CNV
+    - name: report access information for cnv (Dedicated IP)
       when:
         - cloud_provider == "openshift_cnv"
+        - openshift_cnv_instance_external_ip | default("") != ""
       vars:
         _bastion_inventory_name: "{{ groups['bastions'][0] }}"
         _bastion_ssh_password: "{{ hostvars[bastion_hostname]['student_password'] }}"
         _kubeadmin_password: "{{ hostvars[bastion_hostname]['kubeadmin_password']['content'] | b64decode }}"
       block:
-        - name: Print access user info
+        - name: print access user info
           agnosticd_user_info:
             msg: |
-              You can access your bastion via SSH:
+              you can access your bastion via ssh:
+              ssh {{ student_name }}@{{ openshift_cnv_instance_external_ip }}
+
+              enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
+
+        - name: save user data
+          agnosticd_user_info:
+            data:
+              cloud_provider: "{{ cloud_provider }}"
+              ssh_command: "ssh {{ student_name }}@{{ openshift_cnv_instance_external_ip }}"
+              ssh_password: "{{ student_password }}"
+              ssh_username: "{{ student_name }}"
+              guid: "{{ guid }}"
+              targethost: "{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
+              targetport: "{{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
+              subdomain: "{{ guid }}{{ subdomain_base_suffix }}"
+              subdomain_internal: "{{ chomped_zone_internal_dns | default('') }}"
+          vars:
+            student_name: "{{ ansible_service_account_user_name }}"
+          register: r_user_data
+
+    - name: report access information for cnv
+      when:
+        - cloud_provider == "openshift_cnv"
+        - openshift_cnv_instance_external_ip | default("") == ""
+      vars:
+        _bastion_inventory_name: "{{ groups['bastions'][0] }}"
+        _bastion_ssh_password: "{{ hostvars[bastion_hostname]['student_password'] }}"
+        _kubeadmin_password: "{{ hostvars[bastion_hostname]['kubeadmin_password']['content'] | b64decode }}"
+      block:
+        - name: print access user info
+          agnosticd_user_info:
+            msg: |
+              you can access your bastion via ssh:
               ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
 
-              Enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
+              enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}
 
-        - name: Save user data
+        - name: save user data
           agnosticd_user_info:
             data:
               cloud_provider: "{{ cloud_provider }}"
@@ -59,7 +93,6 @@
           vars:
             student_name: "{{ ansible_service_account_user_name }}"
           register: r_user_data
-
 
     - name: Output ssh user_info for ec2 based deploys
       when:

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -28,7 +28,7 @@
     - post_software
 
   tasks:
-    - name: Report access information for cnv
+    - name: Report Access Information for CNV
       when:
         - cloud_provider == "openshift_cnv"
       vars:
@@ -39,7 +39,7 @@
         - name: Print access user info
           agnosticd_user_info:
             msg: |
-              You can access your bastion via ssh:
+              You can access your bastion via SSH:
               ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
 
               Enter ssh password when prompted: {{ hostvars[groups['bastions'][0]]['student_password'] }}

--- a/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-create-inventory/tasks/create_inventory.yaml
@@ -60,6 +60,8 @@
     groups: "{{ item.metadata.annotations.AnsibleGroup | default(omit) }}"
     bastion: "{{ local_bastion | default('') }}"
     bastion_ssh_port: "{{ r_expose_bastion.result.spec.ports.0.nodePort|default(omit) }}"
+    external_ip: "{{ item.metadata.annotations.external_ip | default(omit) }}"
+    external_ports: "{{ item.metadata.annotations.external_ports | default(omit) }}"
     # Specify if the node is isolated, so won't connect to it
     isolated: "{{ item.metadata.annotations.isolated | default(false) }}"
   when: item.metadata.annotations.managed | default(true) | bool

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -15,6 +15,7 @@
           {{ service.ports }}
         selector:
           vm.cnv.io/name: "{{ _instance_name }}"
+        type: {{ service.type | default('ClusterIP') }}
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -51,11 +51,11 @@
     state: patched
     api_version: v1
     kind: VirtualMachine
-    name: "{{ worker_node }}"
+    name: "{{ _instance_name }}"
     definition:
       apiVersion: v1
       kind: Virtual Machine
-      name: "{{ _instance_name}}"
+      name: "{{ _instance_name }}"
       namespace: "{{ openshift_cnv_namespace }}"
       metadata:
         labels:

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -38,9 +38,9 @@
   delay: 2
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
-    - ports | selectattr('targetPort', 'equalto', 22) | length > 0
+    - service.ports | selectattr('targetPort', 'equalto', 22) | length > 0
 - debug:
     msg: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
-    - ports | selectattr('targetPort', 'equalto', 22) | length > 0
+    - service.ports | selectattr('targetPort', 'equalto', 22) | length > 0

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -40,7 +40,7 @@
 - name: If exist set the external IP for the instance and the ports
   set_fact:
     _instance_external_ip: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
-    _instance_external_ports: "{{ item.ports | map(attribute='port') | to_json }}"
+    _instance_external_ports: "{{ service.ports | map(attribute='port') | to_json }}"
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
 

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -26,12 +26,12 @@
 
 - debug: var=r_service
 
-- name: Wait for the LoadBalancer value - workers
+- name: Wait for the LoadBalancer value
   register: svc_fip
   kubernetes.core.k8s_info:
     api_version: v1
     kind: Service
-    name: "{{ service-name }}"
+    name: "{{ service.name }}"
     namespace: "{{ openshift_cnv_namespace }}"
   until: svc_fip.resources[0].status.loadBalancer.ingress[0].ip | default('') != ''
   retries: 10

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -58,7 +58,7 @@
       metadata:
         name: "{{ _instance_name }}"
         namespace: "{{ openshift_cnv_namespace }}"
-        labels:
+        annotations:
           external_ip: "{{ _instance_external_ip }}"
           external_ports: "{{ _instance_external_ports }}"
   vars:

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -44,7 +44,7 @@
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
 
-- name: Add external_ip and external_ports
+- name: Add external_ip and external_ports to the instance
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
   kubernetes.core.k8s:
@@ -54,10 +54,10 @@
     name: "{{ _instance_name }}"
     definition:
       apiVersion: v1
-      kind: Virtual Machine
-      name: "{{ _instance_name }}"
-      namespace: "{{ openshift_cnv_namespace }}"
+      kind: VirtualMachine
       metadata:
+        name: "{{ _instance_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
         labels:
           external_ip: "{{ _instance_external_ip }}"
           external_ports: "{{ _instance_external_ports }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -40,7 +40,7 @@
 - name: If exist set the external IP for the instance and the ports
   set_fact:
     _instance_external_ip: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
-    _instance_external_ports: "{{ service.ports | map(attribute='port') | to_json }}"
+    _instance_external_ports: "{{ service.ports | map(attribute='port') | join(',') }}"
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
 

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -23,3 +23,24 @@
   until: r_service is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
+
+- debug: var=r_service
+
+- name: Wait for the LoadBalancer value - workers
+  register: svc_fip
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    name: "{{ service-name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
+  until: svc_fip.resources[0].status.loadBalancer.ingress[0].ip | default('') != ''
+  retries: 10
+  delay: 2
+  when:
+    - service.type | default('ClusterIP') == "LoadBalancer"
+    - ports | selectattr('targetPort', 'equalto', 22) | length > 0
+- debug:
+    msg: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
+  when:
+    - service.type | default('ClusterIP') == "LoadBalancer"
+    - ports | selectattr('targetPort', 'equalto', 22) | length > 0

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -24,8 +24,6 @@
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
 
-- debug: var=r_service
-
 - name: Wait for the LoadBalancer value
   register: svc_fip
   kubernetes.core.k8s_info:
@@ -39,8 +37,9 @@
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
     - service.ports | selectattr('targetPort', 'equalto', 22) | length > 0
-- debug:
-    msg: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
+- name: If exists, set FIP for SSH connection
+  set_fact:
+    openshift_cnv_instance_external_ip: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
     - service.ports | selectattr('targetPort', 'equalto', 22) | length > 0

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -40,7 +40,7 @@
 - name: If exist set the external IP for the instance and the ports
   set_fact:
     _instance_external_ip: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
-    _instance_external_ports: "{{ service.ports | selectattr('port') }}"
+    _instance_external_ports: "{{ item.ports | map(attribute='port') | to_json }}"
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
 

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -36,10 +36,37 @@
   delay: 2
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
-    - service.ports | selectattr('targetPort', 'equalto', 22) | length > 0
-- name: If exists, set FIP for SSH connection
+
+- name: If exist set the external IP for the instance and the ports
   set_fact:
-    openshift_cnv_instance_external_ip: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
+    _instance_external_ip: "{{ svc_fip.resources[0].status.loadBalancer.ingress[0].ip }}"
+    _instance_external_ports: "{{ service.ports | selectattr('port') }}"
   when:
     - service.type | default('ClusterIP') == "LoadBalancer"
-    - service.ports | selectattr('targetPort', 'equalto', 22) | length > 0
+
+- name: Add external_ip and external_ports
+  when:
+    - service.type | default('ClusterIP') == "LoadBalancer"
+  kubernetes.core.k8s:
+    state: patched
+    api_version: v1
+    kind: VirtualMachine
+    name: "{{ worker_node }}"
+    definition:
+      apiVersion: v1
+      kind: Virtual Machine
+      name: "{{ _instance_name}}"
+      namespace: "{{ openshift_cnv_namespace }}"
+      metadata:
+        labels:
+          external_ip: "{{ _instance_external_ip }}"
+          external_ports: "{{ _instance_external_ports }}"
+  vars:
+    _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"
+  loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
+  loop_control:
+    index_var: _index
+  register: r_service
+  until: r_service is success
+  retries: "{{ openshift_cnv_retries }}"
+  delay: "{{ openshift_cnv_delay }}"


### PR DESCRIPTION
##### SUMMARY

For some use cases (as replacement for equinix blank server), we would like to assign a external IP to the instance and map some ports

Usage example:

```
  services:
  - name: bastion-fip
    type: LoadBalancer
    ports:
    - port: 80
      protocol: TCP
      targetPort: 80
      name: bastion-http
    - port: 443
      protocol: TCP
      targetPort: 443
      name: bastion-https
    - port: 8080
      protocol: TCP
      targetPort: 8080
      name: bastion-http-alt
```

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources role 
base-infra role

