### PR TITLE
Update install_kafka-console.yml (Cloud-Native Integration with Red H…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_kafka-console.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_kafka-console.yml
@@ -61,7 +61,7 @@
     kind: Pod
     namespace: openshift-operators
     label_selectors:
-      - app.kubernetes.io/instance=amq-streams-console-operator-v2.9.0-3
+      - app.kubernetes.io/instance=amq-streams-console-operator-v2.9.0-5
     field_selectors:
       - status.phase=Running
   register: r_streams_pod


### PR DESCRIPTION
…at build of Apache Camel)

Cloud-Native Integration with Red Hat build of Apache Camel is failing because this task is checking for the version 2.9.0-3 of the streams console, however the version 2.9.0-5 is being installed in the environments.

I can't find where the version to be installed is actually set in the configs, but as a temporary workaround the hardcoded version here can be increase to match the one being deployed.