### PR TITLE
Update 50-dev-tools-setup.yml - remove reboot async and poll

### DIFF
--- a/ansible/roles/rad_setup_instructlab/tasks/50-dev-tools-setup.yml
+++ b/ansible/roles/rad_setup_instructlab/tasks/50-dev-tools-setup.yml
@@ -18,8 +18,6 @@
         connect_timeout: 60 
         post_reboot_delay: 30 
         reboot_timeout: 180
-      async: 1
-      poll: 0
       become: true
       become_user: root
 


### PR DESCRIPTION
This module does not support these options and will error out: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/reboot_module.html#attributes
