### PR TITLE
Add validation and dynamic sizing for boot volumes

### DIFF
--- a/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
@@ -53,9 +53,6 @@
           - instance.name is defined
           - instance.image is defined
           - instance.profile is defined
-          # rootfs_size cannot be greater than 250,
-          # see https://cloud.ibm.com/docs/vpc?topic=vpc-resize-boot-volumes&interface=ui
-          - instance.rootfs_size | default(100) | int <= 250
 
     - name: Create ssh provision key
       ansible.builtin.include_role:

--- a/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
@@ -43,6 +43,20 @@
       ibmcloud_api_key: "{{ ibmcloud_api_key }}"
       region: "{{ ibmcloud_region }}"
   tasks:
+    - name: Validate input
+      loop: "{{ instances | default([]) }}"
+      loop_control:
+        label: "{{ item.name }}"
+        loop_var: instance
+      assert:
+        that:
+          - instance.name is defined
+          - instance.image is defined
+          - instance.profile is defined
+          # rootfs_size cannot be greater than 250,
+          # see https://cloud.ibm.com/docs/vpc?topic=vpc-resize-boot-volumes&interface=ui
+          - instance.rootfs_size | default(100) | int <= 250
+
     - name: Create ssh provision key
       ansible.builtin.include_role:
         name: create_ssh_provision_key

--- a/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
@@ -46,7 +46,7 @@
     - name: Validate input
       loop: "{{ instances | default([]) }}"
       loop_control:
-        label: "{{ item.name }}"
+        label: "{{ instance.name | default(instance) }}"
         loop_var: instance
       assert:
         that:

--- a/ansible/cloud_providers/ibm_resource_group_mount_volume.yaml
+++ b/ansible/cloud_providers/ibm_resource_group_mount_volume.yaml
@@ -5,6 +5,7 @@
     _matched_device: >-
       {{ _host_block_devices
       | selectattr('serial', 'defined')
+      | selectattr('serial', '!=', None)
       | selectattr('serial', 'in', _volume.id)
       | list | first
       }}

--- a/ansible/configs/base-infra/default_vars_ibm_resource_group.yml
+++ b/ansible/configs/base-infra/default_vars_ibm_resource_group.yml
@@ -73,3 +73,4 @@ instances:
     rootfs_size: "{{ bastion_rootfs_size_node | default(default_rootfs_size_node) }}"
     security_groups:
       - bastionsg
+    user_data: "{{ bastion_user_data | default('') }}"

--- a/ansible/configs/base-infra/default_vars_ibm_resource_group.yml
+++ b/ansible/configs/base-infra/default_vars_ibm_resource_group.yml
@@ -74,3 +74,4 @@ instances:
     security_groups:
       - bastionsg
     user_data: "{{ bastion_user_data | default('') }}"
+    volumes: "{{ bastion_volumes | default([]) }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -43,7 +43,7 @@
     auto_delete_volume: true
     boot_volume:
       - name: "{{ instance.name }}-boot-0"
-        capacity: "{{ instance.rootfs_size | default(100) }}"
+        size: "{{ instance.rootfs_size | default(100) }}"
     region: "{{ ibmcloud_region }}"
     metadata_service:
       - enabled: true

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -43,6 +43,7 @@
       Image {{ instance.image }} minimum provisioned size is {{ _image_dict.minimum_provisioned_size }}.
       Please check the image name or set the rootfs_size to a value greater than {{ _image_dict.minimum_provisioned_size }}.
       rootfs_size should also not exceed 250 GB. (IBM Cloud limitation)
+      see https://cloud.ibm.com/docs/vpc?topic=vpc-resize-boot-volumes&interface=ui
 
 - name: Provision IBM Cloud Virtual Server (VS) instance
   register: ibmcloud_vs_instance_create

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -29,14 +29,20 @@
       | first }}
   when: instance.image is defined
 
-- name: Ensure rootfs_size is not less than minimum provisioned size
+- name: Warn if rootfs_size is less than minimum provisioned size and is > 250 GB
   when: instance.rootfs_size is defined
+  ignore_errors: true
   assert:
-    that: instance.rootfs_size | default(0) >= _image_dict.minimum_provisioned_size
+    that: >-
+      instance.rootfs_size | default(0) >= _image_dict.minimum_provisioned_size
+      and
+      instance.rootfs_size | default(0) <= 250
     fail_msg: >-
       for instance {{ instance.name }},
+      rootfs_size is set to {{ instance.rootfs_size | default(0) }},
       Image {{ instance.image }} minimum provisioned size is {{ _image_dict.minimum_provisioned_size }}.
       Please check the image name or set the rootfs_size to a value greater than {{ _image_dict.minimum_provisioned_size }}.
+      rootfs_size should also not exceed 250 GB. (IBM Cloud limitation)
 
 - name: Provision IBM Cloud Virtual Server (VS) instance
   register: ibmcloud_vs_instance_create
@@ -58,8 +64,17 @@
     auto_delete_volume: true
     boot_volume:
       - name: "{{ instance.name }}-boot-0"
+        # Use the maximum between the specified rootfs_size
+        # and the image's minimum provisioned size but never exceed 250 GB
         size: >-
-          {{ instance.rootfs_size | default(_image_dict.minimum_provisioned_size) }}
+          {{
+          [
+            [ instance.rootfs_size | default(0), _image_dict.minimum_provisioned_size ] | max,
+            250
+          ] | min
+          }}
+
+
     region: "{{ ibmcloud_region }}"
     metadata_service:
       - enabled: true

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -30,7 +30,7 @@
   when: instance.image is defined
 
 - name: Warn if rootfs_size is less than minimum provisioned size and is > 250 GB
-  when: instance.rootfs_size is defined
+  when: instance.rootfs_size | default(0) | int != 0
   ignore_errors: true
   assert:
     that: >-

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -34,9 +34,9 @@
   ignore_errors: true
   assert:
     that: >-
-      instance.rootfs_size | default(0) >= _image_dict.minimum_provisioned_size
+      instance.rootfs_size | default(0) | int >= _image_dict.minimum_provisioned_size
       and
-      instance.rootfs_size | default(0) <= 250
+      instance.rootfs_size | default(0) | int <= 250
     fail_msg: >-
       for instance {{ instance.name }},
       rootfs_size is set to {{ instance.rootfs_size | default(0) }},
@@ -70,7 +70,7 @@
         size: >-
           {{
           [
-            [ instance.rootfs_size | default(0), _image_dict.minimum_provisioned_size ] | max,
+            [ instance.rootfs_size | default(0) | int, _image_dict.minimum_provisioned_size | int] | max,
             250
           ] | min
           }}

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -21,14 +21,29 @@
       for instance {{ instance.name }},
       Image {{ instance.image }} not found in the list of available images. Please check the image name.
 
+- name: Set image
+  set_fact:
+    _image_dict: >-
+      {{ ibmcloud_os_image_list
+      | selectattr('name', 'equalto', instance.image)
+      | first }}
+  when: instance.image is defined
+
+- name: Ensure rootfs_size is not less than minimum provisioned size
+  when: instance.rootfs_size is defined
+  assert:
+    that: instance.rootfs_size | default(0) >= _image_dict.minimum_provisioned_size
+    fail_msg: >-
+      for instance {{ instance.name }},
+      Image {{ instance.image }} minimum provisioned size is {{ _image_dict.minimum_provisioned_size }}.
+      Please check the image name or set the rootfs_size to a value greater than {{ _image_dict.minimum_provisioned_size }}.
+
 - name: Provision IBM Cloud Virtual Server (VS) instance
   register: ibmcloud_vs_instance_create
-  vars:
-    _secury_group_filter: "[?name=='{{ instance.name }}'].id"
   ibm.cloudcollection.ibm_is_instance:
     state: available
     name: "{{ instance.name }}"
-    image: "{{ (ibmcloud_os_image_list | selectattr('name', 'equalto', instance.image) | first).id }}"
+    image: "{{ _image_dict.id }}"
     profile: "{{ instance.profile }}"
     keys:
       - "{{ ibmcloud_ssh_public_key.resource.id }}"
@@ -43,7 +58,8 @@
     auto_delete_volume: true
     boot_volume:
       - name: "{{ instance.name }}-boot-0"
-        size: "{{ instance.rootfs_size | default(100) }}"
+        size: >-
+          {{ instance.rootfs_size | default(_image_dict.minimum_provisioned_size) }}
     region: "{{ ibmcloud_region }}"
     metadata_service:
       - enabled: true

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -43,6 +43,7 @@
     auto_delete_volume: true
     boot_volume:
       - name: "{{ instance.name }}-boot-0"
+        capacity: "{{ instance.rootfs_size | default(100) }}"
     region: "{{ ibmcloud_region }}"
     metadata_service:
       - enabled: true


### PR DESCRIPTION
##### SUMMARY


This commit introduces validation and dynamic sizing for virtual server instance boot volumes to prevent deployment failures.

Changes:

- **Input Validation:** A ceck is added to the main playbook to validate that `instance.name`, `instance.image`, and `instance.profile` are defined.

- **Dynamic Boot Volume Sizing:** The instance creation logic is updated to  determine the boot volume size. It now uses the maximum value between the user-defined `rootfs_size` and the selected image's `minimum_provisioned_size`, while still respecting the 250 GB upper limit. This ensures the volume is always large enough for the chosen OS without exceeding platform constraints.

- Improved Warnings: guide the user if their specified `rootfs_size` is smaller than the image's minimum requirement.


##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request


##### COMPONENT NAME
* IBM Cloud core
