### PR TITLE
[host-ocp4-hcp-cnv-install] Authentication improvements

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -15,6 +15,8 @@ hcp_admin_password_randomized: true
 hcp_user_password_randomized: true
 hcp_admin_password: ""
 hcp_user_password: ""
+hcp_enable_user_info_messages: true
+hcp_enable_user_info_data: true
 hcp_controller_availability_policy: SingleReplica
 hcp_authentication: "htpasswd"
 hcp_etcd_pvc_size: "8Gi"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -11,6 +11,10 @@ hcp_user_password_length: 16
 hcp_user_base: "user"
 hcp_admin_user: "admin"
 hcp_user_passwords: []
+hcp_admin_password_randomized: true
+hcp_user_password_randomized: true
+hcp_admin_password: ""
+hcp_user_password: ""
 hcp_controller_availability_policy: SingleReplica
 hcp_authentication: "htpasswd"
 hcp_etcd_pvc_size: "8Gi"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -11,8 +11,6 @@ hcp_user_password_length: 16
 hcp_user_base: "user"
 hcp_admin_user: "admin"
 hcp_user_passwords: []
-hcp_admin_password_randomized: true
-hcp_user_password_randomized: true
 hcp_admin_password: ""
 hcp_user_password: ""
 hcp_enable_user_info_messages: true

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -1,18 +1,33 @@
 ---
 - name: Generate admin user password
+  when: hcp_admin_password_randomized | default(true)
   ansible.builtin.set_fact:
     _hcp_admin_password: >-
       {{ lookup('password', '/dev/null chars=ascii_letters,digits '
           ~ 'length=' ~ hcp_admin_password_length
       ) }}
 
+- name: Set admin user password
+  when:
+    - not hcp_admin_password_randomized | default(true)
+  ansible.builtin.set_fact:
+    _hcp_admin_password: "{{ hcp_admin_password }}"
+
 - name: Set up randomized user password array
+  when: hcp_user_password_randomized | default(true)
   ansible.builtin.set_fact:
     hcp_user_passwords: >-
       {{ hcp_user_passwords + [ lookup('password',
         '/dev/null chars=ascii_letters,digits '
         ~ 'length=' ~ hcp_user_password_length ) ] }}
   loop: "{{ range(0, num_users, 1) | list }}"
+
+- name: Set up user password array
+  when: not hcp_user_password_randomized | default(true)
+  ansible.builtin.set_fact:
+    hcp_user_passwords: "{{ hcp_user_password }}"
+  loop: "{{ range(0, num_users, 1) | list }}"
+
 
 - name: Create temporary htpasswd file
   ansible.builtin.tempfile:

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -105,11 +105,11 @@
         msg: >-
           {%- if num_users | int == 1 -%}
           Normal user `{{ hcp_user_name }}`
-          created with password `{{ _hcp_user_password }}`
+          created with password `{{ hcp_user_password }}`
           {%- else -%}
           Users `{{ hcp_user_base }}1` ..
           `{{ hcp_user_base ~ num_users }}`
-          created with password `{{ _hcp_user_password }}`
+          created with password `{{ hcp_user_password }}`
           {%- endif -%}
 
     - name: Print user information for randomized password
@@ -136,7 +136,7 @@
       openshift_cluster_admin_password: "{{ _hcp_admin_password }}"
       openshift_cluster_num_users: "{{ num_users }}"
       openshift_cluster_user_base: "{{ hcp_user_base }}"
-      openshift_cluster_user_password: "{{ _hcp_user_password }}"
+      openshift_cluster_user_password: "{{ hcp_user_passwords[0] | default(hcp_user_password) }}"
       console_url: "{{ _hcp_console_route }}"
       openshift_cluster_console_url: "{{ _hcp_console_url }}"
       openshift_console_url: "{{ _hcp_console_route }}"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -99,26 +99,26 @@
 
     - name: Print user information for common password
       when:
-        - hcp_user_count | int > 0
+        - num_users | int > 0
         - not hcp_user_password_randomized | bool
       agnosticd_user_info:
         msg: >-
-          {%- if hcp_user_count | int == 1 -%}
+          {%- if num_users | int == 1 -%}
           Normal user `{{ hcp_user_name }}`
           created with password `{{ _hcp_user_password }}`
           {%- else -%}
           Users `{{ hcp_user_base }}1` ..
-          `{{ hcp_user_base ~ hcp_user_count }}`
+          `{{ hcp_user_base ~ num_users }}`
           created with password `{{ _hcp_user_password }}`
           {%- endif -%}
 
     - name: Print user information for randomized password
       when:
-        - hcp_user_count | int > 0
+        - num_users | int > 0
         - hcp_user_password_randomized | bool
       agnosticd_user_info:
         msg: >-
-          {%- if hcp_user_count  | int== 1 -%}
+          {%- if num_users  | int== 1 -%}
           Normal user `{{ hcp_user_name }}`
           created with password `{{ _hcp_user_passwords[0] }}`
           {%- else -%}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -25,7 +25,7 @@
 - name: Set up user password array
   when: not hcp_user_password_randomized | default(true)
   ansible.builtin.set_fact:
-    hcp_user_passwords: "{{ hcp_user_password }}"
+    hcp_user_passwords: "{{ hcp_user_passwords + [hcp_user_password] }}"
   loop: "{{ range(0, num_users, 1) | list }}"
 
 

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -5,7 +5,7 @@
       https://console-openshift-console.apps.hcp-{{ guid }}.{{ cluster_dns_zone }}
 
 - name: Generate admin user password
-  when: hcp_admin_password_randomized | default(true)
+  when: hcp_admin_password | default("") | length == 0
   ansible.builtin.set_fact:
     _hcp_admin_password: >-
       {{ lookup('password', '/dev/null chars=ascii_letters,digits '
@@ -13,13 +13,12 @@
       ) }}
 
 - name: Set admin user password
-  when:
-    - not hcp_admin_password_randomized | default(true)
+  when: hcp_admin_password | default("") | length > 0
   ansible.builtin.set_fact:
     _hcp_admin_password: "{{ hcp_admin_password }}"
 
 - name: Set up randomized user password array
-  when: hcp_user_password_randomized | default(true)
+  when: hcp_user_password | default("") | length == 0
   ansible.builtin.set_fact:
     hcp_user_passwords: >-
       {{ hcp_user_passwords + [ lookup('password',
@@ -28,7 +27,7 @@
   loop: "{{ range(0, num_users, 1) | list }}"
 
 - name: Set up user password array
-  when: not hcp_user_password_randomized | default(true)
+  when: hcp_user_password | default("") | length > 0
   ansible.builtin.set_fact:
     hcp_user_passwords: "{{ hcp_user_passwords + [hcp_user_password] }}"
   loop: "{{ range(0, num_users, 1) | list }}"
@@ -100,7 +99,7 @@
     - name: Print user information for common password
       when:
         - num_users | int > 0
-        - not hcp_user_password_randomized | bool
+        - hcp_user_password | default("") | length > 0
       agnosticd_user_info:
         msg: >-
           {%- if num_users | int == 1 -%}
@@ -115,7 +114,7 @@
     - name: Print user information for randomized password
       when:
         - num_users | int > 0
-        - hcp_user_password_randomized | bool
+        - hcp_user_password | default("") | length == 0
       agnosticd_user_info:
         msg: >-
           {%- if num_users  | int== 1 -%}

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -104,7 +104,7 @@
       agnosticd_user_info:
         msg: >-
           {%- if num_users | int == 1 -%}
-          Normal user `{{ hcp_user_name }}`
+          Normal user `user1`
           created with password `{{ hcp_user_password }}`
           {%- else -%}
           Users `{{ hcp_user_base }}1` ..
@@ -119,7 +119,7 @@
       agnosticd_user_info:
         msg: >-
           {%- if num_users  | int== 1 -%}
-          Normal user `{{ hcp_user_name }}`
+          Normal user `user1`
           created with password `{{ _hcp_user_passwords[0] }}`
           {%- else -%}
           User `{{ hcp_user_base }}{{ n + 1 }}`,

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -152,6 +152,8 @@
         data:
           user: "{{ hcp_user_base }}{{ n + 1 }}"
           password: "{{ hcp_user_passwords[ n ] }}"
+          openshift_cluster_user_name: "{{ hcp_user_base }}{{ n + 1 }}"
+          openshift_cluster_user_password: "{{ hcp_user_passwords[ n ] }}"
           console_url: "{{ _hcp_console_route }}"
           openshift_cluster_console_url: "{{ _hcp_console_url }}"
           openshift_console_url: "{{ _hcp_console_route }}"

--- a/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/tasks/setup_htpasswd_authentication.yml
@@ -1,4 +1,9 @@
 ---
+- name: Set hosted cluster console URL
+  ansible.builtin.set_fact:
+    _hcp_console_url: >-
+      https://console-openshift-console.apps.hcp-{{ guid }}.{{ cluster_dns_zone }}
+
 - name: Generate admin user password
   when: hcp_admin_password_randomized | default(true)
   ansible.builtin.set_fact:
@@ -79,6 +84,51 @@
   vars:
     namespace: "{{ sandbox_hcp.sandbox_openshift_namespace }}"
 
+- name: Print user information messages
+  when: hcp_enable_user_info_messages | bool
+  block:
+    - name: Print common user information messages
+      agnosticd_user_info:
+        msg: >-
+          Authentication via htpasswd is enabled on this cluster.
+
+
+          User `{{ hcp_admin_user }}`
+          with password `{{ _hcp_admin_password }}`
+          is cluster admin.
+
+    - name: Print user information for common password
+      when:
+        - hcp_user_count | int > 0
+        - not hcp_user_password_randomized | bool
+      agnosticd_user_info:
+        msg: >-
+          {%- if hcp_user_count | int == 1 -%}
+          Normal user `{{ hcp_user_name }}`
+          created with password `{{ _hcp_user_password }}`
+          {%- else -%}
+          Users `{{ hcp_user_base }}1` ..
+          `{{ hcp_user_base ~ hcp_user_count }}`
+          created with password `{{ _hcp_user_password }}`
+          {%- endif -%}
+
+    - name: Print user information for randomized password
+      when:
+        - hcp_user_count | int > 0
+        - hcp_user_password_randomized | bool
+      agnosticd_user_info:
+        msg: >-
+          {%- if hcp_user_count  | int== 1 -%}
+          Normal user `{{ hcp_user_name }}`
+          created with password `{{ _hcp_user_passwords[0] }}`
+          {%- else -%}
+          User `{{ hcp_user_base }}{{ n + 1 }}`,
+          Password: `{{ _hcp_user_passwords[n] }}`
+          {%- endif -%}
+      loop: "{{ range(0, user_count | int) | list }}"
+      loop_control:
+        loop_var: n
+
 - name: Save admin user information
   agnosticd_user_info:
     data:
@@ -86,20 +136,26 @@
       openshift_cluster_admin_password: "{{ _hcp_admin_password }}"
       openshift_cluster_num_users: "{{ num_users }}"
       openshift_cluster_user_base: "{{ hcp_user_base }}"
-
-- name: Set hosted cluster console URL
-  ansible.builtin.set_fact:
-    _hcp_console_url: >-
-      https://console-openshift-console.apps.hcp-{{ guid }}.{{ cluster_dns_zone }}
-
-- name: Save user information for each user
-  agnosticd_user_info:
-    user: "{{ hcp_user_base }}{{ n + 1 }}"
-    data:
-      user: "{{ hcp_user_base }}{{ n + 1 }}"
-      password: "{{ hcp_user_passwords[ n ] }}"
+      openshift_cluster_user_password: "{{ _hcp_user_password }}"
+      console_url: "{{ _hcp_console_route }}"
       openshift_cluster_console_url: "{{ _hcp_console_url }}"
-      openshift_console_url: "{{ _hcp_console_url }}"
-  loop: "{{ range(0, num_users | int) | list }}"
-  loop_control:
-    loop_var: n
+      openshift_console_url: "{{ _hcp_console_route }}"
+      openshift_cluster_ingress_domain: "apps.hcp-{{ guid }}.{{ cluster_dns_zone }}"
+
+
+- name: Save user information
+  when: hcp_enable_user_info_data | bool
+  block:
+    - name: Save user information for user access
+      agnosticd_user_info:
+        user: "{{ hcp_user_base }}{{ n + 1 }}"
+        data:
+          user: "{{ hcp_user_base }}{{ n + 1 }}"
+          password: "{{ hcp_user_passwords[ n ] }}"
+          console_url: "{{ _hcp_console_route }}"
+          openshift_cluster_console_url: "{{ _hcp_console_url }}"
+          openshift_console_url: "{{ _hcp_console_route }}"
+          openshift_cluster_ingress_domain: "apps.hcp-{{ guid }}.{{ cluster_dns_zone }}"
+        loop: "{{ range(0, num_users | int) | list }}"
+        loop_control:
+          loop_var: n


### PR DESCRIPTION
##### SUMMARY

By default password for admin and users will be randomised, now we will be able to specify a password. New variabesL:

```
hcp_admin_password: ""
hcp_user_password: ""
```

Improved the data saved to be used (not only) by showroom

```
hcp_enable_user_info_messages: true
hcp_enable_user_info_data: true
```

##### ISSUE TYPE

- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
host-ocp4-hcp-cnv-install role