### PR TITLE
[host-ocp4-assisted-installer] Improve static network [ocp4-cluster] Add vmware.vmware

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -21,6 +21,8 @@ collections:
   version: 4.5.0
 - name: vmware.vmware_rest
   version: 3.0.1
+- name: vmware.vmware
+  version: 1.11.0
 - name: google.cloud
   version: 1.3.0
 - name: openstack.cloud

--- a/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
+++ b/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
@@ -36,10 +36,6 @@
       logical_nic_name: "enp1s0"
     - mac_address: "{{ ai_masters_macs2[index] }}"
       logical_nic_name: "enp2s0"
-{% for _network in ai_attach_masters_networks %}
-    - mac_address: "{{ ai_attach_masters_macs[_network][master_loop.index0] }}"
-      logical_nic_name: "enp{{ loop.index+2 }}s0"
-{% endfor %}
 {% endfor %}
 {% for index in range(0,worker_instance_count|int) %}
 {% set worker_loop = loop %}
@@ -79,8 +75,4 @@
       logical_nic_name: "enp1s0"
     - mac_address: "{{ ai_workers_macs2[index] }}"
       logical_nic_name: "enp2s0"
-{% for _network in ai_attach_workers_networks %}
-    - mac_address: "{{ ai_attach_workers_macs[_network][worker_loop.index0] }}"
-      logical_nic_name: "enp{{ loop.index+2 }}s0"
-{% endfor %}
 {% endfor %}

--- a/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
+++ b/ansible/roles/host-ocp4-assisted-installer/templates/static_network_config_full.j2
@@ -17,14 +17,6 @@
       name: enp2s0
       state: up
       type: ethernet
-{% for _network in ai_attach_masters_networks %}
-    - ipv4:
-        dhcp: false
-        enabled: false
-      name: enp{{ loop.index+2 }}s0
-      state: down
-      type: ethernet
-{% endfor %}
     routes:
       config:
       - destination: 0.0.0.0/0
@@ -56,14 +48,6 @@
       name: enp2s0
       state: up
       type: ethernet
-{% for _network in ai_attach_workers_networks %}
-    - ipv4:
-        dhcp: false
-        enabled: false
-      name: enp{{ loop.index+2 }}s0
-      state: down
-      type: ethernet
-{% endfor %}
     routes:
       config:
       - destination: 0.0.0.0/0


### PR DESCRIPTION
##### SUMMARY

Remove from the static_network_full the extra networks, as is not needed for the assisted installer.

Add vmware.vmware to ocp4-cluster config, for the roadshow vmware role

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
ocp4-cluster config
