### PR TITLE
More robust, tmp, jupyter certs

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/service_vm_jupyter_lab/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/service_vm_jupyter_lab/tasks/main.yml
@@ -24,6 +24,7 @@
     name: certbot
     state: present
 
+
 - name: Request certificate using standalone mode
   ansible.builtin.command: >
     certbot certonly --standalone
@@ -31,6 +32,12 @@
     --agree-tos
     --email {{ service_vm_jupyter_lab_certbot_email }}
     --non-interactive
+    --keep-until-expiring
+    --server https://acme-v02.api.letsencrypt.org/directory
+  register: r_certbot_result
+  retries: 5
+  delay: 30
+  until: r_certbot_result.rc == 0
   args:
     creates: "/etc/letsencrypt/live/{{ service_vm_jupyter_lab_domain_name }}/fullchain.pem"
 


### PR DESCRIPTION
Post summit will move to Sandbox API certs