### PR TITLE
Update workload.yml ocp4_workload_tl500 machine config timeout increase

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
@@ -10,7 +10,7 @@
   register: cmd
   failed_when: "cmd.rc != 0"
   vars:
-    ansible_command_timeout: 600
+    ansible_command_timeout: "{{ mco_timeout | default(1800) }}"
 
 - name: Install IPA
   command: >-


### PR DESCRIPTION
increase the wait-time '600' to "{{ mco_timeout | default(1800) }}"

##### SUMMARY
The task for awaiting machine-config to apply times-out. This is simply to increase timeout

Here is an example log: https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/1314399/output

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
tl500 workload applying machine config