### PR TITLE
Remove restart mta-hub pod workload mta7_workshop

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_mta7_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta7_workshop/defaults/main.yml
@@ -11,5 +11,3 @@ ocp4_workload_mta7_workshop_postgresql_image_pull_policy: IfNotPresent
 ocp4_workload_mta7_workshop_postgresql_database_name: customers
 ocp4_workload_mta7_workshop_postgresql_user: redhat
 ocp4_workload_mta7_workshop_postgresql_password: redhat
-
-ocp4_workload_mta7_workshop_restart_hub: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_mta7_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_mta7_workshop/tasks/workload.yml
@@ -14,26 +14,6 @@
   loop_control:
     loop_var: resource
 
-- name: Restart mta-hub deployment
-  when: ocp4_workload_mta7_workshop_restart_hub | bool
-  block:
-  - name: Wait for mta-hub deployment to exist and become available
-    ansible.builtin.command: >-
-      oc wait deployment/mta-hub -n mta --for=condition=Available --timeout=1s
-    register: wait_deploy
-    until: wait_deploy.rc == 0
-    retries: 30
-    delay: 10
-    changed_when: false
-  - name: oc rollout restart deployment mta-hub -n mta
-    ansible.builtin.command: >-
-      oc rollout restart deployment mta-hub -n mta
-    register: result
-    changed_when: false
-  - name: print result.stdout_lines
-    ansible.builtin.debug:
-      var: result.stdout_lines
-
 # -----------------------------------------------------------------------------
 # Leave this as the last task in the playbook.
 - name: Workload tasks complete


### PR DESCRIPTION
This is basically reverting a change I did before Summit. It is restoring how it is used to be.