### PR TITLE
Add retries in ocp4_workload_trusted_application_pipeline

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_jenkins.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_jenkins.yml
@@ -59,6 +59,10 @@
     state: present
     namespace: "{{ ocp4_workload_trusted_application_pipeline_jenkins_namespace }}"
     definition: "{{ lookup('template', item) | from_yaml }}"
+  register: r_deploy_nginx
+  retries: 5
+  delay: 10
+  until: r_deploy_nginx is successful
   loop:
   - pvc-nginx.yml.j2
   - deployment-nginx.yml.j2
@@ -84,6 +88,9 @@
     kind: Infrastructure
     name: cluster
   register: r_infra
+  retries: 5
+  delay: 10
+  until: r_infra is successful
 
 - name: Get the Openshift API URL
   ansible.builtin.set_fact:
@@ -125,3 +132,4 @@
     command: >-
       nginx -s stop
   ignore_errors: true
+...


### PR DESCRIPTION
##### SUMMARY

Add retries to tasks in ocp4_workload_trusted_application_pipeline to avoid failure from random OpenShift api connectivity issues.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role ocp4_workload_trusted_application_pipeline