### PR TITLE
[open-environment-azure-subscription] Add back azure_subscription variable

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/post_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/post_software.yml
@@ -154,6 +154,7 @@
     agnosticd_user_info:
       data:
         azure_tenant: "{{ azure_tenant }}"
+        azure_subscription: "{{ assignedsubscription.subscriptions[0].subscription_id }}"
         azure_resource_group: "openenv-{{ guid }}"
         azure_dns_zone: "{{ guid }}.{{ azure_root_dns_zone }}"
         azure_application: "openenv-{{ guid }}"


### PR DESCRIPTION
##### SUMMARY

The variable azure_subscription was removed from the provision data and is needed in some use cases

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
open-environment-azure-subscription config
