### PR TITLE
[vscode-server] Remove wrong condition on nginx-server.yml

### DIFF
--- a/ansible/roles/vscode-server/tasks/nginx-server.yml
+++ b/ansible/roles/vscode-server/tasks/nginx-server.yml
@@ -10,7 +10,6 @@
     state: started
 
 - name: nginx | generate certbot certificate
-  when: certbot_cert_manager_provider == 'zerossl'
   command: >-
     certbot certonly --nginx
     {% if certbot_cert_manager_provider == 'zerossl' %}


### PR DESCRIPTION
##### SUMMARY

Previous commit/PR to add retry added a bug, only allowing zerossl to be used. This PR is to switch the CIs to letsencrypt till fallback for certbot will be implemented.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vscode-server role
