### PR TITLE
Add test-empty-config simulation of hosts

### DIFF
--- a/ansible/configs/test-empty-config/default_vars.yml
+++ b/ansible/configs/test-empty-config/default_vars.yml
@@ -8,6 +8,12 @@ bookbag_deploy: false
 test_empty_config_multi_user: false
 test_empty_config_user_count: "{{ user_count | default(num_users) | default(10) }}"
 
+# Number of hosts to simulate
+test_empty_config_host_count: 0
+# Size of temporary file generated to simulate host activity.
+# Size in count of 1k blocks.
+test_empty_config_host_data_size: 1024
+
 # Request config set agnosticd_user_data at top level or per user
 #test_empty_config_passthrough_user_data:
 #  foo: bar

--- a/ansible/configs/test-empty-config/infra.yml
+++ b/ansible/configs/test-empty-config/infra.yml
@@ -36,6 +36,31 @@
       include_role:
         name: infra-equinix-metal-dry-run
 
+    - name: Add testhosts
+      loop: >-
+        {{ range(0, test_empty_config_host_count|int) }}
+      loop_control:
+        loop_var: testhost_num
+        label: "{{ testhost_name }}"
+      vars:
+        testhost_name: testhost{{ testhost_num }}
+      ansible.builtin.add_host:
+        name: "{{ testhost_name }}"
+        ansible_become: false
+        ansible_connection: local
+        groups: testhosts
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+        test_empty_config_host_data_size: "{{ test_empty_config_host_data_size }}"
+
+- name: End step 001 infra
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+    - step001
+    - infrastructure
+  tasks:
     - name: Exiting the test-empty-config infra.yml
       debug:
         msg:

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -99,6 +99,40 @@
     include_role:
       name: ocp4_workload_showroom
 
+- name: Simulate activity on test hosts
+  hosts: testhosts
+  gather_facts: false
+  tags:
+    - step004
+    - deploy_software
+  tasks:
+    - name: Create tempfile
+      ansible.builtin.tempfile:
+        state: file
+      register: r_tempfile
+
+    - name: Populate tempfile with random data
+      ansible.builtin.command:
+        cmd: >-
+          dd
+          if=/dev/urandom
+          of={{ r_tempfile.path | quote }}
+          bs=1k
+          count={{ test_empty_config_host_data_size | quote }}
+
+    - name: Slurp tempfile
+      ansible.builtin.slurp:
+        path: "{{ r_tempfile.path }}"
+
+- name: Step 005 Post Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tags:
+  - step005
+  - post_software
+  tasks:
   - name: Print string expected by Cloudforms
     debug:
       msg: "Post-Software checks completed successfully"

--- a/ansible/configs/test-empty-config/post_software.yml
+++ b/ansible/configs/test-empty-config/post_software.yml
@@ -103,26 +103,26 @@
   hosts: testhosts
   gather_facts: false
   tags:
-    - step004
-    - deploy_software
+  - step004
+  - deploy_software
   tasks:
-    - name: Create tempfile
-      ansible.builtin.tempfile:
-        state: file
-      register: r_tempfile
+  - name: Create tempfile
+    ansible.builtin.tempfile:
+      state: file
+    register: r_tempfile
 
-    - name: Populate tempfile with random data
-      ansible.builtin.command:
-        cmd: >-
-          dd
-          if=/dev/urandom
-          of={{ r_tempfile.path | quote }}
-          bs=1k
-          count={{ test_empty_config_host_data_size | quote }}
+  - name: Populate tempfile with random data
+    ansible.builtin.command:
+      cmd: >-
+        dd
+        if=/dev/urandom
+        of={{ r_tempfile.path | quote }}
+        bs=1k
+        count={{ test_empty_config_host_data_size | quote }}
 
-    - name: Slurp tempfile
-      ansible.builtin.slurp:
-        path: "{{ r_tempfile.path }}"
+  - name: Slurp tempfile
+    ansible.builtin.slurp:
+      path: "{{ r_tempfile.path }}"
 
 - name: Step 005 Post Software
   hosts: localhost


### PR DESCRIPTION
##### SUMMARY

Add support to test-empty-config to simulate host activity.

- `test_empty_config_host_count` number of hosts to simulate
- `test_empty_config_host_data_size` amount of work to do on host by size of 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Config test-empty-config