### PR TITLE
Install cosign & gitsign from TAS CLI server

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
@@ -1,8 +1,10 @@
 ---
 - name: Install and configure cosign
   ansible.builtin.shell: |
-    COSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n trusted-artifact-signer | tail -n 1 | awk '{print $2}')/clients/linux/cosign-amd64.gz
-    GITSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n trusted-artifact-signer | tail -n 1 | awk '{print $2}')/clients/linux/gitsign-amd64.gz
+    COSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n {{
+    ocp4_workload_trusted_application_pipeline_rhtas_namespace }} | tail -n 1 | awk '{print $2}')/clients/linux/cosign-amd64.gz
+    GITSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n {{
+    ocp4_workload_trusted_application_pipeline_rhtas_namespace }}| tail -n 1 | awk '{print $2}')/clients/linux/gitsign-amd64.gz
     wget -q $COSIGN_CLI_URL
     wget -q $GITSIGN_CLI_URL
     gunzip cosign-amd64.gz

--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
@@ -1,9 +1,16 @@
 ---
 - name: Install and configure cosign
   ansible.builtin.shell: |
-    wget "https://github.com/sigstore/cosign/releases/download/v2.0.0/cosign-linux-amd64"
-    sudo mv cosign-linux-amd64 /usr/local/bin/cosign
-    sudo chmod +x /usr/local/bin/cosign
+    COSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n trusted-artifact-signer | tail -n 1 | awk '{print $2}')/clients/linux/cosign-amd64.gz
+    GITSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n trusted-artifact-signer | tail -n 1 | awk '{print $2}')/clients/linux/gitsign-amd64.gz
+    wget -q $COSIGN_CLI_URL
+    wget -q $GITSIGN_CLI_URL
+    gunzip cosign-amd64.gz
+    chmod a+x cosign-amd64
+    mv cosign-amd64 /usr/local/bin/cosign
+    gunzip gitsign-amd64.gz
+    chmod a+x gitsign-amd64
+    mv gitsign-amd64 /usr/local/bin/gitsign
     cosign login -u {{ ocp4_workload_trusted_application_pipeline_docker_username }} -p {{
      ocp4_workload_trusted_application_pipeline_docker_password }} {{
      ocp4_workload_trusted_application_pipeline_docker_registry }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
@@ -4,7 +4,7 @@
     COSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n {{
     ocp4_workload_trusted_application_pipeline_rhtas_namespace }} | tail -n 1 | awk '{print $2}')/clients/linux/cosign-amd64.gz
     GITSIGN_CLI_URL=https://$(oc get routes -l app.kubernetes.io/component=client-server -n {{
-    ocp4_workload_trusted_application_pipeline_rhtas_namespace }}| tail -n 1 | awk '{print $2}')/clients/linux/gitsign-amd64.gz
+    ocp4_workload_trusted_application_pipeline_rhtas_namespace }} | tail -n 1 | awk '{print $2}')/clients/linux/gitsign-amd64.gz
     wget -q $COSIGN_CLI_URL
     wget -q $GITSIGN_CLI_URL
     gunzip cosign-amd64.gz


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Downloads and installs `cosign` and `gitsign` binaries from the RHTAS Cli-Server. 
Reason: The OpenShift Security Roadshow uses the binaries for command line exercises on the bastion host. The fix uses the clis that are part of the operator install. 
The previous version used an outdated upstream cosign version that doesn't work with the current TAS anymore. gitsign was completely missing but is required for an exercise, too.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```

```
