### PR TITLE
fix: missing sudo to mv to /usr/local/bin

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml
@@ -9,10 +9,10 @@
     wget -q $GITSIGN_CLI_URL
     gunzip cosign-amd64.gz
     chmod a+x cosign-amd64
-    mv cosign-amd64 /usr/local/bin/cosign
+    sudo mv cosign-amd64 /usr/local/bin/cosign
     gunzip gitsign-amd64.gz
     chmod a+x gitsign-amd64
-    mv gitsign-amd64 /usr/local/bin/gitsign
+    sudo mv gitsign-amd64 /usr/local/bin/gitsign
     cosign login -u {{ ocp4_workload_trusted_application_pipeline_docker_username }} -p {{
      ocp4_workload_trusted_application_pipeline_docker_password }} {{
      ocp4_workload_trusted_application_pipeline_docker_registry }}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Previous PR was missing the `sudo` that the older version included. This fixes it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible/roles_ocp_workloads/ocp4_workload_trusted_application_pipeline/tasks/setup_tekton_chains.yml


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
mv: cannot move 'cosign-amd64' to '/usr/local/bin/cosign': Permission denied
mv: cannot move 'gitsign-amd64' to '/usr/local/bin/gitsign': Permission denied
/bin/sh: line 11: cosign: command not found

```
https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/1357779/output 
