### PR TITLE
Add default for subdomain_base in infra-ec2-template-generate

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
+++ b/ansible/roles-infra/infra-ec2-template-generate/defaults/main.yml
@@ -11,6 +11,7 @@ aws_comment: "Created by Ansible Agnostic Deployer"
 
 aws_vpc_cidr: 192.168.0.0/16
 aws_vpc_name: "{{ subdomain_base }}"
+subdomain_base: "{{ guid }}{{ subdomain_base_suffix }}"
 
 #################################################################
 # Subnet


### PR DESCRIPTION
##### SUMMARY

The `infra-ec2-template-generate` role fails unless `subdomain_base` is defined. The sandbox api provides `subdomain_base_suffix`. This PR uses that var to set a default for `subdomain_base`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role `infra-ec2-template-generate`