### PR TITLE
Adding RHEL96GOLD-latest as infra image

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -32,6 +32,13 @@ infra_images_predefined:
     aws_filters:
       is-public: false
 
+  RHEL96GOLD-latest:
+    owner: "{{ infra_images_redhat_owner_id }}"
+    name: RHEL-9.6.*_HVM_*Access*
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
   RHEL95GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-9.5.*_HVM_*Access*


### PR DESCRIPTION
##### SUMMARY
Add RHEL96GOLD-latest as infra image

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible/roles-infra/infra-images/defaults/main.yaml

##### ADDITIONAL INFORMATION
Adding RHEL96GOLD-latest as infra image ansible/roles-infra/infra-images/defaults/main.yaml as requested by Lab developer.
