### PR TITLE
OCP4_WORKLOAD_QUARKUS_SUPER_HEROES_DEMO  - Update to RHBQ 3.20

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/defaults/main.yml
@@ -19,13 +19,13 @@ ocp4_workload_quarkus_super_heroes_demo_install_prometheus: true
 ocp4_workload_quarkus_super_heroes_demo_install_grafana: false
 
 ocp4_workload_quarkus_super_heroes_demo_temp_dir: /tmp/quarkus_superheroes
-ocp4_workload_quarkus_super_heroes_demo_release_tag: rhbq-3.15
+ocp4_workload_quarkus_super_heroes_demo_release_tag: rhbq-3.20
 ocp4_workload_quarkus_super_heroes_demo_project_name: quarkus-superheroes
 
 # yamllint disable-line rule:line-length
 ocp4_workload_quarkus_super_heroes_demo_github_raw_url: "https://raw.githubusercontent.com/quarkusio/quarkus-super-heroes/{{ ocp4_workload_quarkus_super_heroes_demo_release_tag }}/deploy/k8s"
 
-ocp4_workload_quarkus_super_heroes_demo_java_versions: [17]
+ocp4_workload_quarkus_super_heroes_demo_java_versions: [21]
 ocp4_workload_quarkus_super_heroes_demo_native: native
 ocp4_workload_quarkus_super_heroes_demo_service_project_names:
 - "rest-villains"

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/amqstreams_instance.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/files/amqstreams_instance.yaml
@@ -135,39 +135,26 @@ data:
       type: GAUGE
       labels:
         quantile: "0.$4"
-
-  zookeeper-metrics-config.yml: |
-    # See https://github.com/prometheus/jmx_exporter for more info
-    # about JMX Prometheus Exporter metrics
-    lowercaseOutputName: true
-    rules:
-    # replicated Zookeeper
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
-      name: "zookeeper_$2"
-      type: GAUGE
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
-      name: "zookeeper_$3"
-      type: GAUGE
-      labels:
-        replicaId: "$2"
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(Packets\\w+)"
-      name: "zookeeper_$4"
-      type: COUNTER
-      labels:
-        replicaId: "$2"
-        memberType: "$3"
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
-      name: "zookeeper_$4"
-      type: GAUGE
-      labels:
-        replicaId: "$2"
-        memberType: "$3"
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
-      name: "zookeeper_$4_$5"
-      type: GAUGE
-      labels:
-        replicaId: "$2"
-        memberType: "$3"
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: kraft-dual-role
+  labels:
+    strimzi.io/cluster: fights-kafka
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 100Gi
+        deleteClaim: false
+        kraftMetadata: shared
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
@@ -175,6 +162,9 @@ metadata:
   name: fights-kafka
   labels:
     app: fights-kafka
+  annotations:
+    strimzi.io/kraft: enabled
+    strimzi.io/node-pools: enabled
 spec:
   kafka:
     config:
@@ -183,8 +173,7 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       auto.create.topics.enable: "false"
-    storage:
-      type: ephemeral
+      min.insync.replicas: 2
     listeners:
       - name: plain
         port: 9092
@@ -194,7 +183,6 @@ spec:
         port: 9093
         type: internal
         tls: true
-    replicas: 3
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:
@@ -217,26 +205,6 @@ spec:
   kafkaExporter:
     topicRegex: ".*"
     groupRegex: ".*"
-  zookeeper:
-    storage:
-      type: ephemeral
-    replicas: 3
-    metricsConfig:
-      type: jmxPrometheusExporter
-      valueFrom:
-        configMapKeyRef:
-          name: kafka-metrics
-          key: zookeeper-metrics-config.yml
-    readinessProbe:
-      initialDelaySeconds: 60
-      timeoutSeconds: 15
-      failureThreshold: 5
-      periodSeconds: 30
-    livenessProbe:
-      initialDelaySeconds: 60
-      timeoutSeconds: 15
-      failureThreshold: 5
-      periodSeconds: 30
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/readme.adoc
@@ -1,12 +1,12 @@
 = ocp4-workload-quarkus-super-heroes-demo - Deploy Quarkus Superheroes Demo into OCP4
 
 == Role overview
-This role deploys the https://github.com/quarkusio/quarkus-super-heroes/tree/rhbq-3.2[Quarkus Superheroes Sample application], using Red Hat Build of Quarkus, to OCP4.
+This role deploys the https://github.com/quarkusio/quarkus-super-heroes/tree/rhbq-3.20[Quarkus Superheroes Sample application], using Red Hat Build of Quarkus, to OCP4.
 
 2 projects are created in the cluster:
 
-* `quarkus-superheroes-java17`
-** Contains https://github.com/quarkusio/quarkus-super-heroes/blob/rhbq-3.2/deploy/k8s/java17-openshift.yml[JVM Java 17 version of the system]
+* `quarkus-superheroes-java21`
+** Contains https://github.com/quarkusio/quarkus-super-heroes/blob/rhbq-3.2/deploy/k8s/java21-openshift.yml[JVM Java 21 version of the system]
 * `quarkus-superheroes-native`
 ** Contains https://github.com/quarkusio/quarkus-super-heroes/blob/rhbq-3.2/deploy/k8s/native-openshift.yml[Native version of the system]
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/templates/opentelemetry_collector_instance.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/templates/opentelemetry_collector_instance.yaml.j2
@@ -24,7 +24,7 @@ spec:
         tls:
           insecure: true
     processors:
-      batch:
+      batch: {}
     service:
       telemetry:
         metrics:

--- a/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/templates/opentelemetry_collector_instance.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_quarkus_super_heroes_demo/templates/opentelemetry_collector_instance.yaml.j2
@@ -25,11 +25,15 @@ spec:
           insecure: true
     processors:
       batch:
-    extensions:
-      health_check:
     service:
-      extensions:
-        - health_check
+      telemetry:
+        metrics:
+          readers:
+            - periodic:
+                exporter:
+                  otlp:
+                    protocol: grpc
+                    endpoint: 0.0.0.0:4317
       pipelines:
         traces:
           receivers:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This is to move the `OCP4_WORKLOAD_QUARKUS_SUPER_HEROES_DEMO` to the red hat build of Quarkus 3.20 along with moving to OpenShift 4.18.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
OCP4_WORKLOAD_QUARKUS_SUPER_HEROES_DEMO
