### PR TITLE
Remove the 'vllm serve' from systemd template, it is implicit

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_rhaiis_on_rhel/templates/rhaiis.service.j2
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_rhaiis_on_rhel/templates/rhaiis.service.j2
@@ -16,7 +16,8 @@ ExecStart=/usr/bin/podman run --rm -it --device nvidia.com/gpu=all -p {{ setup_r
     {{ setup_rhaiis_on_rhel_vllm_container_image }} \
     --tensor-parallel-size {{ setup_rhaiis_on_rhel_vllm_tensor_parallel_size }} \
     --max-model-len {{ setup_rhaiis_on_rhel_vllm_max_model_len }} \
-    --enforce-eager {{ setup_rhaiis_on_rhel_vllm_model }}
+    --enforce-eager \
+    --model {{ setup_rhaiis_on_rhel_vllm_model }}
 ExecStop=/usr/bin/podman stop {{ setup_rhaiis_on_rhel_vllm_container_name }}
 Restart=on-failure
 RestartSec=5s

--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_rhaiis_on_rhel/templates/rhaiis.service.j2
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_rhaiis_on_rhel/templates/rhaiis.service.j2
@@ -14,7 +14,6 @@ ExecStart=/usr/bin/podman run --rm -it --device nvidia.com/gpu=all -p {{ setup_r
     -v {{ setup_rhaiis_on_rhel_vllm_cache_dir }}:/home/vllm/.cache \
     --name={{ setup_rhaiis_on_rhel_vllm_container_name }} \
     {{ setup_rhaiis_on_rhel_vllm_container_image }} \
-    vllm serve \
     --tensor-parallel-size {{ setup_rhaiis_on_rhel_vllm_tensor_parallel_size }} \
     --max-model-len {{ setup_rhaiis_on_rhel_vllm_max_model_len }} \
     --enforce-eager {{ setup_rhaiis_on_rhel_vllm_model }}


### PR DESCRIPTION
##### SUMMARY

The systemd template contained a podman run arg `vllm serve` that is implicit and breaks the service.

Removed

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

agnosticd/ai/roles/setup_rhaiis_on_rhel

##### ADDITIONAL INFORMATION

Thanks Anshul Behl @anshulbehl 