### PR TITLE
Add agnosticd_user_info to control-user role

### DIFF
--- a/ansible/roles/control-user/README.adoc
+++ b/ansible/roles/control-user/README.adoc
@@ -35,6 +35,7 @@ control-user/
     ├── create-directory.yml
     ├── create-user.yml
     ├── main.yml
+    ├── report-user-data.yml
     └── ssh-config.yml
 
 4 directories, 11 files

--- a/ansible/roles/control-user/defaults/main.yml
+++ b/ansible/roles/control-user/defaults/main.yml
@@ -1,8 +1,20 @@
 ---
 
+control_user_create_env_ssh_authorized_keys: true
+control_user_enable_env_ssh_keys: true
+control_user_enable_skel: true
+control_user_enable_sudoers: true
+control_user_enable_user_data: true
+control_user_enable_user_data_ssh_provision_key: false
+control_user_enable_user_data_by_hostname: false
+
 ## User skel files used in tasks/main.yml
 control_user_skel_files:                # list of user skel files
   - .vimrc
+
+control_user_sudo_commands: 'NOPASSWD: ALL'
+
+env_authorized_key: "{{ guid }}key"
 
 ## User's variable used in tasks/create-user.yml
 control_user_name: devops               # User name

--- a/ansible/roles/control-user/tasks/create-directory.yml
+++ b/ansible/roles/control-user/tasks/create-directory.yml
@@ -6,7 +6,7 @@
     dest: "/home/{{ control_user_name }}/{{ control_user_resource_dir_name }}"
     owner: "{{ control_user_name }}"
     group: "{{ control_user_private_group }}"
-    mode: 0755
+    mode: u=rwx,go=rx
     state: directory
 
 - name: Create user's custom directory
@@ -20,5 +20,4 @@
   loop: "{{ control_user_directories }}"
   loop_control:
     loop_var: __user_dir
-
 ...

--- a/ansible/roles/control-user/tasks/create-user.yml
+++ b/ansible/roles/control-user/tasks/create-user.yml
@@ -9,11 +9,10 @@
     update_password: "{{ control_user_password_update | default(omit) }}"
     state: present
 
-- name: Set random ssh user {{ control_user_name }} password
+- name: Set ssh user {{ control_user_name }} password
   when: control_user_password is defined
   ansible.builtin.user:
     name: "{{ control_user_name }}"
-    password: "{{ control_user_password | password_hash('sha512') | default(omit) }}"
+    password: "{{ control_user_password | password_hash('sha512') }}"
     update_password: always
-
 ...

--- a/ansible/roles/control-user/tasks/main.yml
+++ b/ansible/roles/control-user/tasks/main.yml
@@ -5,7 +5,7 @@
     src: "{{ item }}"
     dest: "/etc/skel/"
   loop: "{{ control_user_skel_files }}"
-  when: control_user_enable_skel | default(true) | bool
+  when: control_user_enable_skel | bool
 
 - name: Create user {{ control_user_name }}
   ansible.builtin.include_tasks:
@@ -17,10 +17,10 @@
 
 - name: Enable sudoers
   ansible.builtin.copy:
-    content: "{{ control_user_name }} ALL=(ALL) {{ control_user_sudo_commands | default('NOPASSWD: ALL') }}"
+    content: "{{ control_user_name }} ALL=(ALL) {{ control_user_sudo_commands }}"
     dest: '/etc/sudoers.d/{{ control_user_name }}'
-    mode: 0640
-  when: control_user_enable_sudoers | default(true) | bool
+    mode: u=rw,g=r,o=-
+  when: control_user_enable_sudoers | bool
 
 - name: SSH setup for user
   ansible.builtin.include_tasks:
@@ -38,4 +38,8 @@
   ansible.builtin.include_tasks:
     file: copy-contents.yml
 
+- name: Report user data
+  when: control_user_enable_user_data | bool
+  ansible.builtin.include_tasks:
+    file: report-user-data.yml
 ...

--- a/ansible/roles/control-user/tasks/report-user-data.yml
+++ b/ansible/roles/control-user/tasks/report-user-data.yml
@@ -1,0 +1,35 @@
+---
+- name: Report user data
+  throttle: 1
+  agnosticd_user_info:
+    data: >-
+      {{
+        {
+          "hosts":
+            lookup('agnosticd_user_data', 'hosts') |
+            default({}, true) |
+            combine({
+              inventory_hostname: {
+                "ssh_host": public_dns_name,
+                "user": control_user_name,
+                "password": control_user_password,
+              }
+            })
+        }
+        if control_user_enable_user_data_by_hostname | bool else
+        {
+          "ssh_host": public_dns_name,
+          "user": control_user_name,
+          "password": control_user_password,
+        }
+      }}
+
+- name: Report user data ssh key
+  when:
+  - control_user_enable_user_data_ssh_provision_key | bool
+  - hostvars.localhost.ssh_provision_key_path is defined
+  agnosticd_user_info:
+    data:
+      ssh_private_key: "{{ lookup('file', hostvars.localhost.ssh_provision_key_path) }}"
+        
+...

--- a/ansible/roles/control-user/tasks/report-user-data.yml
+++ b/ansible/roles/control-user/tasks/report-user-data.yml
@@ -31,5 +31,4 @@
   agnosticd_user_info:
     data:
       ssh_private_key: "{{ lookup('file', hostvars.localhost.ssh_provision_key_path) }}"
-        
 ...

--- a/ansible/roles/control-user/tasks/ssh-config.yml
+++ b/ansible/roles/control-user/tasks/ssh-config.yml
@@ -3,43 +3,49 @@
 - name: create /home/{{ control_user_name }}/.ssh
   ansible.builtin.file:
     dest: /home/{{ control_user_name }}/.ssh
-    mode: 0700
+    mode: u=rwx,go=-
     owner: "{{ control_user_name }}"
     group: "{{ control_user_private_group }}"
     state: directory
 
-- when: control_user_enable_env_ssh_keys | default(true) | bool
+- when: control_user_enable_env_ssh_keys | bool
   block:
     - name: copy the environment .pem key
       ansible.builtin.copy:
-        src: "{{ hostvars.localhost.ssh_provision_key_path
-              | default(hostvars.localhost.env_authorized_key_path) }}"
+        src: >-
+          {{ hostvars.localhost.ssh_provision_key_path
+           | default(hostvars.localhost.env_authorized_key_path)
+          }}
         dest: "/home/{{ control_user_name }}/.ssh/{{env_authorized_key}}.pem"
         owner: "{{ control_user_name }}"
         group: "{{ control_user_private_group }}"
-        mode: 0400
+        mode: u=r,go=-
 
     - name: copy the environment .pub key
       ansible.builtin.copy:
-        content: "{{ hostvars.localhost.ssh_provision_pubkey_content
-          | default(hostvars.localhost.env_authorized_key_content_pub) }}"
+        content: >-
+          {{ hostvars.localhost.ssh_provision_pubkey_content
+           | default(hostvars.localhost.env_authorized_key_content_pub)
+          }}
         dest: "/home/{{ control_user_name }}/.ssh/{{env_authorized_key}}.pub"
         owner: "{{ control_user_name }}"
         group: "{{ control_user_private_group }}"
-        mode: 0400
+        mode: u=r,go=-
 
 - name: Create authorized keys
-  when: control_user_create_env_ssh_authrized_keys | default(true) | bool
+  when: control_user_create_env_ssh_authorized_keys | bool
   ansible.builtin.lineinfile:
     path: "/home/{{ control_user_name }}/.ssh/authorized_keys"
-    line: "{{ hostvars.localhost.ssh_provision_pubkey_content
-          | default(hostvars.localhost.env_authorized_key_content_pub) }}"
+    line: >-
+      {{ hostvars.localhost.ssh_provision_pubkey_content
+       | default(hostvars.localhost.env_authorized_key_content_pub)
+      }}
     create: true
     insertafter: 'EOF'
     state: present
     owner: "{{ control_user_name }}"
     group: "{{ control_user_private_group }}"
-    mode: 0400
+    mode: u=r,go=-
 
 - name: copy custom ssh key
   when: control_user_custom_ssh_keys is defined
@@ -48,7 +54,7 @@
     dest: "/home/{{ control_user_name }}/.ssh/"
     owner: "{{ control_user_name }}"
     group: "{{ control_user_private_group }}"
-    mode: 0400
+    mode: u=r,go=-
   loop: "{{ control_user_custom_ssh_keys }}"
   loop_control:
     loop_var: __custom_key
@@ -59,7 +65,7 @@
     dest: /home/{{ control_user_name }}/.ssh/config
     owner: "{{ control_user_name }}"
     group: "{{ control_user_private_group }}"
-    mode: 0400
+    mode: u=r,go=-
   when: control_user_ssh_config is defined
 
 - name: Setup ssh by password


### PR DESCRIPTION
- Add `control_user_enable_user_data` and related vars to support reporting access details.
##### SUMMARY

- Move default vars to defaults and cleanup default filters.
- Add default for `env_authorized_key`.
- Use symbolic file permissions rather than octal.
- Cleanup task name which implied random password generation.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

Role control-user.