### PR TITLE
Fix bug with multiple bastion hosts

### DIFF
--- a/ansible/roles-infra/infra-common-ssh-config-generate/tasks/main.yml
+++ b/ansible/roles-infra/infra-common-ssh-config-generate/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Store bastion hostname as a fact
   set_fact:
-    bastion_hostname: "{{groups['bastions'].0 }}"
+    bastion_hostname: "{{ groups.bastions | sort | first }}"
     # This is where the ssh_config file will be created, this file is used to
     # define the communication method to all the hosts in the deployment
     ansible_ssh_config: "{{output_dir}}/{{ env_type }}_{{ guid }}_ssh_conf"

--- a/ansible/roles-infra/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-create-inventory/tasks/main.yml
@@ -34,17 +34,20 @@
     - create_inventory
     - must
 
-# Find the bastion
-- name: Find the bastion in this batch of host
-  set_fact:
-    local_bastion: "{{ item.tags.internaldns }}"
-  when:
-    - item.state.name != 'terminated'
-    - '"bastions" in item.tags.AnsibleGroup'
-  with_items: "{{ ec2_info['instances'] }}"
+- name: Find the bastion in this batch of hosts
+  loop: >-
+    {{ ec2_info.instances
+     | json_query("[?state.name != 'terminated' && tags.internaldns]")
+     | sort(attribute="tags.internaldns")
+    }}
   loop_control:
-    label: "{{ item.tags.internaldns | default(item.private_dns_name) }}"
-  ignore_errors: true
+    loop_var: __instance
+    label: "{{ __instance.tags.internaldns }}"
+  when:
+    - "'bastions' in __instance.tags.AnsibleGroup | default('') | split(',')"
+    - local_bastion is undefined
+  set_fact:
+    local_bastion: "{{ __instance.tags.internaldns }}"
 
 - name: Add hosts to the current inventory
   add_host:


### PR DESCRIPTION
##### SUMMARY

- Make roles consistently use first bastion by sorted list when multiple hosts belong to the bastions group.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role `infra-ec2-create-inventory`
Role `infra-common-ssh-config-generate`