### PR TITLE
IBM Cloud: automatically detect availability zone

### DIFF
--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -20,7 +20,7 @@
           The floating IP for {{ _instance_name }}
           is {{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}
 
-    - name: DNS entry ({{ _dns_state | default('present') }})
+    - name: DNS entry nsupdate ({{ _dns_state | default('present') }})
       when: cluster_dns_server is defined
       nsupdate:
         server: >-
@@ -38,7 +38,7 @@
         key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
         key_secret: "{{ ddns_key_secret }}"
 
-    - name: DNS entry ({{ _dns_state | default('present') }})
+    - name: DNS entry route53 ({{ _dns_state | default('present') }})
       when: route53_aws_zone_id is defined
       route53:
         state: present

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_networks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_networks.yaml
@@ -36,3 +36,8 @@
     total_ipv4_address_count: "64"
     zone: "{{ ibmcloud_availability_zone }}"
     region: "{{ ibmcloud_region }}"
+
+- name: save availability zone to ibmcloud_availability_zone
+  set_fact:
+    ibmcloud_availability_zone: >-
+      {{ ibmcloud_vpc_subnet_create.resource.zone }}

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/login.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/login.yaml
@@ -5,6 +5,10 @@
     --apikey {{ ibmcloud_api_key |quote }}
     -r {{ ibmcloud_region | quote }}
     -g {{ ibmcloud_resource_group_name | quote }}
+  retries: 5
+  delay: 60
+  register: ibmcloud_login
+  until: ibmcloud_login is succeeded
 
 - name: Disable auto update checks
   command: >-


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Instead of relying on a static zone, use the automatically one picked
from the subnet.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

