### PR TITLE
IBMCloud: Add data volume lifecycle management

### DIFF
--- a/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
@@ -122,11 +122,11 @@
       ansible.builtin.include_role:
         name: infra-generic-wait_for_linux_hosts
       vars:
-        infra_generic_wait_for_linux_hosts_delay: 30
-        infra_generic_wait_for_linux_hosts_sleep: 10
+        infra_generic_wait_for_linux_hosts_delay: 1
+        infra_generic_wait_for_linux_hosts_sleep: 5
         infra_generic_wait_for_linux_hosts_connect_timeout: 20
         infra_generic_wait_for_linux_hosts_timeout: 300
-        infra_generic_wait_for_linux_hosts_retries: 10
+        infra_generic_wait_for_linux_hosts_retries: 25
 
     - name: Add authorized_keys
       ansible.builtin.include_role:
@@ -135,3 +135,38 @@
         ssh_authorized_keys | default([]) | length > 0
         or
         all_ssh_authorized_keys | default([]) | length > 0
+
+    - name: Set volumes fact using deployer(localhost) from previous steps
+      set_fact:
+        host_ibmcloud_volumes: >-
+          {{ hostvars.localhost.get('ibmcloud_volumes', {})[inventory_hostname] | default([]) }}
+
+    - name: DEBUG | Show the volumes fact received by this host
+      ansible.builtin.debug:
+        var: host_ibmcloud_volumes
+        verbosity: 2
+
+    - name: Format and mount disks if any
+      when: host_ibmcloud_volumes | length > 0
+      block:
+        # Gather block device info from the host (runs once per host).
+        - name: Get block device details
+          ansible.builtin.command: lsblk -O --json
+          register: _lsblk_output
+          changed_when: false
+
+        - name: Parse block device details into a fact
+          ansible.builtin.set_fact:
+            _host_block_devices: "{{ (_lsblk_output.stdout | from_json).blockdevices }}"
+
+        - debug:
+            verbosity: 2
+            var: _host_block_devices
+
+        - name: Process volumes that need formatting or mounting
+          loop: "{{ host_ibmcloud_volumes }}"
+          loop_control:
+            loop_var: _volume
+            label: "{{ _volume.name | default(_volume.id) }}"
+          ansible.builtin.include_tasks: ibm_resource_group_mount_volume.yaml
+          when: _volume.fstype is defined or _volume.mount is defined

--- a/ansible/cloud_providers/ibm_resource_group_mount_volume.yaml
+++ b/ansible/cloud_providers/ibm_resource_group_mount_volume.yaml
@@ -1,0 +1,52 @@
+---
+# STEP: Discover the device on the host by matching its serial number.
+- name: "Find device for volume ID {{ _volume.id }}"
+  ansible.builtin.set_fact:
+    _matched_device: >-
+      {{ _host_block_devices
+      | selectattr('serial', 'defined')
+      | selectattr('serial', 'in', _volume.id)
+      | list | first
+      }}
+
+- name: "Verify a device was found"
+  ansible.builtin.fail:
+    msg: "Could not find a matching block device on host for volume ID {{ _volume.id }}"
+  when: _matched_device is not defined
+
+# STEP: Create the filesystem.
+- name: "Create {{ _volume.fstype | default('xfs') }} filesystem on {{ _matched_device.path }}"
+  community.general.filesystem:
+    fstype: "{{ _volume.fstype | default('xfs') }}" # Default to xfs
+    dev: "{{ _matched_device.path }}"
+  register: _filesystem_result
+
+# STEP: Get the new filesystem's UUID for robust mounting.
+- name: "Get filesystem UUID from {{ _matched_device.path }}"
+  ansible.builtin.command: "blkid -s UUID -o value {{ _matched_device.path }}"
+  register: _blkid_result
+  changed_when: false
+
+- name: Set filesystem UUID fact
+  ansible.builtin.set_fact:
+    _device_uuid: "{{ _blkid_result.stdout }}"
+  when: _blkid_result.stdout != ""
+
+# STEP: Mount the volume using its UUID.
+- name: "Ensure mount point {{ _volume.mount }} exists"
+  ansible.builtin.file:
+    path: "{{ _volume.mount }}"
+    state: directory
+    mode: '0755'
+  when: _volume.mount is defined
+
+- name: "Mount device at {{ _volume.mount }} using its UUID"
+  ansible.posix.mount:
+    path: "{{ _volume.mount }}"
+    src: "UUID={{ _device_uuid }}"
+    fstype: "{{ _volume.fstype | default('xfs') }}" # Default to xfs
+    opts: "{{ _volume.mount_opts | default(omit) }}" # Add custom mount options
+    state: mounted
+  when:
+    - _volume.mount is defined
+    - _device_uuid is defined

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
@@ -21,6 +21,7 @@
   loop: "{{ r_ibmcloud_instances.resource.instances | list }}"
   loop_control:
     loop_var: instance
+    label: "{{ instance.shortname | default(instance.name) }}"
   ansible.builtin.add_host:
     name: "{{ instance.name }}"
     shortname: "{{ instance.name }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/create_inventory.yaml
@@ -10,3 +10,4 @@
   loop: "{{ r_ibmcloud_instances.resource.instances }}"
   loop_control:
     loop_var: instance
+    label: "{{ instance.shortname | default(instance.name) }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/checks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/checks.yaml
@@ -1,0 +1,6 @@
+---
+- name: Ensure volume names are unique
+  assert:
+    that:
+      - instances | json_query('[].volumes[].name') | default([]) | length == instances | json_query('[].volumes[].name') | default([]) | unique | length
+    fail_msg: "Volume names must be unique across all instances."

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -70,3 +70,9 @@
 - name: Fill publicips variable
   set_fact:
     publicips: "{{ publicips + [{'name': ibmcloud_vs_instance_create.resource.name, 'ip': r_ibmcloud_fip.resource.address}] }}"
+
+- name: Create volumes
+  loop: "{{ instance.volumes | default([]) }}"
+  loop_control:
+    loop_var: _volume
+  ansible.builtin.include_tasks: create_volume.yaml

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_networks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_networks.yaml
@@ -37,7 +37,7 @@
     zone: "{{ ibmcloud_availability_zone }}"
     region: "{{ ibmcloud_region }}"
 
-- name: save availability zone to ibmcloud_availability_zone
+- name: save availability zone to ibmcloud_availability_zone (idempotency)
   set_fact:
     ibmcloud_availability_zone: >-
       {{ ibmcloud_vpc_subnet_create.resource.zone }}

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
@@ -1,0 +1,108 @@
+---
+- name: Check correctness of user input
+  ansible.builtin.assert:
+    that:
+      - _volume is defined
+      - _volume.name is defined
+      - _volume.size is defined
+    fail_msg: >-
+      Volume name, size must be defined.
+      Example: _volume: { name: 'my-volume', size: 100}
+
+- name: Create data volume
+  command: >-
+    ibmcloud is volume-create
+    --name disk-{{ guid  ~ '-' ~ _volume.name }}
+    --profile {{ _volume.type | default('general-purpose') }}
+    --capacity {{ _volume.size }}
+    --resource-group-id {{ r_ibmcloud_resource_group_id}}
+    --zone {{ ibmcloud_availability_zone }}
+    --tags {{ guid }}
+    --json
+  register: ibmcloud_volume_create
+  failed_when: >-
+    ibmcloud_volume_create.rc != 0
+    and 'already exists' not in ibmcloud_volume_create.stderr
+
+# It's a more robust and readable way to get the volume's details.
+# rather than parsing the output of the create command (idempotent)
+- name: Get authoritative details for the volume
+  # We run this command regardless of the previous step. This ensures we always
+  # get the definitive, current details of the volume, whether it was just
+  # created or it already existed. The '--output JSON' flag is correct.
+  command: >-
+    ibmcloud is volume disk-{{ guid  ~ '-' ~ _volume.name }} --output JSON
+  register: _volume_details
+
+- debug:
+    verbosity: 2
+    var: _volume_details
+
+- name: Set the _volume_to_attach fact
+  ansible.builtin.set_fact:
+    _volume_to_attach: "{{ _volume_details.stdout | from_json }}"
+
+- name: Attach existing volume to instance
+  command: >-
+    ibmcloud is instance-volume-attachment-add
+    attachment-{{ guid }}-{{ _volume.name }}
+    {{ ibmcloud_vs_instance.resource.name }}
+    {{ _volume_to_attach.id }}
+    --auto-delete {{ _volume.auto_delete | default(true) }}
+    --json
+  register: ibmcloud_volume_attach
+  failed_when: >-
+    ibmcloud_volume_attach.rc != 0
+    and 'already attached' not in ibmcloud_volume_attach.stderr
+    and 'is in use' not in ibmcloud_volume_attach.stderr
+
+- name: Get authoritative details for the volume attachment
+  # This task always runs to get the definitive state of the attachment,
+  # regardless of whether the previous task made a change or was skipped.
+  command: >-
+    ibmcloud is instance-volume-attachment
+    {{ ibmcloud_vs_instance.resource.name }}
+    attachment-{{ guid }}-{{ _volume.name }}
+    --output JSON
+  register: _attachment_details
+
+- name: Save fact for IBM Cloud Volume attachment
+  ansible.builtin.set_fact:
+    _attachment: >-
+      {{ _attachment_details.stdout | from_json }}
+  when: _attachment_details is defined and _attachment_details.stdout != ""
+
+- debug:
+    var: _attachment
+    verbosity: 2
+  when: _attachment is defined
+
+- name: Save fact for IBM Cloud Volume, index by instance name
+  when: >-
+    _attachment is defined
+
+  # Save ID, mount point, size, fstype
+  ansible.builtin.set_fact:
+    ibmcloud_volumes: >-
+      {{
+        ibmcloud_volumes | default({}) | combine(
+          {
+            ibmcloud_vs_instance.resource.name:
+              (ibmcloud_volumes[ibmcloud_vs_instance.resource.name] | default([])) +
+              [{
+                'name': _volume.name,
+                'id': _attachment.device.id,
+                'fstype': _volume.fstype | default(omit),
+                'mount': _volume.mount | default(omit),
+                'mount_opts': _volume.mount_opts | default(omit)
+              }]
+          },
+          recursive=true
+        )
+      }}
+
+- name: DEBUG | Show the final aggregated volumes dictionary
+  ansible.builtin.debug:
+    verbosity: 2
+    var: ibmcloud_volumes
+  when: ibmcloud_volumes is defined

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instances.yaml
@@ -9,4 +9,5 @@
   loop: "{{ r_ibmcloud_instances.resource.instances }}"
   loop_control:
     loop_var: instance
+    label: "{{ instance.shortname | default(instance.name) }}"
   ansible.builtin.include_tasks: delete_instance.yaml

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_networks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_networks.yaml
@@ -15,7 +15,6 @@
     vpc: "{{ r_ibmcloud_vpc.resource.id }}"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
     state: absent
-    zone: "{{ ibmcloud_availability_zone }}"
     region: "{{ ibmcloud_region }}"
   loop: "{{ r_ibmcloud_vpc.resource.subnets }}"
 

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/main.yaml
@@ -1,6 +1,7 @@
 ---
 - when: ACTION == 'provision'
   block:
+    - ansible.builtin.include_tasks: checks.yaml
     - ansible.builtin.include_tasks: create_resource_group.yaml
     - ansible.builtin.include_tasks: login.yaml
     - ansible.builtin.include_tasks: create_ssh_key.yaml


### PR DESCRIPTION
This commit introduces the capability to define, create, attach, format, and mount data volumes on IBM Cloud instances. The entire process is designed to be fully idempotent and automated, managed through a new `volumes` list in the `instances` definition. The automation handles the entire process from provisioning the cloud resource to providing a ready-to-use mounted filesystem inside the guest OS.

The implementation is split into two main phases:

1.  **Provisioning Phase (`infra-ibm-resource-group-resources` role):**
    - A new `create_volume.yaml` task flow is introduced, which is looped for each volume defined for an instance.
    - This flow follows a "ensure state, then get authoritative info" pattern for both volume creation and attachment, making it idempotent and safe for re-runs.
    - Adds a pre-flight check to ensure all volume names are unique.

2.  **Configuration Phase (on target hosts):**
    - After instance provisioning, a new block in the deployment playbook now handles the formatting and mounting of the attached volumes.
    - The new logic discovers the block device using IBM Cloud disk ID, creates a filesystem (defaults to `xfs`), and mounts it using its stable filesystem UUID for persistence.

To use this feature, define a `volumes` list for any instance in the input variables. The automation handles creation, attachment, and configuration based on the keys provided.

```yaml
instances:
  - name: "bastion-{{ guid }}"
    # ... other instance parameters ...
    volumes:
      # Case 1: Fully configured volume with default 'xfs' filesystem.
      # Action: Created, attached, formatted with xfs, and mounted on /mnt/vol0.
      - name: "data-vol0"
        size: 50
        mount: "/mnt/vol0"

      # Case 2: Volume with 'ext4' filesystem and custom mount options.
      # Action: Created, attached, formatted with ext4, and mounted with 'noexec'.
      - name: "data-vol1"
        size: 20
        mount: "/mnt/data-app"
        fstype: "ext4"
        mount_opts: "noexec,nodev"

      # Case 3: A volume that is only formatted, but not mounted.
      # Action: Created, attached, and formatted with xfs. No /etc/fstab entry.
      - name: "unmounted-vol"
        size: 100
        fstype: "xfs"

      # Case 4: A raw volume that is only attached.
      # Action: Created and attached. No filesystem is created.
      - name: "raw-data-vol"
        size: 75
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- IBM Cloud core
