### PR TITLE
[base-infra][bastion-student-user] Fix targethost and bastion_ssh_command for CNV

### DIFF
--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -60,7 +60,7 @@
               ssh_password: "{{ student_password }}"
               ssh_username: "{{ student_name }}"
               guid: "{{ guid }}"
-              targethost: "{{ groups['bastions'][0] | regex_replace('\\..*$') }}.{{ guid }}{{ subdomain_base_suffix }}"
+              targethost: "{{ openshift_cnv_ssh_address }}"
               targetport: "{{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
               subdomain: "{{ guid }}{{ subdomain_base_suffix }}"
               subdomain_internal: "{{ chomped_zone_internal_dns | default('') }}"

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -87,6 +87,12 @@
         ssh {{ student_name }}@{{ bastion_public_hostname }}
 
         Make sure you use the username '{{ student_name }}' and the password '{{ student_password }}' when prompted.
+
+  - name: Store access info (non CNV)
+    when:
+    - bastion_student_set_user_data | bool
+    - not cloud_provider == "openshift_cnv"
+    agnosticd_user_info:        
       data:
         bastion_public_hostname: "{{ bastion_public_hostname }}"
         bastion_ssh_password: "{{ student_password }}"
@@ -103,6 +109,12 @@
         ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
 
         Make sure you use the username '{{ student_name }}' and the password '{{ student_password }}' when prompted.
+
+  - name: Store access info (CNV)
+    when:
+    - bastion_student_set_user_data | bool
+    - cloud_provider == "openshift_cnv"
+    agnosticd_user_info:
       data:
         bastion_public_hostname: "{{ bastion_public_hostname }}"
         bastion_ssh_password: "{{ student_password }}"

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -87,6 +87,11 @@
         ssh {{ student_name }}@{{ bastion_public_hostname }}
 
         Make sure you use the username '{{ student_name }}' and the password '{{ student_password }}' when prompted.
+      data:
+        bastion_public_hostname: "{{ bastion_public_hostname }}"
+        bastion_ssh_password: "{{ student_password }}"
+        bastion_ssh_user_name: "{{ student_name }}"
+        bastion_ssh_command: "ssh {{ student_name }}@{{ bastion_public_hostname }}"
 
   - name: Print access info (CNV)
     when:
@@ -95,23 +100,14 @@
     agnosticd_user_info:
       msg: |
         You can access your bastion via SSH:
-        ssh {{ student_name }}@{{ bastion_public_hostname }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
+        ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}
 
         Make sure you use the username '{{ student_name }}' and the password '{{ student_password }}' when prompted.
-
-  - name: Set access data
-    when: bastion_student_set_user_data | bool
-    agnosticd_user_info:
       data:
         bastion_public_hostname: "{{ bastion_public_hostname }}"
         bastion_ssh_password: "{{ student_password }}"
         bastion_ssh_user_name: "{{ student_name }}"
-        bastion_ssh_command: "ssh {{ student_name }}@{{ bastion_public_hostname }}"
-
-  - name: Set bastion port for CNV
-    when: cloud_provider == "openshift_cnv"
-    agnosticd_user_info:
-      data:
+        bastion_ssh_command: "ssh {{ student_name }}@{{ openshift_cnv_ssh_address }} -p {{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
         bastion_ssh_port: "{{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
 
 - name: Prepare student user for using Ansible within the environment


### PR DESCRIPTION
##### SUMMARY

Currently is working for showroom because the connectivy is internal, changing the domain to rhdp.net raises the variables are different to specify the ssh host

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
base-infra config
bastion-student-user role

