### PR TITLE
[ADVANCED_GITOPS] Label namespaces for Argo CD

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
@@ -52,42 +52,42 @@
 
 - name: Label dev namespaces to be managed by Argo CD
   kubernetes.core.k8s:
-      state: present
-      definition:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          labels:
-            argocd.argoproj.io/managed-by: user{{ n }}-argocd
-          name: "user{{ n }}-dev"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          argocd.argoproj.io/managed-by: user{{ n }}-argocd
+        name: "user{{ n }}-dev"
   loop: "{{ range(1, num_users | int + 1) | list }}"
   loop_control:
     loop_var: n
 
 - name: Label stage namespaces to be managed by Argo CD
   kubernetes.core.k8s:
-      state: present
-      definition:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          labels:
-            argocd.argoproj.io/managed-by: user{{ n }}-argocd
-          name: "user{{ n }}-stage"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          argocd.argoproj.io/managed-by: user{{ n }}-argocd
+        name: "user{{ n }}-stage"
   loop: "{{ range(1, num_users | int + 1) | list }}"
   loop_control:
     loop_var: n
 
 - name: Label prod namespaces to be managed by Argo CD
   kubernetes.core.k8s:
-      state: present
-      definition:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          labels:
-            argocd.argoproj.io/managed-by: user{{ n }}-argocd
-          name: "user{{ n }}-prod"
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        labels:
+          argocd.argoproj.io/managed-by: user{{ n }}-argocd
+        name: "user{{ n }}-prod"
   loop: "{{ range(1, num_users | int + 1) | list }}"
   loop_control:
     loop_var: n

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
@@ -50,6 +50,48 @@
   loop_control:
     loop_var: n
 
+- name: Label dev namespaces to be managed by Argo CD
+  kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          labels:
+            argocd.argoproj.io/managed-by: user{{ n }}-argocd
+          name: "user{{ n }}-dev"
+  loop: "{{ range(1, num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: n
+
+- name: Label stage namespaces to be managed by Argo CD
+  kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          labels:
+            argocd.argoproj.io/managed-by: user{{ n }}-argocd
+          name: "user{{ n }}-stage"
+  loop: "{{ range(1, num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: n
+
+- name: Label prod namespaces to be managed by Argo CD
+  kubernetes.core.k8s:
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          labels:
+            argocd.argoproj.io/managed-by: user{{ n }}-argocd
+          name: "user{{ n }}-prod"
+  loop: "{{ range(1, num_users | int + 1) | list }}"
+  loop_control:
+    loop_var: n
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/templates/argocd_cr.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/templates/argocd_cr.yaml.j2
@@ -25,6 +25,7 @@ spec:
     defaultPolicy: ''
     policy: |
       g, system:cluster-admins, role:admin
+      g, cluster-admins, role:admin
     scopes: '[groups]'
   redis:
     resources:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

This PR labels user workspaces to be managed by their corresponding Argo CD instance using the managed-by label. Not sure if there is a better way to do this in AgnosticV where the namespaces are originally created, it's complicated given the label changes based on the user.  

It also tweaks Argo CD to add support OOTB for cluster-admins group which will be added later.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
Advanced GitOps Workshop (In Development only)
