### PR TITLE
infra-dns: separate nsupdate / route53 and standardize on 'base_domain'

### DIFF
--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -39,31 +39,31 @@
             key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
             key_secret: "{{ ddns_key_secret }}"
 
-          - name: Add public_dns entry to host
-            add_host:
-              name: "{{ _instance_name }}"
-              public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
+        - name: Add public_dns entry to host
+          add_host:
+            name: "{{ _instance_name }}"
+            public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
 
-          - name: DNS alternative entry ({{ _dns_state | default('present') }})
-            when: _alt_names | length > 0
-            loop: "{{ _alt_names }}"
-            loop_control:
-              loop_var: _alt_name
-            nsupdate:
-              server: >-
-                {{ cluster_dns_server
-                | ipaddr
-                | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-                }}
-              zone: "{{ cluster_dns_zone }}"
-              record: "{{ _alt_name }}{{_index}}.{{ guid }}"
-              type: CNAME
-              ttl: "{{ infra_dns_default_ttl }}"
-              value: "{{ _instance_name }}.{{ guid }}"
-              port: "{{ cluster_dns_port | d('53') }}"
-              key_name: "{{ ddns_key_name }}"
-              key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
-              key_secret: "{{ ddns_key_secret }}"
+        - name: DNS alternative entry ({{ _dns_state | default('present') }})
+          when: _alt_names | length > 0
+          loop: "{{ _alt_names }}"
+          loop_control:
+            loop_var: _alt_name
+          nsupdate:
+            server: >-
+              {{ cluster_dns_server
+              | ipaddr
+              | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+              }}
+            zone: "{{ cluster_dns_zone }}"
+            record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+            type: CNAME
+            ttl: "{{ infra_dns_default_ttl }}"
+            value: "{{ _instance_name }}.{{ guid }}"
+            port: "{{ cluster_dns_port | d('53') }}"
+            key_name: "{{ ddns_key_name }}"
+            key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+            key_secret: "{{ ddns_key_secret }}"
 
     - when: route53_aws_zone_id is defined
       block:

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -127,27 +127,27 @@
             key_secret: "{{ ddns_key_secret }}"
             state: absent
 
-          - name: DNS alternative entry ({{ _dns_state | default('present') }})
-            when: _alt_names | length > 0
-            loop: "{{ _alt_names }}"
-            loop_control:
-              loop_var: _alt_name
-            nsupdate:
-              server: >-
-                {{ cluster_dns_server
-                | ipaddr
-                | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-                }}
-              zone: "{{ cluster_dns_zone }}"
-              record: "{{ _alt_name }}{{_index}}.{{ guid }}"
-              type: CNAME
-              ttl: "{{ infra_dns_default_ttl }}"
-              value: "{{ _instance_name }}.{{ guid }}"
-              port: "{{ cluster_dns_port | d('53') }}"
-              key_name: "{{ ddns_key_name }}"
-              key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
-              key_secret: "{{ ddns_key_secret }}"
-              state: absent
+        - name: DNS alternative entry ({{ _dns_state | default('present') }})
+          when: _alt_names | length > 0
+          loop: "{{ _alt_names }}"
+          loop_control:
+            loop_var: _alt_name
+          nsupdate:
+            server: >-
+              {{ cluster_dns_server
+              | ipaddr
+              | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+              }}
+            zone: "{{ cluster_dns_zone }}"
+            record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+            type: CNAME
+            ttl: "{{ infra_dns_default_ttl }}"
+            value: "{{ _instance_name }}.{{ guid }}"
+            port: "{{ cluster_dns_port | d('53') }}"
+            key_name: "{{ ddns_key_name }}"
+            key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+            key_secret: "{{ ddns_key_secret }}"
+            state: absent
 
     - when: route53_aws_zone_id is defined
       block:

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -20,158 +20,165 @@
           The floating IP for {{ _instance_name }}
           is {{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}
 
-    - name: DNS entry nsupdate ({{ _dns_state | default('present') }})
-      when: cluster_dns_server is defined
-      nsupdate:
-        server: >-
-          {{ cluster_dns_server
-          | ipaddr
-          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-          }}
-        zone: "{{ cluster_dns_zone }}"
-        record: "{{ _instance_name }}.{{ guid }}"
-        type: A
-        ttl: "{{ infra_dns_default_ttl }}"
-        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
-        port: "{{ cluster_dns_port | d('53') }}"
-        key_name: "{{ ddns_key_name }}"
-        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
-        key_secret: "{{ ddns_key_secret }}"
+    - when: cluster_dns_server is defined
+      block:
+        - name: DNS entry nsupdate ({{ _dns_state | default('present') }})
+          nsupdate:
+            server: >-
+              {{ cluster_dns_server
+              | ipaddr
+              | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+              }}
+            zone: "{{ cluster_dns_zone }}"
+            record: "{{ _instance_name }}.{{ guid }}"
+            type: A
+            ttl: "{{ infra_dns_default_ttl }}"
+            value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+            port: "{{ cluster_dns_port | d('53') }}"
+            key_name: "{{ ddns_key_name }}"
+            key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+            key_secret: "{{ ddns_key_secret }}"
 
-    - name: DNS entry route53 ({{ _dns_state | default('present') }})
-      when: route53_aws_zone_id is defined
-      route53:
-        state: present
-        aws_access_key_id: "{{ route53_aws_access_key_id }}"
-        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
-        hosted_zone_id: "{{ route53_aws_zone_id }}"
-        record: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
-        zone: "{{ cluster_dns_zone  }}"
-        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
-        type: A
-      register: _route53_record
-      retries: 10
-      delay: "{{ 60|random(start=5, step=1) }}"
-      until: _route53_record is succeeded
+          - name: Add public_dns entry to host
+            add_host:
+              name: "{{ _instance_name }}"
+              public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
 
-    - name: Add public_dns entry to host
-      add_host:
-        name: "{{ _instance_name }}"
-        public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
+          - name: DNS alternative entry ({{ _dns_state | default('present') }})
+            when: _alt_names | length > 0
+            loop: "{{ _alt_names }}"
+            loop_control:
+              loop_var: _alt_name
+            nsupdate:
+              server: >-
+                {{ cluster_dns_server
+                | ipaddr
+                | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+                }}
+              zone: "{{ cluster_dns_zone }}"
+              record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+              type: CNAME
+              ttl: "{{ infra_dns_default_ttl }}"
+              value: "{{ _instance_name }}.{{ guid }}"
+              port: "{{ cluster_dns_port | d('53') }}"
+              key_name: "{{ ddns_key_name }}"
+              key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+              key_secret: "{{ ddns_key_secret }}"
 
-    - name: DNS alternative entry ({{ _dns_state | default('present') }})
-      when: cluster_dns_server is defined and _alt_names | length > 0
-      loop: "{{ _alt_names }}"
-      loop_control:
-        loop_var: _alt_name
-      nsupdate:
-        server: >-
-          {{ cluster_dns_server
-          | ipaddr
-          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-          }}
-        zone: "{{ cluster_dns_zone }}"
-        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
-        type: CNAME
-        ttl: "{{ infra_dns_default_ttl }}"
-        value: "{{ _instance_name }}.{{ guid }}"
-        port: "{{ cluster_dns_port | d('53') }}"
-        key_name: "{{ ddns_key_name }}"
-        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
-        key_secret: "{{ ddns_key_secret }}"
+    - when: route53_aws_zone_id is defined
+      block:
+        - name: DNS entry route53 ({{ _dns_state | default('present') }})
+          route53:
+            state: present
+            aws_access_key_id: "{{ route53_aws_access_key_id }}"
+            aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+            hosted_zone_id: "{{ route53_aws_zone_id }}"
+            record: "{{ _instance_name }}.{{ base_domain }}"
+            value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+            type: A
+          register: _route53_record
+          retries: 10
+          delay: "{{ 60|random(start=5, step=1) }}"
+          until: _route53_record is succeeded
 
-    - name: DNS alternative entry ({{ _dns_state | default('present') }})
-      when: route53_aws_zone_id is defined and _alt_names | length > 0
-      loop: "{{ _alt_names }}"
-      loop_control:
-        loop_var: _alt_name
-      route53:
-        state: present
-        aws_access_key_id: "{{ route53_aws_access_key_id }}"
-        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
-        hosted_zone_id: "{{ route53_aws_zone_id }}"
-        record: "{{ _alt_name }}{{_index}}.{{ guid }}.{{ cluster_dns_zone }}"
-        zone: "{{ cluster_dns_zone  }}"
-        value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
-        type: A
-      register: _route53_record
-      retries: 10
-      delay: "{{ 60|random(start=5, step=1) }}"
-      until: _route53_record is succeeded
+        - name: Add public_dns entry to host
+          add_host:
+            name: "{{ _instance_name }}"
+            public_dns_name: "{{ _instance_name }}.{{ base_domain }}"
 
+        - name: DNS alternative entry ({{ _dns_state | default('present') }})
+          when: _alt_names | length > 0
+          loop: "{{ _alt_names }}"
+          loop_control:
+            loop_var: _alt_name
+          route53:
+            state: present
+            aws_access_key_id: "{{ route53_aws_access_key_id }}"
+            aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+            hosted_zone_id: "{{ route53_aws_zone_id }}"
+            record: "{{ _alt_name }}{{_index}}.{{ base_domain }}"
+            value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
+            type: A
+          register: _route53_record
+          retries: 10
+          delay: "{{ 60|random(start=5, step=1) }}"
+          until: _route53_record is succeeded
 
 # When state == absent, don't use inventory var (should not be needed)
 - when: _dns_state == 'absent'
   block:
-    - name: DNS entry ({{ _dns_state | default('present') }})
-      when: cluster_dns_server is defined
-      nsupdate:
-        server: >-
-          {{ cluster_dns_server
-          | ipaddr
-          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-          }}
-        zone: "{{ cluster_dns_zone }}"
-        record: "{{ _instance_name }}.{{ guid }}"
-        type: A
-        ttl: "{{ infra_dns_default_ttl }}"
-        port: "{{ cluster_dns_port | d('53') }}"
-        key_name: "{{ ddns_key_name }}"
-        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
-        key_secret: "{{ ddns_key_secret }}"
-        state: absent
+    - when: cluster_dns_server is defined
+      block:
+        - name: DNS entry ({{ _dns_state | default('present') }})
+          when: cluster_dns_server is defined
+          nsupdate:
+            server: >-
+              {{ cluster_dns_server
+              | ipaddr
+              | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+              }}
+            zone: "{{ cluster_dns_zone }}"
+            record: "{{ _instance_name }}.{{ guid }}"
+            type: A
+            ttl: "{{ infra_dns_default_ttl }}"
+            port: "{{ cluster_dns_port | d('53') }}"
+            key_name: "{{ ddns_key_name }}"
+            key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+            key_secret: "{{ ddns_key_secret }}"
+            state: absent
 
-    - name: DNS entry ({{ _dns_state | default('present') }})
-      when: route53_aws_zone_id is defined
-      route53:
-        state: absent
-        aws_access_key_id: "{{ route53_aws_access_key_id }}"
-        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
-        hosted_zone_id: "{{ route53_aws_zone_id }}"
-        record: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
-        zone: "{{ cluster_dns_zone  }}"
-        type: A
-      register: _route53_record
-      retries: 10
-      delay: "{{ 60|random(start=5, step=1) }}"
-      until: _route53_record is succeeded
+          - name: DNS alternative entry ({{ _dns_state | default('present') }})
+            when: _alt_names | length > 0
+            loop: "{{ _alt_names }}"
+            loop_control:
+              loop_var: _alt_name
+            nsupdate:
+              server: >-
+                {{ cluster_dns_server
+                | ipaddr
+                | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+                }}
+              zone: "{{ cluster_dns_zone }}"
+              record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+              type: CNAME
+              ttl: "{{ infra_dns_default_ttl }}"
+              value: "{{ _instance_name }}.{{ guid }}"
+              port: "{{ cluster_dns_port | d('53') }}"
+              key_name: "{{ ddns_key_name }}"
+              key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
+              key_secret: "{{ ddns_key_secret }}"
+              state: absent
 
-    - name: DNS alternative entry ({{ _dns_state | default('present') }})
-      when: cluster_dns_server is defined and _alt_names | length > 0
-      loop: "{{ _alt_names }}"
-      loop_control:
-        loop_var: _alt_name
-      nsupdate:
-        server: >-
-          {{ cluster_dns_server
-          | ipaddr
-          | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
-          }}
-        zone: "{{ cluster_dns_zone }}"
-        record: "{{ _alt_name }}{{_index}}.{{ guid }}"
-        type: CNAME
-        ttl: "{{ infra_dns_default_ttl }}"
-        value: "{{ _instance_name }}.{{ guid }}"
-        port: "{{ cluster_dns_port | d('53') }}"
-        key_name: "{{ ddns_key_name }}"
-        key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
-        key_secret: "{{ ddns_key_secret }}"
-        state: absent
+    - when: route53_aws_zone_id is defined
+      block:
+        - name: DNS entry ({{ _dns_state | default('present') }})
+          when: route53_aws_zone_id is defined
+          route53:
+            state: absent
+            aws_access_key_id: "{{ route53_aws_access_key_id }}"
+            aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+            hosted_zone_id: "{{ route53_aws_zone_id }}"
+            record: "{{ _instance_name }}.{{ base_domain }}"
+            type: A
+          register: _route53_record
+          retries: 10
+          delay: "{{ 60|random(start=5, step=1) }}"
+          until: _route53_record is succeeded
 
-    - name: DNS alternative entry ({{ _dns_state | default('present') }})
-      when: route53_aws_zone_id is defined and _alt_names | length > 0
-      loop: "{{ _alt_names }}"
-      loop_control:
-        loop_var: _alt_name
-      route53:
-        state: absent
-        aws_access_key_id: "{{ route53_aws_access_key_id }}"
-        aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
-        hosted_zone_id: "{{ route53_aws_zone_id }}"
-        record: "{{ _alt_name }}{{_index}}.{{ guid }}.{{ cluster_dns_zone }}"
-        zone: "{{ cluster_dns_zone  }}"
-        type: A
-      register: _route53_record
-      retries: 10
-      delay: "{{ 60|random(start=5, step=1) }}"
-      until: _route53_record is succeeded
+
+        - name: DNS alternative entry ({{ _dns_state | default('present') }})
+          when: route53_aws_zone_id is defined and _alt_names | length > 0
+          loop: "{{ _alt_names }}"
+          loop_control:
+            loop_var: _alt_name
+          route53:
+            state: absent
+            aws_access_key_id: "{{ route53_aws_access_key_id }}"
+            aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
+            hosted_zone_id: "{{ route53_aws_zone_id }}"
+            record: "{{ _alt_name }}{{_index}}.{{ base_domain }}"
+            type: A
+          register: _route53_record
+          retries: 10
+          delay: "{{ 60|random(start=5, step=1) }}"
+          until: _route53_record is succeeded

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -23,7 +23,7 @@
     - when: cluster_dns_server is defined
       block:
         - name: DNS entry nsupdate ({{ _dns_state | default('present') }})
-          nsupdate:
+          community.general.nsupdate:
             server: >-
               {{ cluster_dns_server
               | ipaddr
@@ -40,7 +40,7 @@
             key_secret: "{{ ddns_key_secret }}"
 
         - name: Add public_dns entry to host
-          add_host:
+          ansible.builtin.add_host:
             name: "{{ _instance_name }}"
             public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
 
@@ -49,7 +49,7 @@
           loop: "{{ _alt_names }}"
           loop_control:
             loop_var: _alt_name
-          nsupdate:
+          community.general.nsupdate:
             server: >-
               {{ cluster_dns_server
               | ipaddr
@@ -68,7 +68,7 @@
     - when: route53_aws_zone_id is defined
       block:
         - name: DNS entry route53 ({{ _dns_state | default('present') }})
-          route53:
+          amazon.aws.route53:
             state: present
             aws_access_key_id: "{{ route53_aws_access_key_id }}"
             aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
@@ -82,7 +82,7 @@
           until: _route53_record is succeeded
 
         - name: Add public_dns entry to host
-          add_host:
+          ansible.builtin.add_host:
             name: "{{ _instance_name }}"
             public_dns_name: "{{ _instance_name }}.{{ base_domain }}"
 
@@ -91,7 +91,7 @@
           loop: "{{ _alt_names }}"
           loop_control:
             loop_var: _alt_name
-          route53:
+          amazon.aws.route53:
             state: present
             aws_access_key_id: "{{ route53_aws_access_key_id }}"
             aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
@@ -111,7 +111,7 @@
       block:
         - name: DNS entry ({{ _dns_state | default('present') }})
           when: cluster_dns_server is defined
-          nsupdate:
+          community.general.nsupdate:
             server: >-
               {{ cluster_dns_server
               | ipaddr
@@ -132,7 +132,7 @@
           loop: "{{ _alt_names }}"
           loop_control:
             loop_var: _alt_name
-          nsupdate:
+          community.general.nsupdate:
             server: >-
               {{ cluster_dns_server
               | ipaddr
@@ -153,7 +153,7 @@
       block:
         - name: DNS entry ({{ _dns_state | default('present') }})
           when: route53_aws_zone_id is defined
-          route53:
+          amazon.aws.route53:
             state: absent
             aws_access_key_id: "{{ route53_aws_access_key_id }}"
             aws_secret_access_key: "{{ route53_aws_secret_access_key }}"
@@ -171,7 +171,7 @@
           loop: "{{ _alt_names }}"
           loop_control:
             loop_var: _alt_name
-          route53:
+          amazon.aws.route53:
             state: absent
             aws_access_key_id: "{{ route53_aws_access_key_id }}"
             aws_secret_access_key: "{{ route53_aws_secret_access_key }}"

--- a/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
+++ b/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
@@ -21,13 +21,13 @@
       when: base_domain is not defined and route53_zone is defined
       set_fact:
         base_domain: >-
-          {{ guid }}.{{ route53_zone | regex_replace('^' ~ guid ~ '.', '') }}
+          {{ guid }}.{{ route53_zone | regex_replace('^' ~ guid ~ '\.', '') }}
 
     - name: defensive programming, guess base_domain using cluster_dns_zone
       when: base_domain is not defined and cluster_dns_zone is defined
       set_fact:
         base_domain: >-
-          {{ guid }}.{{ cluster_dns_zone }}
+          {{ guid }}.{{ cluster_dns_zone | regex_replace('^' ~ guid ~ '\.', '') }}
 
     - when: >-
         route53_aws_access_key_id is not defined

--- a/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
+++ b/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
@@ -17,6 +17,18 @@
 - name: Check variables when route53 is used
   when: route53_aws_zone_id is defined
   block:
+    - name: defensive programming, guess base_domain using route53_zone
+      when: base_domain is not defined and route53_zone is defined
+      set_fact:
+        base_domain: >-
+          {{ route53_zone }}
+
+    - name: defensive programming, guess base_domain using cluster_dns_zone
+      when: base_domain is not defined and cluster_dns_zone is defined
+      set_fact:
+        base_domain: >-
+          {{ guid }}.{{ cluster_dns_zone }}
+
     - when: >-
         route53_aws_access_key_id is not defined
         or route53_aws_secret_access_key is not defined

--- a/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
+++ b/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
@@ -21,7 +21,7 @@
       when: base_domain is not defined and route53_zone is defined
       set_fact:
         base_domain: >-
-          {{ route53_zone }}
+          {{ guid }}.{{ route53_zone | regex_replace('^' ~ guid ~ '.', '') }}
 
     - name: defensive programming, guess base_domain using cluster_dns_zone
       when: base_domain is not defined and cluster_dns_zone is defined

--- a/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
+++ b/ansible/roles-infra/infra-dns/tasks/pre_checks.yml
@@ -20,10 +20,10 @@
     - when: >-
         route53_aws_access_key_id is not defined
         or route53_aws_secret_access_key is not defined
-        or cluster_dns_zone is not defined
+        or base_domain is not defined
       fail:
         msg: |
           All the following variables must be defined:
           - route53_aws_access_key_id
           - route53_aws_secret_access_key
-          - cluster_dns_zone
+          - base_domain


### PR DESCRIPTION
- When using route53, don't use `cluster_dns_zone`.
- Standardize on `base_domain` for DNS clarity
- Clearly separate cases: nsupdate / route53
- Defensive fallbacks are added to `pre_checks.yml` to automatically construct `base_domain` from `cluster_dns_zone` or `route53_zone` if it is not explicitly provided. This ensures backward compatibility during the transition.
