### PR TITLE
IBM Cloud: do not add guid to instance name and fix instance count

### DIFF
--- a/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ibm_resource_group_infrastructure_deployment.yml
@@ -57,6 +57,8 @@
     - name: Create ssh provision key
       ansible.builtin.include_role:
         name: create_ssh_provision_key
+      vars:
+        ssh_provision_key_type: ed25519
       when:
         - instances | default([]) | length
         - ssh_provision_key_name is undefined

--- a/ansible/configs/base-infra/default_vars_ibm_resource_group.yml
+++ b/ansible/configs/base-infra/default_vars_ibm_resource_group.yml
@@ -58,7 +58,7 @@ security_groups:
 # IBM CLOUD Instances
 # -------------------------------------------------
 instances:
-  - name: "bastion-{{ guid }}"
+  - name: bastion
     count: 1
     unique: true
     public_dns: true

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -56,7 +56,7 @@ def ec2_tags_to_dict(tags):
     return converted
 
 
-def dict_to_equinix_metal_tags(tags):
+def dict_to_equinix_metal_tags(tags, delim='='):
     '''Filter to convert dictionary to Equinix Tags format'''
 
     function_name = "dict_to_equinix_metal_tags"
@@ -84,7 +84,7 @@ def dict_to_equinix_metal_tags(tags):
                     %(function_name, type(tags[key]))
                 )
 
-            converted.append('%s=%s' %(key, tags[key]))
+            converted.append('%s%s%s' %(key,delim, tags[key]))
 
     except Exception as e:
         raise AnsibleFilterError(e)
@@ -146,7 +146,7 @@ def ec2_tags_to_equinix_metal_tags(tags):
 
     return converted
 
-def equinix_metal_tags_to_dict(tags):
+def equinix_metal_tags_to_dict(tags, delim='='):
     '''Convert Equinix Tags to a dict'''
 
     function_name = "equinix_metal_tags_to_dict"
@@ -164,8 +164,8 @@ def equinix_metal_tags_to_dict(tags):
                     '''Invalid type used with %s filter,
                     expect a string, got %s''' %(function_name, type(tag)))
 
-            if '=' in tag:
-                splitted = tag.split("=")
+            if delim in tag:
+                splitted = tag.split(delim, 1)
                 if splitted[0] == "":
                     raise AnsibleFilterError(
                         'Invalid type used with %s filter, key is empty string.'

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -387,8 +387,8 @@ def agnosticd_expand_instances(instances):
 
         for i in range(count):
             new_instance = deepcopy(instance)
-            new_instance.count = 1  # Reset count to 1 for each instance
-            new_instance.name = f"{instance.get('name')}{i+1}"
+            new_instance['count'] = 1  # Reset count to 1 for each instance
+            new_instance['name'] = f"{instance.get('name')}{i+1}"
             expanded.append(new_instance)
 
     return expanded

--- a/ansible/filter_plugins/core.py
+++ b/ansible/filter_plugins/core.py
@@ -357,6 +357,42 @@ def agnosticd_instances_to_odcr(instances, agnosticd_images):
 
     return result
 
+def agnosticd_expand_instances(instances):
+    """Expand instances list to a flat list of instances, using the count field"""
+
+    function_name = "agnosticd_expand_instances"
+
+    if not isinstance(instances, list):
+        raise AnsibleFilterError(
+            '%s: instances should be a list, got %s' %(function_name, type(instances))
+        )
+
+    expanded = []
+    for instance in instances:
+        if not isinstance(instance, dict):
+            raise AnsibleFilterError(
+                '%s: instance should be a dict, got %s' %(function_name, type(instance))
+            )
+
+        count = instance.get('count', 1)
+        if not isinstance(count, integer_types) or count < 1:
+            raise AnsibleFilterError(
+                '%s: count should be a positive integer, got %s' %(function_name, count)
+            )
+
+        if count == 1:
+            # If count is 1, just add the instance as is
+            expanded.append(deepcopy(instance))
+            continue
+
+        for i in range(count):
+            new_instance = deepcopy(instance)
+            new_instance.count = 1  # Reset count to 1 for each instance
+            new_instance.name = f"{instance.get('name')}{i+1}"
+            expanded.append(new_instance)
+
+    return expanded
+
 class FilterModule(object):
     ''' AgnosticD core jinja2 filters '''
 
@@ -370,4 +406,5 @@ class FilterModule(object):
             'agnosticd_get_all_images': agnosticd_get_all_images,
             'agnosticd_filter_out_installed_collections': agnosticd_filter_out_installed_collections,
             'agnosticd_instances_to_odcr': agnosticd_instances_to_odcr,
+            'agnosticd_expand_instances': agnosticd_expand_instances,
         }

--- a/ansible/lifecycle.yml
+++ b/ansible/lifecycle.yml
@@ -70,4 +70,4 @@
       include_tasks: lifecycle_gcp.yml
 
     - when: cloud_provider == 'ibm_resource_group'
-      include_tasks: lifecycle_resource_group.yml
+      include_tasks: lifecycle_ibm_resource_group.yml

--- a/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
+++ b/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
@@ -27,6 +27,7 @@
     ssh_provision_pubkey_path: "{{ ssh_provision_pubkey_path }}"
     ssh_provision_key_path: "{{ ssh_provision_key_path }}"
     ssh_provision_key_name: "{{ ssh_provision_key_name }}"
+    ssh_provision_key_type: "{{ ssh_provision_key_type }}"
 
 - name: Write SSH pub key
   copy:

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -1,5 +1,13 @@
 ---
 - name: Set the query to find the public IPv4 IP of the instance
+  vars:
+    # helper
+    _instance_name_with_guid: >-
+      {%- if guid in _instance_name -%}
+        {{- _instance_name -}}
+      {%- else -%}
+        {{- _instance_name }}-{{ guid -}}
+      {%- endif -%}
   set_fact:
     find_ip_query: >-
       {%- if cloud_provider == 'osp' -%}
@@ -9,7 +17,7 @@
       {%- elif cloud_provider == 'vmc' or cloud_provider == 'vmware_ibm' -%}
       localhost.publicips[?name=='{{ _instance_name }}'].ip
       {%- elif cloud_provider == 'ibm_resource_group' -%}
-      localhost.publicips[?name=='{{ _instance_name }}'].ip
+      localhost.publicips[?name=='{{ _instance_name_with_guid }}'].ip
       {%- endif -%}
 
 - when: _dns_state == 'present'

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
@@ -11,13 +11,14 @@
     instance_tags: "{{ instance.tags | equinix_metal_tags_to_dict(':') }}"
   ansible.builtin.add_host:
     name: "{{ instance_tags.ansiblename | default(instance.name) }}"
-    shortname: "{{ instance.name }}"
+    shortname: "{{ instance_tags.ansiblename | default(instance.name) }}"
     ansible_user: "{{ remote_user }}"
-    ansible_ssh_host: "{{ instance.name }}"
+    ansible_ssh_host: "{{ instance_tags.ansiblename | default(instance.name) }}"
+    isolated: "{{ instance_tags.isolated | default(false) }}"
     ssh_port: "22"
     private_ip_address: "{{ instance.primary_network_interface[0].primary_ip[0].address }}"
     public_ip_address: "{{ r_ibmcloud_floating_ips.resource.floating_ips[0]['address'] }}"
     groups: "{{ instance_tags.ansiblegroup | default(omit) }}"
-    bastion: "{{ local_bastion | default('') }}"
+    bastion: "{{ local_bastion | default('bastion') }}"
     bastion_ssh_port: "22"
   when: instance.annotations.managed | default(true) | bool

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/add_host.yaml
@@ -1,36 +1,23 @@
 ---
 - name: Get floating ip for instance
   ibm.cloudcollection.ibm_is_floating_ips_info:
-    name: "{{ instance.name }}-fip"
+    name: "{{ instance_name_with_guid }}-fip"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
     region: "{{ ibmcloud_region }}"
   register: r_ibmcloud_floating_ips
 
-- name: Initialize tags_dict variable
-  set_fact:
-    tags_dict: {}
-
-- name: Populate dict
-  set_fact:
-    tags_dict: "{{ tags_dict | combine( {item.split(':')[0]: item.split(':')[1]} ) }}"
-  with_items:
-    - "{{ instance.tags }}"
-
-
 - name: Create inventory (add_host)
-  loop: "{{ r_ibmcloud_instances.resource.instances | list }}"
-  loop_control:
-    loop_var: instance
-    label: "{{ instance.shortname | default(instance.name) }}"
+  vars:
+    instance_tags: "{{ instance.tags | equinix_metal_tags_to_dict(':') }}"
   ansible.builtin.add_host:
-    name: "{{ instance.name }}"
+    name: "{{ instance_tags.ansiblename | default(instance.name) }}"
     shortname: "{{ instance.name }}"
     ansible_user: "{{ remote_user }}"
     ansible_ssh_host: "{{ instance.name }}"
     ssh_port: "22"
     private_ip_address: "{{ instance.primary_network_interface[0].primary_ip[0].address }}"
     public_ip_address: "{{ r_ibmcloud_floating_ips.resource.floating_ips[0]['address'] }}"
-    groups: "{{ tags_dict['ansiblegroup'] | default(omit) }}"
+    groups: "{{ instance_tags.ansiblegroup | default(omit) }}"
     bastion: "{{ local_bastion | default('') }}"
     bastion_ssh_port: "22"
   when: instance.annotations.managed | default(true) | bool

--- a/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/create_inventory.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-create-inventory/tasks/create_inventory.yaml
@@ -8,6 +8,13 @@
 - name: Include add host task for each instance
   ansible.builtin.include_tasks: add_host.yaml
   loop: "{{ r_ibmcloud_instances.resource.instances }}"
+  vars:
+    instance_name_with_guid: >-
+      {%- if guid in instance.name -%}
+        {{- instance.name -}}
+      {%- else -%}
+        {{- instance.name }}-{{ guid -}}
+      {%- endif -%}
   loop_control:
     loop_var: instance
     label: "{{ instance.shortname | default(instance.name) }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/defaults/main.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/defaults/main.yaml
@@ -6,3 +6,11 @@ ibmcloud_vpc_name: "vpc-{{ guid }}"
 ibmcloud_vpc_subnet_name: "subnet-{{ guid }}"
 publicips: []
 _ibmcloud_security_groups_id: []
+
+# helper
+instance_name_with_guid: >-
+  {%- if guid in instance.name -%}
+    {{- instance.name -}}
+  {%- else -%}
+    {{- instance.name }}-{{ guid -}}
+  {%- endif -%}

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -47,9 +47,14 @@
 
 - name: Provision IBM Cloud Virtual Server (VS) instance
   register: ibmcloud_vs_instance_create
+  vars:
+    mandatory_tags:
+      - guid:{{ guid }}
+      - service_uuid:{{ service_uuid | default(uuid) }}
+      - ansiblename:{{ instance.name }}
   ibm.cloudcollection.ibm_is_instance:
     state: available
-    name: "{{ instance.name }}"
+    name: "{{ instance_name_with_guid }}"
     image: "{{ _image_dict.id }}"
     profile: "{{ instance.profile }}"
     keys:
@@ -57,14 +62,19 @@
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
     zone: "{{ ibmcloud_availability_zone  }}"
     vpc: "{{ ibmcloud_vpc_subnet_create.resource.vpc }}"
-    tags: "{{ instance.tags|default([]) }}"
+    tags: >-
+      {{ ( instance.tags
+           | default([])
+           + mandatory_tags )
+         | unique
+      }}
     primary_network_interface:
-      - name: "{{ instance.name }}-eth0"
+      - name: "{{ instance_name_with_guid }}-eth0"
         subnet: "{{ ibmcloud_vpc_subnet_create.resource.id }}"
         security_groups: "{{ _instance_sg_ids }}"
     auto_delete_volume: true
     boot_volume:
-      - name: "{{ instance.name }}-boot-0"
+      - name: "{{ instance_name_with_guid }}-boot-0"
         # Use the maximum between the specified rootfs_size
         # and the image's minimum provisioned size but never exceed 250 GB
         size: >-
@@ -89,7 +99,7 @@
 
 - name: Configure Floating IP Address
   ibm.cloudcollection.ibm_is_floating_ip:
-    name: "{{ instance.name }}-fip"
+    name: "{{ instance_name_with_guid }}-fip"
     state: available
     target: "{{ ibmcloud_vs_instance_create.resource.primary_network_interface[0]['id'] }}"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -118,4 +118,6 @@
   loop: "{{ instance.volumes | default([]) }}"
   loop_control:
     loop_var: _volume
+  vars:
+    _volume_name: disk-{{ instance_name_with_guid  ~ '-' ~ _volume.name }}
   ansible.builtin.include_tasks: create_volume.yaml

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instance.yaml
@@ -58,7 +58,7 @@
     image: "{{ _image_dict.id }}"
     profile: "{{ instance.profile }}"
     keys:
-      - "{{ ibmcloud_ssh_public_key.resource.id }}"
+      - "{{ ibmcloud_ssh_public_key.id }}"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
     zone: "{{ ibmcloud_availability_zone  }}"
     vpc: "{{ ibmcloud_vpc_subnet_create.resource.vpc }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instances.yaml
@@ -19,7 +19,7 @@
     ibmcloud_os_image_list: "{{ r_ibmcloud_os_image_list.stdout | from_json }}"
 
 - name: Create Instances
-  loop: "{{ instances|default([]) }}"
+  loop: "{{ instances|default([])|agnosticd_expand_instances }}"
   loop_control:
     loop_var: instance
   ansible.builtin.include_tasks: create_instance.yaml

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_instances.yaml
@@ -19,7 +19,7 @@
     ibmcloud_os_image_list: "{{ r_ibmcloud_os_image_list.stdout | from_json }}"
 
 - name: Create Instances
-  loop: "{{ instances|default([])|agnosticd_expand_instances }}"
+  loop: "{{ instances| default([]) |agnosticd_expand_instances }}"
   loop_control:
     loop_var: instance
   ansible.builtin.include_tasks: create_instance.yaml

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_ssh_key.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_ssh_key.yaml
@@ -1,22 +1,37 @@
 ---
-- name: Create SSH Public Key pair
-  register: ibmcloud_ssh_public_key
-  ibm.cloudcollection.ibm_is_ssh_key:
-    name: "{{ ibmcloud_resource_group_name }}-ssh-key"
-    resource_group: "{{ r_ibmcloud_resource_group_id }}"
-    public_key: "{{ ssh_provision_pubkey_content }}"
-    region: "{{ ibmcloud_region }}"
+# using the ansible module is too slow, it takes ~20-30s
+# name: Create SSH Public Key pair
+#   register: ibmcloud_ssh_public_key
+#   ibm.cloudcollection.ibm_is_ssh_key:
+#     name: "{{ ibmcloud_resource_group_name }}-ssh-key"
+#     resource_group: "{{ r_ibmcloud_resource_group_id }}"
+#     public_key: "{{ ssh_provision_pubkey_content }}"
+#     region: "{{ ibmcloud_region }}"
 
 - name: Create SSH Public Key pair using ibmcloud CLI
   command: >-
     ibmcloud is key-create {{ ibmcloud_resource_group_name }}-ssh-key
+    "{{ ssh_provision_pubkey_content }}"
+    --key-type {{ ssh_provision_key_type | default('rsa') }}
     --resource-group-name {{ ibmcloud_resource_group_name }}
-    --public-key "{{ ssh_provision_pubkey_content }}"
-
+    --json
   register: r_ibmcloud_ssh_public_key
   until: r_ibmcloud_ssh_public_key is succeeded
+  retries: 5
   failed_when: >-
-    r_ibmcloud_ssh_public_key.rc != 0
-    and 'already exists' not in r_ibmcloud_ssh_public_key.stderr
+    (r_ibmcloud_ssh_public_key.rc != 0
+    and 'already exists' not in r_ibmcloud_ssh_public_key.stderr)
+    or 'Incorrect Usage' in r_ibmcloud_ssh_public_key.stdout
   changed_when: >-
     r_ibmcloud_ssh_public_key.rc == 0
+
+- name: Get authoritative details for the SSH Public Key
+  command: >-
+    ibmcloud is key {{ ibmcloud_resource_group_name }}-ssh-key --output JSON
+  register: r_ibmcloud_ssh_public_key_details
+  until: r_ibmcloud_ssh_public_key_details is succeeded
+  changed_when: false
+  retries: 5
+
+- set_fact:
+    ibmcloud_ssh_public_key: "{{ r_ibmcloud_ssh_public_key_details.stdout | from_json }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_ssh_key.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_ssh_key.yaml
@@ -4,5 +4,19 @@
   ibm.cloudcollection.ibm_is_ssh_key:
     name: "{{ ibmcloud_resource_group_name }}-ssh-key"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
-    public_key: "{{ lookup('ansible.builtin.file', ssh_provision_pubkey_path) }}"
+    public_key: "{{ ssh_provision_pubkey_content }}"
     region: "{{ ibmcloud_region }}"
+
+- name: Create SSH Public Key pair using ibmcloud CLI
+  command: >-
+    ibmcloud is key-create {{ ibmcloud_resource_group_name }}-ssh-key
+    --resource-group-name {{ ibmcloud_resource_group_name }}
+    --public-key "{{ ssh_provision_pubkey_content }}"
+
+  register: r_ibmcloud_ssh_public_key
+  until: r_ibmcloud_ssh_public_key is succeeded
+  failed_when: >-
+    r_ibmcloud_ssh_public_key.rc != 0
+    and 'already exists' not in r_ibmcloud_ssh_public_key.stderr
+  changed_when: >-
+    r_ibmcloud_ssh_public_key.rc == 0

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
@@ -33,6 +33,8 @@
   command: >-
     ibmcloud is volume disk-{{ guid  ~ '-' ~ _volume.name }} --output JSON
   register: _volume_details
+  until: _volume_details is succeeded
+  retries: 5
 
 - debug:
     verbosity: 2
@@ -65,6 +67,8 @@
     attachment-{{ guid }}-{{ _volume.name }}
     --output JSON
   register: _attachment_details
+  until: _attachment_details is succeeded
+  retries: 5
 
 - name: Save fact for IBM Cloud Volume attachment
   ansible.builtin.set_fact:

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
@@ -21,8 +21,9 @@
     --json
   register: ibmcloud_volume_create
   failed_when: >-
-    ibmcloud_volume_create.rc != 0
-    and 'already exists' not in ibmcloud_volume_create.stderr
+    (ibmcloud_volume_create.rc != 0
+    and 'already exists' not in ibmcloud_volume_create.stderr)
+    or 'Incorrect Usage' in ibmcloud_volume_create.stdout
 
 # It's a more robust and readable way to get the volume's details.
 # rather than parsing the output of the create command (idempotent)
@@ -54,9 +55,10 @@
     --json
   register: ibmcloud_volume_attach
   failed_when: >-
-    ibmcloud_volume_attach.rc != 0
+    (ibmcloud_volume_attach.rc != 0
     and 'already attached' not in ibmcloud_volume_attach.stderr
-    and 'is in use' not in ibmcloud_volume_attach.stderr
+    and 'is in use' not in ibmcloud_volume_attach.stderr)
+    or 'Incorrect Usage' in ibmcloud_volume_attach.stdout
 
 - debug:
     verbosity: 2

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
@@ -87,8 +87,8 @@
       {{
         ibmcloud_volumes | default({}) | combine(
           {
-            ibmcloud_vs_instance.resource.name:
-              (ibmcloud_volumes[ibmcloud_vs_instance.resource.name] | default([])) +
+            instance.name:
+              (ibmcloud_volumes[instance.name] | default([])) +
               [{
                 'name': _volume.name,
                 'id': _attachment.device.id,

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/create_volume.yaml
@@ -12,7 +12,7 @@
 - name: Create data volume
   command: >-
     ibmcloud is volume-create
-    --name disk-{{ guid  ~ '-' ~ _volume.name }}
+    --name {{ _volume_name }}
     --profile {{ _volume.type | default('general-purpose') }}
     --capacity {{ _volume.size }}
     --resource-group-id {{ r_ibmcloud_resource_group_id}}
@@ -31,7 +31,7 @@
   # get the definitive, current details of the volume, whether it was just
   # created or it already existed. The '--output JSON' flag is correct.
   command: >-
-    ibmcloud is volume disk-{{ guid  ~ '-' ~ _volume.name }} --output JSON
+    ibmcloud is volume {{ _volume_name }} --output JSON
   register: _volume_details
   until: _volume_details is succeeded
   retries: 5
@@ -47,7 +47,7 @@
 - name: Attach existing volume to instance
   command: >-
     ibmcloud is instance-volume-attachment-add
-    attachment-{{ guid }}-{{ _volume.name }}
+    attachment-{{ _volume_name }}
     {{ ibmcloud_vs_instance.resource.name }}
     {{ _volume_to_attach.id }}
     --auto-delete {{ _volume.auto_delete | default(true) }}
@@ -58,17 +58,24 @@
     and 'already attached' not in ibmcloud_volume_attach.stderr
     and 'is in use' not in ibmcloud_volume_attach.stderr
 
+- debug:
+    verbosity: 2
+    var: ibmcloud_volume_attach
+
 - name: Get authoritative details for the volume attachment
   # This task always runs to get the definitive state of the attachment,
   # regardless of whether the previous task made a change or was skipped.
   command: >-
     ibmcloud is instance-volume-attachment
     {{ ibmcloud_vs_instance.resource.name }}
-    attachment-{{ guid }}-{{ _volume.name }}
+    attachment-{{ _volume_name }}
     --output JSON
   register: _attachment_details
-  until: _attachment_details is succeeded
+  until: >-
+    _attachment_details is succeeded
+    and 'device' in (_attachment_details.stdout | from_json)
   retries: 5
+  delay: 10
 
 - name: Save fact for IBM Cloud Volume attachment
   ansible.builtin.set_fact:

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
@@ -4,7 +4,6 @@
   ibm.cloudcollection.ibm_is_instance:
     region: "{{ ibmcloud_region }}"
     state: absent
-    #name: "{{ instance_name_with_guid }}"
     id: "{{ instance.id }}"
     image: "{{ instance.image }}"
     vpc: "{{ instance.vpc }}"
@@ -15,10 +14,3 @@
         subnet: "{{ instance.primary_network_interface[0].subnet }}"
     keys: "{{ instance.keys }}"
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
-
-- name: Delete floating ip for instance
-  ibm.cloudcollection.ibm_is_floating_ip:
-    name: "{{ instance_name_with_guid }}-fip"
-    state: absent
-    resource_group: "{{ r_ibmcloud_resource_group_id }}"
-    zone: "{{ instance.zone }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
@@ -4,7 +4,7 @@
   ibm.cloudcollection.ibm_is_instance:
     region: "{{ ibmcloud_region }}"
     state: absent
-    name: "{{ instance.name }}"
+    name: "{{ instance_name_with_guid }}"
     id: "{{ instance.id }}"
     image: "{{ instance.image }}"
     vpc: "{{ instance.vpc }}"
@@ -18,7 +18,7 @@
 
 - name: Delete floating ip for instance
   ibm.cloudcollection.ibm_is_floating_ip:
-    name: "{{ instance.name }}-fip"
+    name: "{{ instance_name_with_guid }}-fip"
     state: absent
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
     zone: "{{ instance.zone }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_instance.yaml
@@ -4,7 +4,7 @@
   ibm.cloudcollection.ibm_is_instance:
     region: "{{ ibmcloud_region }}"
     state: absent
-    name: "{{ instance_name_with_guid }}"
+    #name: "{{ instance_name_with_guid }}"
     id: "{{ instance.id }}"
     image: "{{ instance.image }}"
     vpc: "{{ instance.vpc }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_networks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_networks.yaml
@@ -35,6 +35,7 @@
   register: r_ibmcloud_floating_ips
   until: r_ibmcloud_floating_ips is succeeded
   retries: 5
+  changed_when: false
   delay: 10
 
 - name: Release all floating IPs for the resource group {{ ibmcloud_resource_group_name }}
@@ -49,7 +50,7 @@
       }}
   command: >-
     ibmcloud is floating-ip-release --force
-    {{ _floating_ips.join(' ') }}
+    {{ _floating_ips | join(' ') }}
   register: r_ibmcloud_floating_ips_release
   until: r_ibmcloud_floating_ips_release is succeeded
   retries: 5

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_networks.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_networks.yaml
@@ -26,3 +26,30 @@
     resource_group: "{{ r_ibmcloud_resource_group_id }}"
     state: absent
     region: "{{ ibmcloud_region }}"
+
+- name: Get all floating IPs for the resource group {{ ibmcloud_resource_group_name }}
+  command: >-
+    ibmcloud is floating-ips
+    --resource-group-name {{ ibmcloud_resource_group_name }}
+    --json
+  register: r_ibmcloud_floating_ips
+  until: r_ibmcloud_floating_ips is succeeded
+  retries: 5
+  delay: 10
+
+- name: Release all floating IPs for the resource group {{ ibmcloud_resource_group_name }}
+  when: _floating_ips | length > 0
+  vars:
+    _floating_ips: >-
+      {{ r_ibmcloud_floating_ips.stdout
+      | default('[]')
+      | from_json
+      | map(attribute='id')
+      | list
+      }}
+  command: >-
+    ibmcloud is floating-ip-release --force
+    {{ _floating_ips.join(' ') }}
+  register: r_ibmcloud_floating_ips_release
+  until: r_ibmcloud_floating_ips_release is succeeded
+  retries: 5

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_ssh_key.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/delete_ssh_key.yaml
@@ -1,18 +1,13 @@
 ---
-- name: Get SSH Public Key pair
-  register: r_ibmcloud_public_key
-  ibm.cloudcollection.ibm_is_ssh_key_info:
-    name: "{{ ibmcloud_resource_group_name }}-ssh-key"
-    resource_group: "{{ r_ibmcloud_resource_group_id }}"
-    region: "{{ ibmcloud_region }}"
-  ignore_errors: true
-
-- name: Delete SSH Public Key pair
-  when: r_ibmcloud_public_key is success
-  ibm.cloudcollection.ibm_is_ssh_key:
-    state: absent
-    name: "{{ ibmcloud_resource_group_name }}-ssh-key"
-    public_key: "{{ r_ibmcloud_public_key.resource.public_key }}"
-    id: "{{ r_ibmcloud_public_key.resource.id }}"
-    resource_group: "{{ r_ibmcloud_resource_group_id }}"
-    region: "{{ ibmcloud_region }}"
+- name: Delete SSH Public Key pair using ibmcloud CLI
+  command: >-
+    ibmcloud is key-delete {{ ibmcloud_resource_group_name }}-ssh-key
+    --force
+  register: r_ibmcloud_delete_ssh_public_key
+  until: r_ibmcloud_delete_ssh_public_key is succeeded
+  retries: 5
+  failed_when: >-
+    r_ibmcloud_delete_ssh_public_key.rc != 0
+    and 'not found' not in r_ibmcloud_delete_ssh_public_key.stderr
+  changed_when: >-
+    r_ibmcloud_delete_ssh_public_key.rc == 0

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/main.yaml
@@ -15,6 +15,7 @@
 
 - when: ACTION == 'destroy'
   block:
+    - ansible.builtin.include_tasks: login.yaml
     - name: Get IBM Resource Group details
       ibm.cloudcollection.ibm_resource_group_info:
         ibmcloud_api_key: "{{ ibmcloud_api_key }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/main.yaml
@@ -33,4 +33,5 @@
 
 - when: ACTION in ['status', 'start', 'stop']
   block:
+    - ansible.builtin.include_tasks: login.yaml
     - ansible.builtin.include_tasks: "{{ ACTION }}_instances.yaml"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/start_instances.yaml
@@ -1,13 +1,22 @@
 ---
-- name: List all IBM Cloud instances
-  ibm.cloudcollection.instance_info:
-    region: "{{ ibmcloud_region }}"
+- name: List all IBM Cloud instances using ibmcloud CLI
+  command: >-
+    ibmcloud is instances --output JSON
+    --resource-group-name "{{ ibmcloud_resource_group_name }}"
   register: r_ibmcloud_instances
+  changed_when: false
+  until: r_ibmcloud_instances is succeeded
+  retries: 5
 
-- name: Start all running instances
-  ibm.cloudcollection.instance:
-    id: "{{ item['id'] }}"
-    region: "{{ ibmcloud_region }}"
-    state: running
-  with_items: "{{ r_ibmcloud_instances.instances }}"
-  when: item['status'] == 'stopped'
+- set_fact:
+    ibmcloud_instances: "{{ r_ibmcloud_instances.stdout | from_json }}"
+
+- name: Start all running instances using ibmcloud CLI
+  command: >-
+    ibmcloud is instance-start {{ item.id }} --force --output JSON
+  register: r_ibmcloud_start_instances
+  until: r_ibmcloud_start_instances is succeeded
+  retries: 5
+  loop: "{{ ibmcloud_instances }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/status_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/status_instances.yaml
@@ -1,23 +1,31 @@
 ---
-- name: List all IBM Cloud instances
-  ibm.cloudcollection.instance_info:
+- name: List all IBM Cloud instances using ibmcloud CLI
+  command: >-
+    ibmcloud is instances --output JSON
+    --resource-group-name "{{ ibmcloud_resource_group_name }}"
   register: r_ibmcloud_instances
+  changed_when: false
+  until: r_ibmcloud_instances is succeeded
+  retries: 5
+
+- set_fact:
+    ibmcloud_instances: "{{ r_ibmcloud_instances.stdout | from_json }}"
 
 - name: Report status in user info
   agnosticd_user_info:
     msg: |-
-      {{ "%-20s %-10s" | format("Instance", "State") }}
+      {{ "%-20s %-10s %-10s" | format("Instance", "State", "Health") }}
       ----------------------------------------------------------------
-      {% for instance in r_ibmcloud_instances .resources | default([]) %}
-      {{ "%-20s %-10s" | format(instance.name, instance.status) }}
+      {% for instance in ibmcloud_instances| default([]) %}
+      {{ "%-20s %-10s %-10s" | format(instance.name, instance.status, instance.health_state) }}
       {% endfor %}
 
 - name: Print status information to a file
   ansible.builtin.copy:
     dest: "{{ output_dir }}/status.txt"
     content: |-
-      {{ "%-20s %-10s" | format("Instance", "State") }}
+      {{ "%-20s %-10s %-10s" | format("Instance", "State", "Health") }}
       ----------------------------------------------------------------
-      {% for instance in r_ibmcloud_instances | default([]) %}
-      {{ "%-20s %-10s" | format(instance.name, instance.status) }}
+      {% for instance in ibmcloud_instances| default([]) %}
+      {{ "%-20s %-10s %-10s" | format(instance.name, instance.status, instance.health_state) }}
       {% endfor %}

--- a/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra-ibm-resource-group-resources/tasks/stop_instances.yaml
@@ -1,13 +1,22 @@
 ---
-- name: List all IBM Cloud instances
-  ibm.cloudcollection.instance_info:
-    region: "{{ ibmcloud_region }}"
+- name: List all IBM Cloud instances using ibmcloud CLI
+  command: >-
+    ibmcloud is instances --output JSON
+    --resource-group-name "{{ ibmcloud_resource_group_name }}"
   register: r_ibmcloud_instances
+  changed_when: false
+  until: r_ibmcloud_instances is succeeded
+  retries: 5
 
-- name: Start all stopped instances
-  ibm.cloudcollection.instance:
-    id: "{{ item['id'] }}"
-    state: running
-    region: "{{ ibmcloud_region }}"
-  with_items: "{{ r_ibmcloud_instances }}"
-  when: item['status'] == 'stopped'
+- set_fact:
+    ibmcloud_instances: "{{ r_ibmcloud_instances.stdout | from_json }}"
+
+- name: Stop all running instances using ibmcloud CLI
+  command: >-
+    ibmcloud is instance-stop {{ item.id }} --force --output JSON
+  register: r_ibmcloud_start_instances
+  until: r_ibmcloud_start_instances is succeeded
+  retries: 5
+  loop: "{{ ibmcloud_instances }}"
+  loop_control:
+    label: "{{ item.name }}"


### PR DESCRIPTION
##### SUMMARY
adding GUID to instance name is an implementation detail, underlying
logic to work at the cloud provider level.
At the agnosticV and agnosticD level, allow names to be simple.

- Allow simply `bastion.GUID.DOMAIN.TLD`
  instead of  `bastion-GUID.GUID.DOMAIN.TLD`

- Add an helper 'instance_name_with_guid' to add the guid for names of
instance resources (network card, disk, ...) which should be unique
across the account.

- Add mandatory tags: guid, service_uuid to instance - Cost tracking etc.

- Fix find_ip_query when building the inventory

- Fix broken logic in the loops of inventory (double looping)

- reuse the equinix_metal filter to translate tags from list to dict

- Implement logic for `instances[].count`: introduce a new filter `agnosticd_expand_instances` to facilitate and simplify the code.
- delete all floating IPs in the RG (using ibmcloud CLI) instead of deleting only {instance-name}-fip
- Fix volumes key as it was using the ibmcloud resource name

- Use ibmcloud CLI for SSH keys (faster, **save 20-40s** compared to ansible module)
- Use ssh_provision_key_type: ed25519  for IBM Cloud  env key
- fix start/stop
- fix lifecycle status

```
Instance             State      Health
----------------------------------------------------------------
bastion-6s6lx        running    ok
node1-6s6lx          running    ok
node2-6s6lx          running    ok
```

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
IBM Cloud provider - core

