### PR TITLE
CNV and IBM Cloud: Cleanup dns names

### DIFF
--- a/ansible/cloud_providers/ibm_resource_group_destroy_env.yml
+++ b/ansible/cloud_providers/ibm_resource_group_destroy_env.yml
@@ -48,3 +48,10 @@
         name: infra-ibm-resource-group-resources
       vars:
         ACTION: destroy
+
+    - name: Run infra-dns Role
+      when: cluster_dns_server is defined or route53_aws_zone_id is defined
+      ansible.builtin.include_role:
+        name: infra-dns
+      vars:
+        _dns_state: absent

--- a/ansible/cloud_providers/openshift_cnv_destroy_env.yml
+++ b/ansible/cloud_providers/openshift_cnv_destroy_env.yml
@@ -12,3 +12,10 @@
         name: infra-openshift-cnv-resources
       vars:
         ACTION: destroy
+
+    - name: Run infra-dns Role
+      when: cluster_dns_server is defined or route53_aws_zone_id is defined
+      ansible.builtin.include_role:
+        name: infra-dns
+      vars:
+        _dns_state: absent


### PR DESCRIPTION
the infra-dns playbook is missing in the destroy playbooks for CNV and IBM Cloud resource group.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
- CNV
- IBM Cloud resource group
- 
