### PR TITLE
Add control_user_enable_user_data_by_shortname to control-user workload

### DIFF
--- a/ansible/roles/control-user/defaults/main.yml
+++ b/ansible/roles/control-user/defaults/main.yml
@@ -6,7 +6,12 @@ control_user_enable_skel: true
 control_user_enable_sudoers: true
 control_user_enable_user_data: true
 control_user_enable_user_data_ssh_provision_key: false
+
+# Enable user data in "hosts" dictionary keyed by inventory hostname.
 control_user_enable_user_data_by_hostname: false
+
+# Enable user data in simple key/value prefixed by host shortname.
+control_user_enable_user_data_by_shortname: false
 
 ## User skel files used in tasks/main.yml
 control_user_skel_files:                # list of user skel files

--- a/ansible/roles/control-user/tasks/report-user-data.yml
+++ b/ansible/roles/control-user/tasks/report-user-data.yml
@@ -18,6 +18,12 @@
         }
         if control_user_enable_user_data_by_hostname | bool else
         {
+          shortname ~ "_ssh_host": public_dns_name,
+          shortname ~ "_user": control_user_name,
+          shortname ~ "_password": control_user_password,
+        }
+        if control_user_enable_user_data_by_shortname | bool else
+        {
           "ssh_host": public_dns_name,
           "user": control_user_name,
           "password": control_user_password,


### PR DESCRIPTION
##### SUMMARY

Add `control_user_enable_user_data_by_shortname` feature to control-user workload. This allows the user data such as ssh hostname and password to be set with each variable prefixed by the hosts shortname.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

role control-user.