### PR TITLE
Role, vscode-server Fix dnf module error on RHEL 8 systems

### DIFF
--- a/ansible/roles/vscode-server/tasks/nginx/RedHat7.yml
+++ b/ansible/roles/vscode-server/tasks/nginx/RedHat7.yml
@@ -1,6 +1,6 @@
 ---
 - name: nginx/RedHat7 | install nginx
-  yum:
+  ansible.builtin.yum:
     name:
       - nginx
       - certbot-nginx

--- a/ansible/roles/vscode-server/tasks/nginx/RedHat8.yml
+++ b/ansible/roles/vscode-server/tasks/nginx/RedHat8.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: nginx/RedHat8 | enable EPEL
-  dnf:
+  ansible.builtin.yum:
     name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm"
     state: present
     disable_gpg_check: true
 
 - name: nginx/RedHat8 | install nginx and certbot packages
-  yum:
+  ansible.builtin.yum:
     name:
       - nginx
       - certbot


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
vscode-server
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Zero Touch "Getting Started With Ansible Navigtor" fails to deploy with the below error:

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below
TASK [vscode-server : nginx/RedHat8 | enable EPEL] *****************************
Wednesday 02 July 2025  13:25:08 +0000 (0:00:00.021)       0:03:10.670 ******** 
fatal: [control.sg267.internal]: FAILED! => {"changed": false, "msg": "Could not import the dnf python module using /usr/bin/python3.9 (3.9.19 (main, May 16 2024, 08:45:40) [GCC 8.5.0 20210514 (Red Hat 8.5.0-22)]). Please install `python3-dnf` package or ensure you have specified the correct ansible_python_interpreter. (attempted ['/usr/libexec/platform-python', '/usr/bin/python3', '/usr/bin/python'])", "results": []}
```
