### PR TITLE
fix: Set output.dir for zerotouch items

### DIFF
--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -6,14 +6,14 @@
   register: default_site_stat
 
 - name: Ensure output.dir is set to ./www/www for zero-touch
-  when:
-    - default_site_stat.stat.exists
-    - showroom_ui == "zero-touch"
   community.general.yaml:
     path: "{{ showroom_user_content_dir }}/default-site.yml"
     key: output.dir
     value: ./www/www
     update: yes
+  when:
+    - default_site_stat.stat.exists
+    - showroom_ui == "zero-touch"
 
 - name: Render asciidoc via antora container using the default-site.yml
   containers.podman.podman_container:

--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -5,6 +5,16 @@
     path: "{{ showroom_user_content_dir }}/default-site.yml"
   register: default_site_stat
 
+- name: Ensure output.dir is set to ./www/www for zero-touch
+  when:
+    - default_site_stat.stat.exists
+    - showroom_ui == "zero-touch"
+  community.general.yaml:
+    path: "{{ showroom_user_content_dir }}/default-site.yml"
+    key: output.dir
+    value: ./www/www
+    update: yes
+
 - name: Render asciidoc via antora container using the default-site.yml
   containers.podman.podman_container:
     name: container


### PR DESCRIPTION
As some repos will be working for showroom and zerotouch at the same time we need to manage the output dir, as they are different. 
For showroom usually is ./www
For zerotouch usually is ./www/www

This PR aims to set the output directory for zerotouch items. So the repo can live with the current showroom dir