### PR TITLE
roadshow_vmware: make pooling true default

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_vmware/defaults/main.yml
@@ -6,7 +6,7 @@ silent: false
 # Assign permission to precreated VMs instead to create new VMs
 # VMs are precreated as database-userX, winweb01-userX and winweb-userX
 # If this is enabled but the VM doesnt exist, it will create the VMs anyway
-ocp4_workload_virt_roadshow_vmware_use_pool: false
+ocp4_workload_virt_roadshow_vmware_use_pool: true
 
 # Folder where the pool VMs (described above) are located
 ocp4_workload_virt_roadshow_vmware_vcenter_pool_folder: "Roadshow"


### PR DESCRIPTION
People create new CIs that don't have pooling enabled, kinda messing up the VMware cluster.
This sets pooling to default.

- Feature Pull Request