### PR TITLE
Add option to leave nfd_operator_operand_image empty

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/templates/nodefeature_discovery_cr.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/templates/nodefeature_discovery_cr.yaml.j2
@@ -14,7 +14,9 @@ spec:
       #      matchOn:
       #      - nodename: ["special-.*-node-.*"]
   operand:
+{% if nfd_operator_operand_image is defined and nfd_operator_operand_image | length > 0 %}
     image: '{{ nfd_operator_operand_image }}'
+{% endif %}
     imagePullPolicy: IfNotPresent
     servicePort: 12000
   workerConfig:


### PR DESCRIPTION
##### SUMMARY

With newer version, you don't need and want to set `nfd_operator_operand_image`

Now you can simply add 
```
nfd_operator_operand_image: ""
```
and image is not set.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

 - gpu operator & nfd operator

##### ADDITIONAL INFORMATION

n/a
