### PR TITLE
Write out external IP to a file when running on CNV

### DIFF
--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -64,8 +64,8 @@
               targetport: "{{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
               subdomain: "{{ guid }}{{ subdomain_base_suffix }}"
               subdomain_internal: "{{ chomped_zone_internal_dns | default('') }}"
-              external_ip: "{{ hostvars[groups['bastions'][0]]['external_ip'] }}"
-              external_ports: "{{ hostvars[groups['bastions'][0]]['external_ports'] }}"
+              external_ip: "{{ hostvars[groups['bastions'][0]]['external_ip'] | default('') }}"
+              external_ports: "{{ hostvars[groups['bastions'][0]]['external_ports'] | default('') }}"
           vars:
             student_name: "{{ ansible_service_account_user_name }}"
           register: r_user_data

--- a/ansible/configs/base-infra/post_software.yml
+++ b/ansible/configs/base-infra/post_software.yml
@@ -64,6 +64,8 @@
               targetport: "{{ hostvars[groups['bastions'][0]].bastion_ssh_port }}"
               subdomain: "{{ guid }}{{ subdomain_base_suffix }}"
               subdomain_internal: "{{ chomped_zone_internal_dns | default('') }}"
+              external_ip: "{{ hostvars[groups['bastions'][0]]['external_ip'] }}"
+              external_ports: "{{ hostvars[groups['bastions'][0]]['external_ports'] }}"
           vars:
             student_name: "{{ ansible_service_account_user_name }}"
           register: r_user_data

--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -41,6 +41,15 @@
     line: "export GUID={{ guid }}"
     create: true
 
+- name: Write external IP to user home directory (CNV)
+  when: cloud_provider == "openshift_cnv"
+  ansible.builtin.copy:
+    content: "{{ hostvars[inventory_hostname]['external_ip'] }}"
+    dest: "~{{ ansible_user }}/external_ip"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0644'
+
   # TODO: Is there any value in doing the below?
   #       Discuss with team and consider "per cloud" includes
   #       Leave for now as a reminder and reference

--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -42,7 +42,10 @@
     create: true
 
 - name: Write external IP to user home directory (CNV)
-  when: cloud_provider == "openshift_cnv"
+  when:
+    - cloud_provider == "openshift_cnv"
+    - hostvars[inventory_hostname]['external_ip'] is defined
+    - hostvars[inventory_hostname]['external_ip'] != ""
   ansible.builtin.copy:
     content: "{{ hostvars[inventory_hostname]['external_ip'] }}"
     dest: "~{{ ansible_user }}/external_ip"


### PR DESCRIPTION
##### SUMMARY

The external IP is available as an agnosticd variable, but it is not available to someone inside the environment. When someone uses one of these environments to run with their own automation or lab guides, they potentially need access to this IP without having to go to the RHDP UI to find it.

This will write out the IP to a file on the bastion. It will also display the external IP as agnosticd_user_info data, not just in the message.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles/bastion-base
configs/base-infra


