### PR TITLE
Add missing authorization policy for InstructLab to COS access

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/tasks/destroy.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/tasks/destroy.yml
@@ -65,6 +65,75 @@
   when: terraform_state_check.stat.exists
   block:
 
+    - name: Get Terraform outputs before destruction
+      community.general.terraform:
+        project_path: "{{ output_dir }}"
+        state: present
+        force_init: true
+        variables:
+          ibmcloud_api_key: "{{ ibmcloud_api_key }}"
+          ibm_region_location: "{{ ibmcloud_region }}"
+          requester_email: "{{ requester_email }}"
+          ibm_realm_name: "{{ ibm_realm_name }}"
+          guid: "{{ guid }}"
+      environment:
+        PATH: "{{ user_path }}"
+      register: terraform_outputs_for_cleanup
+      failed_when: false
+
+    - name: Remove authorization policy before destroying resources
+      when: terraform_outputs_for_cleanup is succeeded and terraform_outputs_for_cleanup.outputs is defined
+      block:
+        - name: Set cleanup facts from Terraform outputs
+          ansible.builtin.set_fact:
+            cleanup_instructlab_guid: "{{ terraform_outputs_for_cleanup.outputs.instructlab_instance_guid.value | default('') }}"
+            cleanup_cos_guid: "{{ terraform_outputs_for_cleanup.outputs.cos_instance_guid.value | default('') }}"
+
+        - name: Authenticate with IBM Cloud CLI for cleanup
+          ansible.builtin.shell: |
+            export IBMCLOUD_API_KEY="{{ ibmcloud_api_key }}"
+            ibmcloud login --apikey "${IBMCLOUD_API_KEY}" -r "{{ ibmcloud_region }}" --quiet
+          environment:
+            IBMCLOUD_API_KEY: "{{ ibmcloud_api_key }}"
+          register: ibmcloud_login_cleanup
+          changed_when: false
+          no_log: true
+          failed_when: false
+
+        - name: Find and delete authorization policies for this InstructLab instance
+          when: 
+            - cleanup_instructlab_guid != ''
+            - cleanup_cos_guid != ''
+            - ibmcloud_login_cleanup.rc == 0
+          block:
+            - name: Find authorization policies for InstructLab instance
+              ansible.builtin.shell: |
+                ibmcloud iam authorization-policies --output json | \
+                jq -r '.[] | select(.subjects[0].attributes[]?.value == "{{ cleanup_instructlab_guid }}" and .resources[0].attributes[]?.value == "{{ cleanup_cos_guid }}") | .id'
+              register: auth_policies_to_delete
+              failed_when: false
+              changed_when: false
+
+            - name: Delete authorization policies
+              ansible.builtin.shell: |
+                ibmcloud iam authorization-policy-delete "{{ item }}" --force
+              loop: "{{ auth_policies_to_delete.stdout_lines | default([]) }}"
+              when: 
+                - auth_policies_to_delete.rc == 0
+                - auth_policies_to_delete.stdout_lines is defined
+                - auth_policies_to_delete.stdout_lines | length > 0
+              register: auth_policy_deletion
+              failed_when: false
+
+            - name: Report authorization policy cleanup results
+              ansible.builtin.debug:
+                msg: "{{ 'Authorization policies deleted successfully' if (auth_policy_deletion.results | default([]) | selectattr('rc', 'equalto', 0) | list | length > 0) else 'No authorization policies found or deletion failed' }}"
+
+      rescue:
+        - name: Handle authorization policy cleanup failure
+          ansible.builtin.debug:
+            msg: "⚠️ WARNING: Could not clean up authorization policies automatically. Manual cleanup may be required."
+
     - name: Execute Terraform destroy
       community.general.terraform:
         project_path: "{{ output_dir }}"

--- a/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/tasks/provision.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/tasks/provision.yml
@@ -159,6 +159,53 @@
         f_ibmcloud_cos_instance_id: "{{ r_terraform_output.outputs.cos_instance_id.value }}"
         f_ibmcloud_instructlab_instance_id: "{{ r_terraform_output.outputs.instructlab_instance_id.value }}"
         f_ibmcloud_instructlab_instance_guid: "{{ r_terraform_output.outputs.instructlab_instance_guid.value }}"
+        f_ibmcloud_cos_instance_guid: "{{ r_terraform_output.outputs.cos_instance_guid.value }}"
+
+    - name: Create authorization policy for InstructLab to access COS
+      block:
+        - name: Authenticate with IBM Cloud CLI
+          ansible.builtin.shell: |
+            export IBMCLOUD_API_KEY="{{ ibmcloud_api_key }}"
+            ibmcloud login --apikey "${IBMCLOUD_API_KEY}" -r "{{ ibmcloud_region }}" --quiet
+          environment:
+            IBMCLOUD_API_KEY: "{{ ibmcloud_api_key }}"
+          register: ibmcloud_login
+          changed_when: false
+          no_log: true
+
+        - name: Create authorization policy for InstructLab service to write to COS
+          ansible.builtin.shell: |
+            ibmcloud iam authorization-policy-create instructlab cloud-object-storage "Writer" \
+              --source-service-instance-id "{{ f_ibmcloud_instructlab_instance_guid }}" \
+              --target-service-instance-id "{{ f_ibmcloud_cos_instance_guid }}" \
+              --output JSON
+          register: auth_policy_result
+          failed_when: false
+          changed_when: auth_policy_result.rc == 0
+
+        - name: Check if authorization policy creation was successful
+          ansible.builtin.debug:
+            msg: "Authorization policy {{ 'created successfully' if auth_policy_result.rc == 0 else 'creation failed: ' + auth_policy_result.stderr }}"
+
+        - name: Warn if authorization policy creation failed
+          ansible.builtin.debug:
+            msg: |
+              ⚠️ WARNING: Authorization policy creation failed. You may need to create it manually:
+              ibmcloud iam authorization-policy-create instructlab cloud-object-storage "Writer" \
+                --source-service-instance-id "{{ f_ibmcloud_instructlab_instance_guid }}" \
+                --target-service-instance-id "{{ f_ibmcloud_cos_instance_guid }}"
+          when: auth_policy_result.rc != 0
+
+      rescue:
+        - name: Handle authorization policy creation failure
+          ansible.builtin.debug:
+            msg: |
+              ⚠️ WARNING: Could not create authorization policy automatically. 
+              IBM Cloud CLI may not be available or authentication failed.
+              Please create manually after deployment:
+              ibmcloud iam authorization-policy-create instructlab cloud-object-storage "Writer" \
+                --source-service-instance-id "{{ f_ibmcloud_instructlab_instance_guid }}" \
+                --target-service-instance-id "{{ f_ibmcloud_cos_instance_guid }}"
 
   rescue:
     - name: Check for specific error types

--- a/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/templates/instructlab-as-a-service.j2
+++ b/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/templates/instructlab-as-a-service.j2
@@ -243,6 +243,20 @@ resource "ibm_iam_trusted_profile_policy" "instructlab_service_instance_policy" 
   depends_on = [ibm_resource_instance.instructlab_instance]
 }
 
+# Grant InstructLab service instance authorization to write to COS instance
+resource "ibm_iam_authorization_policy" "instructlab_to_cos_policy" {
+  source_service_name = "instructlab"
+  source_service_instance = ibm_resource_instance.instructlab_instance.guid
+  target_service_name = "cloud-object-storage"
+  target_service_instance = ibm_resource_instance.instructlab_cos_instance.guid
+  roles = ["Object Writer"]
+  
+  depends_on = [
+    ibm_resource_instance.instructlab_instance,
+    ibm_resource_instance.instructlab_cos_instance
+  ]
+}
+
 # Outputs
 output "resource_group_id" {
   description = "ID of the created resource group"

--- a/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/templates/instructlab-as-a-service.j2
+++ b/ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service/templates/instructlab-as-a-service.j2
@@ -243,19 +243,9 @@ resource "ibm_iam_trusted_profile_policy" "instructlab_service_instance_policy" 
   depends_on = [ibm_resource_instance.instructlab_instance]
 }
 
-# Grant InstructLab service instance authorization to write to COS instance
-resource "ibm_iam_authorization_policy" "instructlab_to_cos_policy" {
-  source_service_name = "instructlab"
-  source_service_instance = ibm_resource_instance.instructlab_instance.guid
-  target_service_name = "cloud-object-storage"
-  target_service_instance = ibm_resource_instance.instructlab_cos_instance.guid
-  roles = ["Object Writer"]
-  
-  depends_on = [
-    ibm_resource_instance.instructlab_instance,
-    ibm_resource_instance.instructlab_cos_instance
-  ]
-}
+# NOTE: Authorization policy for InstructLab service to access COS must be created manually
+# The current IBM Terraform provider version does not support the required arguments
+# Manual command: ibmcloud iam authorization-policy-create instructlab cloud-object-storage "Writer" --source-service-instance-id <instructlab-guid> --target-service-instance-id <cos-guid>
 
 # Outputs
 output "resource_group_id" {


### PR DESCRIPTION
- Added ibm_iam_authorization_policy resource to grant InstructLab service instance 'Object Writer' permissions to COS instance
- This fixes the taxonomy file upload issue where InstructLab service could not write to the COS bucket
- Policy grants source service (instructlab) access to target service (cloud-object-storage) with proper dependencies

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible/collections/ansible_collections/agnosticd/ibm/roles/ibm_instructlab_service
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
