### PR TITLE
Add custom role for GitOps Operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/controller-managedby-rbac-admin.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/controller-managedby-rbac-admin.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-controller-admin
+  labels:
+    gitops/aggregate-to-controller: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/controller-managedby-rbac-controller.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/controller-managedby-rbac-controller.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  name: gitops-controller
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      gitops/aggregate-to-controller: "true"
+rules: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/controller-managedby-rbac-view.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/controller-managedby-rbac-view.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-controller-view
+  labels:
+    gitops/aggregate-to-controller: "true"
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/server-managedby-rbac.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/server-managedby-rbac.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-server
+rules:
+  - verbs:
+      - get
+      - patch
+      - delete
+    apiGroups:
+      - "*"
+    resources:
+      - "*"
+  - verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+  - verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - delete
+      - patch
+    apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+      - appprojects
+      - applicationsets
+  - verbs:
+      - create
+      - list
+    apiGroups:
+      - ""
+    resources:
+      - events
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
@@ -1,0 +1,19 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  config:
+    env:
+    - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+      value: openshift-gitops, gitops
+    - name: CONTROLLER_CLUSTER_ROLE
+      value: gitops-controller
+    - name: SERVER_CLUSTER_ROLE
+      value: gitops-server
+  channel: gitops-1.13
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
@@ -7,7 +7,7 @@ spec:
   config:
     env:
     - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
-      value: openshift-gitops, gitops
+      value: openshift-gitops
     - name: CONTROLLER_CLUSTER_ROLE
       value: gitops-controller
     - name: SERVER_CLUSTER_ROLE

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
@@ -11,6 +11,18 @@
   set_fact:
     sub_domain: "{{ ingress | json_query('resources[0].spec.domain')}}"
 
+# Support custom roles for managed-by Argo CD namespaces
+- name: update-gitops-operator
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('file', 'gitops-operator/' + item) | from_yaml }}"
+  with_items:
+    - controller-managedby-rbac-view.yaml
+    - controller-managedby-rbac-admin.yaml
+    - controller-managedby-rbac-controller.yaml
+    - server-managedby-rbac.yaml
+    - subscription.yaml
+
 # Implement your Workload deployment tasks here
 # deploy individual argo instances for users
 - name: Deploy ArgoCD instances for users


### PR DESCRIPTION
##### SUMMARY

This adds a custom role to the GitOps operator that is used when namespaces are labeled with the `managed-by` label. This new role is needed to support the Argo CD terminal which requires pod/exec create permissions.

This workshop only has a Dev environment at this time. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_advanced_gitops_workshop

