### PR TITLE
[ADVANCED_GITOPS] Update subscription for GitOps operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-gitops-operator
-  namespace: openshift-gitops-operator
+  namespace: openshift-operators
 spec:
   config:
     env:
@@ -12,7 +12,7 @@ spec:
       value: gitops-controller
     - name: SERVER_CLUSTER_ROLE
       value: gitops-server
-  channel: gitops-1.13
+  channel: gitops-1.16
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
##### SUMMARY

Updates the GitOps Operator to put it in the right namespace since the RHDP still uses `openshift-operators`, also bumped the version to the correct one as I copy/pasted too fast.

Note this workshop is in Development only, no test or prod environments exist at this time.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_advanced_gitops_workshop

