### PR TITLE
[roles_ocp_workloads/ocp4_workload_showroom] Add support for zerotouch chart

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -98,6 +98,14 @@ ocp4_workload_showroom_zero_touch_ui_enabled: false
 
 ocp4_workload_showroom_use_sandbox_domain: false
 
+ocp4_workload_showroom_terminal_enable: false
+
+# Project zero
+ocp4_workload_showroom_ironrdp_enable: false
+ocp4_workload_showroom_ironrdp_image: quay.io/agonzalezrh/ironrdp:v0.0.2
+ocp4_workload_showroom_automation_disable: false
+ocp4_workload_showroom_cloud_image: quay.io/rhpds/showroom-cloud:v1
+
 
 # defaults for _showroom_user_data so env destroys don't fail
 _showroom_user_data:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -28,8 +28,13 @@
         zero_touch_ui_enabled: "{{ ocp4_workload_showroom_zero_touch_ui_enabled | string | lower }}"
 
       guid: "{{ guid }}"
+      satellite:
+        url: "{{ satellite_url | default('') }}"
+        org: "{{ satellite_org | default('') }}"
+        activationkey: "{{ satellite_activationkey | default('') }}"
       deployer:
         domain: "{{ _deployer_domain }}"
+        registry_pull_token: "{{ registry_pull_token | default('') }}"
       stacked_terminals:
         setup: "{{ ocp4_workload_showroom_stacked_terminals_enable | bool | string | lower }}"
         display_name: "{{ ocp4_workload_showroom_stacked_terminals_display_name }}"
@@ -41,7 +46,7 @@
                          else false) | bool | string | lower }}"
         display_name: "{{ ocp4_workload_showroom_second_terminal_tab_display_name }}"
       terminal:
-        setup: "{{ (true if ocp4_workload_showroom_terminal_type == 'showroom' else false) | bool | string | lower }}"
+        setup: "{{ ocp4_workload_showroom_terminal_enable | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_terminal_image }}"
         resources:
           requests:
@@ -67,6 +72,8 @@
           sshUser: "{{ _showroom_user_data['users'][_showroom_user].bastion_ssh_user_name | default(_showroom_user_data.bastion_ssh_user_name) }}"
           sshPass: "{{ _showroom_user_data['users'][_showroom_user].bastion_ssh_password | default(_showroom_user_data.bastion_ssh_password) }}"
           sshPort: "{{ _showroom_user_data.bastion_ssh_port | default(22) }}"
+          sshOtherHosts: "{{ instances | selectattr('name') | map(attribute='name') | list | default([]) }}"
+          terminals: "{{ instances | selectattr('terminals', 'defined') | community.general.json_query('[].{name: name, terminals: terminals}') }}"
       novnc:
         setup: "{{ (true if ocp4_workload_showroom_novnc_enable | bool else false) | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_novnc_image }}"
@@ -79,6 +86,36 @@
           limits:
             cpu: "{{ ocp4_workload_showroom_novnc_limits_cpu }}"
             memory: "{{ ocp4_workload_showroom_novnc_limits_memory }}"
+      cloud:
+        setup: "{{ ('false' if auth_cloud_provider | default('none') == 'none' else 'true') | string | lower }}"
+        image: "{{ ocp4_workload_showroom_cloud_image }}"
+        auth_cloud_provider: "{{ auth_cloud_provider | default('none') }}"
+        aws_access_key_id: "{{ aws_sandbox_provision_data.aws_access_key_id | default('') }}"
+        aws_secret_access_key: "{{ aws_sandbox_provision_data.aws_secret_access_key | default('') }}"
+        aws_web_console_url: "{{ aws_sandbox_provision_data.aws_web_console_url | default('') }}"
+        aws_web_console_user_name: "{{ aws_sandbox_provision_data.aws_web_console_user_name | default('') }}"
+        aws_web_console_password: "{{ aws_sandbox_provision_data.aws_web_console_password | default('') }}"
+        aws_sandbox_account_id: "{{ aws_sandbox_provision_data.aws_sandbox_account_id | default('') }}"
+        aws_route53_domain: "{{ aws_sandbox_provision_data.aws_route53_domain | default('') }}"
+        aws_default_region: "{{ aws_sandbox_provision_data.aws_default_region | default('') }}"
+        azure_subscription: "{{ azure_sandbox_provision_data.azure_subscription | default('') }}"
+        azure_tenant: "{{ azure_sandbox_provision_data.azure_tenant_id | default('') }}"
+        azure_client_id: "{{ azure_sandbox_provision_data.azure_service_principal_id | default('') }}"
+        azure_password: "{{ azure_sandbox_provision_data.azure_service_principal_password | default('') }}"
+        azure_resourcegroup: "{{ azure_sandbox_provision_data.azure_resource_group | default('') }}"
+
+      ironrdp:
+        setup: "{{ ('true' if ocp4_workload_showroom_ironrdp_enable | bool  else 'false') | string | lower }}"
+        image: "{{ ocp4_workload_showroom_ironrdp_image }}"
+        server: "windows"
+        user: "Administrator"
+        password: "{{ _showroom_user_data.windows_password | default('') }}"
+        jetserver: "localhost:7171"
+        tokengenserver: "localhost:8081"
+      automation:
+        setup: "{{ ('false' if ocp4_workload_showroom_automation_disable | bool  else 'true') | string | lower }}"
+        vault_password: "{{ _showroom_user_data.vault_password | default('') }}"
+
 
   register: r_helm_templates
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -46,7 +46,7 @@
                          else false) | bool | string | lower }}"
         display_name: "{{ ocp4_workload_showroom_second_terminal_tab_display_name }}"
       terminal:
-        setup: "{{ ocp4_workload_showroom_terminal_enable }}"
+        setup: "{{ ocp4_workload_showroom_terminal_enable | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_terminal_image }}"
         resources:
           requests:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -28,8 +28,13 @@
         zero_touch_ui_enabled: "{{ ocp4_workload_showroom_zero_touch_ui_enabled | string | lower }}"
 
       guid: "{{ guid }}"
+      satellite:
+        url: "{{ satellite_url | default('') }}"
+        org: "{{ satellite_org | default('') }}"
+        activationkey: "{{ satellite_activationkey | default('') }}"
       deployer:
         domain: "{{ _deployer_domain }}"
+        registry_pull_token: "{{ registry_pull_token | default('') }}"
       stacked_terminals:
         setup: "{{ ocp4_workload_showroom_stacked_terminals_enable | bool | string | lower }}"
         display_name: "{{ ocp4_workload_showroom_stacked_terminals_display_name }}"
@@ -41,7 +46,7 @@
                          else false) | bool | string | lower }}"
         display_name: "{{ ocp4_workload_showroom_second_terminal_tab_display_name }}"
       terminal:
-        setup: "{{ (true if ocp4_workload_showroom_terminal_type == 'showroom' else false) | bool | string | lower }}"
+        setup: "{{ ocp4_workload_showroom_terminal_enable }}"
         image: "{{ ocp4_workload_showroom_terminal_image }}"
         resources:
           requests:
@@ -67,6 +72,8 @@
           sshUser: "{{ _showroom_user_data['users'][_showroom_user].bastion_ssh_user_name | default(_showroom_user_data.bastion_ssh_user_name) }}"
           sshPass: "{{ _showroom_user_data['users'][_showroom_user].bastion_ssh_password | default(_showroom_user_data.bastion_ssh_password) }}"
           sshPort: "{{ _showroom_user_data.bastion_ssh_port | default(22) }}"
+          sshOtherHosts: "{{ instances | selectattr('name') | map(attribute='name') | list | default([]) }}"
+          terminals: "{{ instances | selectattr('terminals', 'defined') | community.general.json_query('[].{name: name, terminals: terminals}') }}"
       novnc:
         setup: "{{ (true if ocp4_workload_showroom_novnc_enable | bool else false) | bool | string | lower }}"
         image: "{{ ocp4_workload_showroom_novnc_image }}"
@@ -79,6 +86,36 @@
           limits:
             cpu: "{{ ocp4_workload_showroom_novnc_limits_cpu }}"
             memory: "{{ ocp4_workload_showroom_novnc_limits_memory }}"
+      cloud:
+        setup: "{{ ('false' if auth_cloud_provider | default('none') == 'none' else 'true') | string | lower }}"
+        image: "{{ ocp4_workload_showroom_cloud_image }}"
+        auth_cloud_provider: "{{ auth_cloud_provider | default('none') }}"
+        aws_access_key_id: "{{ aws_sandbox_provision_data.aws_access_key_id | default('') }}"
+        aws_secret_access_key: "{{ aws_sandbox_provision_data.aws_secret_access_key | default('') }}"
+        aws_web_console_url: "{{ aws_sandbox_provision_data.aws_web_console_url | default('') }}"
+        aws_web_console_user_name: "{{ aws_sandbox_provision_data.aws_web_console_user_name | default('') }}"
+        aws_web_console_password: "{{ aws_sandbox_provision_data.aws_web_console_password | default('') }}"
+        aws_sandbox_account_id: "{{ aws_sandbox_provision_data.aws_sandbox_account_id | default('') }}"
+        aws_route53_domain: "{{ aws_sandbox_provision_data.aws_route53_domain | default('') }}"
+        aws_default_region: "{{ aws_sandbox_provision_data.aws_default_region | default('') }}"
+        azure_subscription: "{{ azure_sandbox_provision_data.azure_subscription | default('') }}"
+        azure_tenant: "{{ azure_sandbox_provision_data.azure_tenant_id | default('') }}"
+        azure_client_id: "{{ azure_sandbox_provision_data.azure_service_principal_id | default('') }}"
+        azure_password: "{{ azure_sandbox_provision_data.azure_service_principal_password | default('') }}"
+        azure_resourcegroup: "{{ azure_sandbox_provision_data.azure_resource_group | default('') }}"
+
+      ironrdp:
+        setup: "{{ ('true' if ocp4_workload_showroom_ironrdp_enable | bool  else 'false') | string | lower }}"
+        image: "{{ ocp4_workload_showroom_ironrdp_image }}"
+        server: "windows"
+        user: "Administrator"
+        password: "{{ _showroom_user_data.windows_password | default('') }}"
+        jetserver: "localhost:7171"
+        tokengenserver: "localhost:8081"
+      automation:
+        setup: "{{ ('false' if ocp4_workload_showroom_automation_disable | bool  else 'true') | string | lower }}"
+        vault_password: "{{ _showroom_user_data.vault_password | default('') }}"
+
 
   register: r_helm_templates
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -25,7 +25,9 @@
     ansible.builtin.include_tasks: check-and-install-helm.yaml
 
   - name: Deploy showroom via Helm (single user)
-    when: not _showroom_user_data.users is defined
+    when: 
+      - not _showroom_user_data.users is defined
+      - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
     vars:
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
       _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
@@ -33,7 +35,9 @@
       file: deploy-showroom-helm.yaml
 
   - name: Deploy showroom via Helm (multi user)
-    when: _showroom_user_data.users is defined
+    when: 
+      - _showroom_user_data.users is defined
+      - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
     vars:
       _showroom_user: "{{ _showroom_users_item.key }}"
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"
@@ -44,6 +48,32 @@
     loop_control:
       loop_var: _showroom_users_item
       label: "{{ _showroom_users_item.key }}"
+
+  - name: Deploy showroom via Helm (single user) (zerotouch)
+    when: 
+      - not _showroom_user_data.users is defined
+      - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
+    vars:
+      _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
+      _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
+    ansible.builtin.include_tasks:
+      file: deploy-showroom-helm-zerotouch.yaml
+
+  - name: Deploy showroom via Helm (multi user) (zerotouch)
+    when: 
+      - _showroom_user_data.users is defined
+      - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
+    vars:
+      _showroom_user: "{{ _showroom_users_item.key }}"
+      _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"
+      _showroom_vars: "{{ _showroom_users_item.value | combine({'guid': guid, 'user': _showroom_user}) }}"
+    ansible.builtin.include_tasks:
+      file: deploy-showroom-helm-zerotouch.yaml
+    loop: "{{ _showroom_user_data.users | dict2items }}"
+    loop_control:
+      loop_var: _showroom_users_item
+      label: "{{ _showroom_users_item.key }}"
+
 
 - name: Report Variables to user_data (single user)
   when: not _showroom_user_data.users is defined

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -50,9 +50,9 @@
       label: "{{ _showroom_users_item.key }}"
 
   - name: Deploy showroom via Helm (single user) (zerotouch)
-    when: 
-      - not _showroom_user_data.users is defined
-      - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
+    when:
+    - not _showroom_user_data.users is defined
+    - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
     vars:
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
       _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
@@ -60,9 +60,9 @@
       file: deploy-showroom-helm-zerotouch.yaml
 
   - name: Deploy showroom via Helm (multi user) (zerotouch)
-    when: 
-      - _showroom_user_data.users is defined
-      - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
+    when:
+    - _showroom_user_data.users is defined
+    - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
     vars:
       _showroom_user: "{{ _showroom_users_item.key }}"
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -25,9 +25,9 @@
     ansible.builtin.include_tasks: check-and-install-helm.yaml
 
   - name: Deploy showroom via Helm (single user)
-    when: 
-      - not _showroom_user_data.users is defined
-      - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
+    when:
+    - not _showroom_user_data.users is defined
+    - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
     vars:
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
       _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
@@ -35,9 +35,9 @@
       file: deploy-showroom-helm.yaml
 
   - name: Deploy showroom via Helm (multi user)
-    when: 
-      - _showroom_user_data.users is defined
-      - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
+    when:
+    - _showroom_user_data.users is defined
+    - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
     vars:
       _showroom_user: "{{ _showroom_users_item.key }}"
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"


### PR DESCRIPTION
##### SUMMARY

To reduce risks about the current showroom, a  new file called deploy-showroom-helm-zerotouch.yaml will be called if the chart name is zerotouch. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom role
