### PR TITLE
assisted installer - ad hoc ignition manifests - ai_machineconfig

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -333,7 +333,7 @@
       rhpds.assisted_installer.create_manifest:
         cluster_id: "{{ newcluster.result.id }}"
         offline_token: "{{ ai_offline_token }}"
-        content: "{{ item | to_yaml | base64encode }}"         # Convert MachineConfig to YAML string
+        content: "{{ item | to_yaml | b64encode }}"         # Convert MachineConfig to YAML string
         file_name: "{{ item.metadata.name }}.yaml"  # Use the MachineConfig name as filename
         folder: openshift                       # Target folder in Assisted Installer
       loop: "{{ ai_machineconfigs }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -329,6 +329,18 @@
         folder: "openshift"
       when: ai_cluster_version is version_compare('4.14', '>=')
 
+    - name: "Add MachineConfig manifests to Assisted Installer"
+      rhpds.assisted_installer.create_manifest:
+        cluster_id: "{{ newcluster.result.id }}"
+        offline_token: "{{ ai_offline_token }}"
+        content: "{{ item | to_yaml | base64encode }}"         # Convert MachineConfig to YAML string
+        file_name: "{{ item.metadata.name }}.yaml"  # Use the MachineConfig name as filename
+        folder: openshift                       # Target folder in Assisted Installer
+      loop: "{{ ai_machineconfigs }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"      # Clean logging output using the MachineConfig name
+      when: ai_machineconfigs is defined
+
     - name: Generate mac addresses for control plane
       ansible.builtin.set_fact:
         ai_masters_macs: >
@@ -596,7 +608,7 @@
 
 - name: Find installer Pods in Error Status with label app=installer
   environment:
-    KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig    
+    KUBECONFIG: /home/{{ ansible_user }}/{{ cluster_name }}/auth/kubeconfig
   kubernetes.core.k8s_info:
     kind: Pod
     label_selectors:
@@ -620,6 +632,6 @@
   loop: "{{ r_pod_info.resources }}"
   loop_control:
     loop_var: pod
-    
+
 - name: Gather and Print cluster info
   ansible.builtin.import_tasks: print_cluster_info.yml


### PR DESCRIPTION
- Feature Pull Request

One lab I'm working on needs kernel parameters applied at install time.  It doesn't work post-install, because node reboots locks up a busy cluster that's resource constrained.

agV example

```
ai_machineconfigs:
- apiVersion: machineconfiguration.openshift.io/v1
  kind: MachineConfig
  metadata:
    labels:
      machineconfiguration.openshift.io/role: worker
    name: 99-openshift-machineconfig-worker-psi-karg
  spec:
    kernelArguments:
    - psi=1
```

