### PR TITLE
install_operator | Add delay to "Wait until InstallPlan is created"

### DIFF
--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -105,7 +105,7 @@
     _query: >-
       [?contains(spec.clusterServiceVersionNames[] | join(',', @), '{{ install_operator_csv_nameprefix }}') && status.phase ]
   retries: 100
-  delay: 10
+  delay: 15
   until:
   - r_install_plans.resources | default([]) | length > 0
   - r_install_plans.resources | to_json | from_json | json_query(_query)


### PR DESCRIPTION
ocp4-sentiment-analysis-wksp times out with this task but checking an environment manually confirms that the installPlan eventually comes up.

Adding a delay to give it more time.
