### PR TITLE
Add RHEL AI 1.5 image and remove RHEL AI 1.2 

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -11,6 +11,13 @@ _infra_images_arch: "{{ ocp4_architecture_cluster | default(infra_images_arch) |
 
 infra_images_predefined:
 
+  RHELAI15-latest:
+    owner: "{{ infra_images_redhat_owner_id }}"
+    name: rhel-ai-*-nvidia-1.5.*-with-models
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
   RHEL-10.0-GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-10.0.*_HVM_*Access*
@@ -21,13 +28,6 @@ infra_images_predefined:
   RHEL-10-GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-10.*_HVM-*Access*
-    architecture: "{{ _infra_images_arch }}"
-    aws_filters:
-      is-public: false
-
-  RHELAI12:
-    owner: "{{ infra_ai_images_redhat_owner_id  | default(infra_images_redhat_owner_id) }}"
-    name: rhel-ai-nvidia-1.2*
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false

--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -4,7 +4,7 @@ infra_images_instances: "{{ instances | default([]) }}"
 
 # Predefined search dicts for commonly used images
 infra_images_redhat_owner_id: 309956199498
-#TODO: Do we want AI images owned by 309956199498?
+#TODO: Do we want AI images owned by 309956199498? 
 infra_ai_images_redhat_owner_id: 809721187735
 
 _infra_images_arch: "{{ ocp4_architecture_cluster | default(infra_images_arch) | default('x86_64') }}"


### PR DESCRIPTION
SUMMARY
The AI BU has begun automating the AMI creation of RHEL AI and they are sharing those images with us. This will let us follow a similar pattern to RHEL where we can define the image as RHELAI15-latest and it should find the correct ami based on the defined pattern

ISSUE TYPE
Feature Pull Request
COMPONENT NAME
roles-infra/infra-images

