### PR TITLE
Update AMI mapping for RHEL 1.5

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -13,7 +13,7 @@ infra_images_predefined:
 
   RHELAI15-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
-    name: rhel-ai-*-nvidia-1.5.*-with-models
+    name: rhel-ai-1.5.*-nvidia-*-with-models
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false


### PR DESCRIPTION
##### SUMMARY

The AMII name to search for had an extra wildcard. This fixes the search pattern.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
roles-infra/infra-images



```
