### PR TITLE
change rhel ai ami owner account

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -12,7 +12,7 @@ _infra_images_arch: "{{ ocp4_architecture_cluster | default(infra_images_arch) |
 infra_images_predefined:
 
   RHELAI15-latest:
-    owner: "{{ infra_images_redhat_owner_id }}"
+    owner: "{{ infra_ai_images_redhat_owner_id }}"
     name: rhel-ai-1.5.*-nvidia-*-with-models
     architecture: "{{ _infra_images_arch }}"
     aws_filters:


### PR DESCRIPTION
##### SUMMARY

The account that the RHEL AI images are copied to is different from regular RHEL images and this will set the default to the correct account.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
roles-infra/infra-images
