### PR TITLE
change external IP directory to student_name

### DIFF
--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -48,9 +48,9 @@
     - hostvars[inventory_hostname]['external_ip'] != ""
   ansible.builtin.copy:
     content: "{{ hostvars[inventory_hostname]['external_ip'] }}"
-    dest: "~{{ ansible_user }}/external_ip"
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
+    dest: "~{{ student_name | default(ansible_user) }}/external_ip"
+    owner: "{{ student_name | default(ansible_user) }}"
+    group: "{{ student_name | default(ansible_user) }}"
     mode: '0644'
 
   # TODO: Is there any value in doing the below?


### PR DESCRIPTION
##### SUMMARY

Changes the default location where the external IP is written. If defined, it will use the `student_name`, otherwise it will default to `ansible_user`. As it currently is, it writes it to a user account that is not even provided to someone who orders certain CIs, like the CNV Blank Server.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
roles/bastion-base

