### PR TITLE
Change order of writing external IP to file

### DIFF
--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -41,7 +41,7 @@
     line: "export GUID={{ guid }}"
     create: true
 
-- name: Write external IP to user home directory (CNV)
+- name: Write external IP to ansible user home directory (CNV)
   when:
     - cloud_provider == "openshift_cnv"
     - hostvars[inventory_hostname]['external_ip'] is defined

--- a/ansible/roles/bastion-base/tasks/main.yml
+++ b/ansible/roles/bastion-base/tasks/main.yml
@@ -48,9 +48,9 @@
     - hostvars[inventory_hostname]['external_ip'] != ""
   ansible.builtin.copy:
     content: "{{ hostvars[inventory_hostname]['external_ip'] }}"
-    dest: "~{{ student_name | default(ansible_user) }}/external_ip"
-    owner: "{{ student_name | default(ansible_user) }}"
-    group: "{{ student_name | default(ansible_user) }}"
+    dest: "~{{ ansible_user }}/external_ip"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: '0644'
 
   # TODO: Is there any value in doing the below?

--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -70,6 +70,18 @@
     name: sshd
     state: restarted
 
+- name: Write external IP to student user home directory (CNV)
+  when:
+    - cloud_provider == "openshift_cnv"
+    - hostvars[inventory_hostname]['external_ip'] is defined
+    - hostvars[inventory_hostname]['external_ip'] != ""
+  ansible.builtin.copy:
+    content: "{{ hostvars[inventory_hostname]['external_ip'] }}"
+    dest: "~{{ student_name }}/external_ip"
+    owner: "{{ student_name }}"
+    group: "{{ student_name }}"
+    mode: '0644'
+
 - name: Print and set access user info
   vars:
     bastion_public_hostname: >-


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#9462

The sequence was bad, since the student user was set up after it tried to write out the external IP. Now it will write the external IP to both the ansible_user and student_name