### PR TITLE
[ocp4-cluster] Exclude isolated nodes from post_infra task (sshregression task)

### DIFF
--- a/ansible/configs/ocp4-cluster/post_infra.yml
+++ b/ansible/configs/ocp4-cluster/post_infra.yml
@@ -78,7 +78,7 @@
       - "Windows Password: {{ windows_password }}"
 
 - name: Step 002 Post Infrastructure regreSSHion hotfix
-  hosts: all:!windows:!network
+  hosts: all:!windows:!network:!isolated
   become: true
   tags:
   - regresshion_hotfix


### PR DESCRIPTION
##### SUMMARY

Currently is failing this task when OCP is installed + a node defined as isolated, as is trying to connect

isolated nodes are VMs which are not managed by agD

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-cluster role
