### PR TITLE
change owner group of external ip file

### DIFF
--- a/ansible/roles/bastion-student-user/tasks/main.yml
+++ b/ansible/roles/bastion-student-user/tasks/main.yml
@@ -79,7 +79,7 @@
     content: "{{ hostvars[inventory_hostname]['external_ip'] }}"
     dest: "~{{ student_name }}/external_ip"
     owner: "{{ student_name }}"
-    group: "{{ student_name }}"
+    group: "users"
     mode: '0644'
 
 - name: Print and set access user info


### PR DESCRIPTION
This user is created without a specific group, but rather it uses "users" as the group