### PR TITLE
BugFix PR: sap-hana-rhel9

### DIFF
--- a/ansible/configs/sap-hana-rhel9/default_vars_openshift_cnv.yaml
+++ b/ansible/configs/sap-hana-rhel9/default_vars_openshift_cnv.yaml
@@ -277,4 +277,6 @@ ansible_s4hana_hostname: "s4hana-{{ guid }}"
 bastion_hostname: "bastion-{{ guid }}"
 deployment_db_host: "hana-{{ guid }}1"
 
+# Required for proper certificate passthrough
+openshift_cnv_legacy_routes: true
 #__run_aap_deployment: true


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
sap-hana-rhel9

##### ADDITIONAL INFORMATION

Changes in the OpenShift routing prohibit proper certificate passthrough for AAP platform.
Hence a new switch has been introduced `openshift_cnv_legacy_routes`.
To keep the CI working the variable `openshift_cnv_legacy_routes: true` needs to be set.


<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
