### PR TITLE
[ADVANCED_GITOPS] Increase retries waiting for Argo CD to be ready

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/files/gitops-operator/subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-gitops-operator
-  namespace: openshift-gitops-operator
+  namespace: openshift-operators
 spec:
   config:
     env:
@@ -12,7 +12,7 @@ spec:
       value: gitops-controller
     - name: SERVER_CLUSTER_ROLE
       value: gitops-server
-  channel: gitops-1.13
+  channel: gitops-1.16
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
@@ -46,7 +46,7 @@
     namespace: "user{{ item }}-argocd"
   loop: "{{ range(1, num_users | int + 1) | list }}"
   register: r_argo_cr
-  retries: 10
+  retries: 30
   delay: 30
   until: r_argo_cr.resources[0].status.phase == "Available"
 


### PR DESCRIPTION
##### SUMMARY

The play that waits for the Argo CD to be ready fails when using 1 user but when I check the instance manually it works fine. I suspect it's failing with 1 but working with 5 is because 5 bumps up the number of nodes available which provides more computing power. 

To rectify this I'm increasing the retries from 10 to 30, if this doesn't work I'll look at increasing the minimum node count.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ADVANCED_GITOPS_WORKSHOP

