### PR TITLE
[infra-openshift-cnv-resources] add support for cdroms and possibility to disable cloud_init

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -92,7 +92,7 @@
         {{_instance.userdata|default('')|replace('#cloud-config','')|default('')}}
 
 - name: Set cloud init disk if needed
-  when: _instance.disable_cloud_init | default(false) == true
+  when: _instance.disable_cloud_init | default(false) == false
   set_fact:
     _instance_volumes: "{{ _instance_volumes | from_yaml + [
         {

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -11,8 +11,6 @@
       - disk:
           bus: "{{ _instance.disk_type | default('virtio') }}"
         name: "INSTANCENAME-{{guid}}"
-    _instance_cdroms: []
-
 
 - name: Set the instances interfaces
   ansible.builtin.set_fact:

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -11,6 +11,8 @@
       - disk:
           bus: "{{ _instance.disk_type | default('virtio') }}"
         name: "INSTANCENAME-{{guid}}"
+    _instance_cdroms: []
+
 
 - name: Set the instances interfaces
   ansible.builtin.set_fact:
@@ -64,6 +66,24 @@
   loop_control:
     loop_var: _disk
 
+- name: Set the instances cdroms
+  ansible.builtin.set_fact:
+    _instance_disks: "{{ _instance_disks | from_yaml + [
+    {
+        'name': _disk.metadata.name,
+        'cdrom': {'bus': 'sata'}
+    }
+    ] }}"
+    _instance_volumes: "{{ _instance_volumes | from_yaml + [
+        {
+            'name': _disk.metadata.name,
+            'dataVolume': {'name': _disk.metadata.name}
+        }
+    ] }}"
+  loop: "{{ _instance.cdroms | default([]) | list }}"
+  loop_control:
+    loop_var: _disk
+
 
 - name: Set cloud_config
   ansible.builtin.set_fact:
@@ -74,6 +94,7 @@
         {{_instance.userdata|default('')|replace('#cloud-config','')|default('')}}
 
 - name: Set cloud init disk if needed
+  when: _instance.disable_cloud_init | default(false) == true
   set_fact:
     _instance_volumes: "{{ _instance_volumes | from_yaml + [
         {
@@ -158,7 +179,7 @@
           | combine(_instance.metadata|default({})) | combine(_instance.tags|default({}) | ec2_tags_to_dict) }}
       spec:
         dataVolumeTemplates: >-
-         {{ _datavolume | from_yaml + (_instance.disks | default([]) | to_json | replace('INSTANCENAME',_instance_name) | from_json)  }}
+         {{ _datavolume | from_yaml + (_instance.disks | default([]) | to_json | replace('INSTANCENAME',_instance_name) | from_json) + (_instance.cdroms | default([]) | to_json | replace('INSTANCENAME',_instance_name) | from_json) }}
         running: true
         template:
           metadata:


### PR DESCRIPTION
##### SUMMARY

Added new parameter to instances called "disable_cloud_init" to disable attach the cloud-init disk

Currently we have "disks" key in the instances to define extra disks, this PR adds "cdroms" to be able to add cdrom the the instances, snippet:

    cdroms:
    - metadata:
        name: "cisco-config"
      spec:
        source:
          pvc:
            name: "c8800v-rhdp-config"
            namespace: cnv-images
        pvc:
          accessModes:
          - ReadWriteMany
          volumeMode: Block
          resources:
            requests:
              storage: "20Mi"

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-openshift-cnv-resources role
