### PR TITLE
ocp4_workload_advanced_gitops_workshop | Fix retry logic for "Wait fo…

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_gitops_workshop/tasks/workload.yml
@@ -48,7 +48,7 @@
   register: r_argo_cr
   retries: 30
   delay: 30
-  until: r_argo_cr.resources[0].status.phase == "Available"
+  until: (r_argo_cr.resources[0].status | default({})).phase == "Available"
 
 - name: Label dev namespaces to be managed by Argo CD
   kubernetes.core.k8s:


### PR DESCRIPTION
…r ArgoCD instances to successfully deploy""

---

This is causing some items to fail. When checking AAP logs I can see that no retries are performed despite the task having retry logic. Example [1].

The until condition is evaluated on the very first run of the task. If the status key is missing, the condition fails immediately and the task fails without retrying.

the `| default({})` filter added provides a default empty dictionary for the status key. This ensures the expression won't fail even if the `status` key is not present.

[1] https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/1496274/output