### PR TITLE
Fix role ocp4-workload-quarkus-workshop content url proto

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-guides.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-guides.yaml
@@ -52,6 +52,6 @@
           targetPort: 8080-tcp
         tls:
           termination: edge
-          insecureEdgeTerminationPolicy: None
+          insecureEdgeTerminationPolicy: Redirect
         wildcardPolicy: None
   register: Route

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-username-distribution.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-username-distribution.yaml
@@ -38,7 +38,7 @@
 
 - name: construct url argument for username distribution
   set_fact:
-    guides_urls: "{{ guides_urls + ['http://web-' + item.name + '-guides.' + route_subdomain + item.path + '?userid=%USERNAME%;' + item.title ] if (item.name in modules) else guides_urls }}"
+    guides_urls: "{{ guides_urls + ['https://web-' + item.name + '-guides.' + route_subdomain + item.path + '?userid=%USERNAME%;' + item.title ] if (item.name in modules) else guides_urls }}"
   loop: "{{ module_titles }}"
   
 - name: deploy username distribution tool

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/post_workload.yml
@@ -9,7 +9,7 @@
     msg: |
       Username: {{ item }}
       {% for m in modules %}
-      Workshop User Guide: http://web-{{ m }}-guides.{{ route_subdomain }}
+      Workshop User Guide: https://web-{{ m }}-guides.{{ route_subdomain }}
       {% endfor %}
   loop: "{{ users }}"
 
@@ -39,19 +39,19 @@
   when: ("m1" in modules)
   agnosticd_user_info:
     msg: |
-      Module 1 http://web-m1-guides.{{ route_subdomain }}
+      Module 1 https://web-m1-guides.{{ route_subdomain }}
 
 - name: output workshop info guides
   when: ("m2" in modules)
   agnosticd_user_info:
     msg: |
-      Module 2 http://web-m2-guides.{{ route_subdomain }}
+      Module 2 https://web-m2-guides.{{ route_subdomain }}
 
 - name: output workshop info guides
   when: ("m3" in modules)
   agnosticd_user_info:
     msg: |
-      Module 3 http://web-m3-guides.{{ route_subdomain }}
+      Module 3 https://web-m3-guides.{{ route_subdomain }}
 
 - name: output workshop info guides
   agnosticd_user_info:


### PR DESCRIPTION
##### SUMMARY
This change will update the url protocol for the resulting workshop content to `https`

The resulting workshop content will fail to load correctly (using http).  If you update the url protocol to https instead, then the content will load successfully

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4-workload-quarkus-workshop

##### ADDITIONAL INFORMATION
You can reproduce this bug by deploying a Prod CI for the Quarkus on OpenShift workshop: https://catalog.demo.redhat.com/catalog?item=babylon-catalog-prod/openshift-cnv.ocp4-workshop-quarkus-cnv.prod