### PR TITLE
Automate Satellite workshop - update to utilize latest LetsEncrypt certificate chain certificates for Satellite

### DIFF
--- a/ansible/roles/ansible_bu_satellite/tasks/main.yml
+++ b/ansible/roles/ansible_bu_satellite/tasks/main.yml
@@ -40,7 +40,6 @@
             docker.io/certbot/certbot:latest certonly \
             --key-type rsa \
             --rsa-key-size 4096 \
-            --no-bootstrap \
             --standalone \
             -d "{{ ansible_bu_satellite_external_fqdn }}" \
             --email ansible-network@redhat.com \
@@ -69,34 +68,34 @@
     group: root
     owner: root
   loop:
-    - url: https://letsencrypt.org/certs/2024/r10.pem
-      checksum: sha256:29ee679fb573c905bf3538126de6893a9e20ebe1cf400c6df22e5d171c94f543
-    - url: https://letsencrypt.org/certs/2024/r11.pem
-      checksum: sha256:6c06a45850f93aa6e31f9388f956379d8b4fb7ffca5211b9bab4ad159bdfb7b9
+    - url: https://letsencrypt.org/certs/2024/r12.pem
+      checksum: sha256:c6afa726f611cd87bb3c7b743567221782655db4c4f47e7c64993d1bbdaae8f3
+    - url: https://letsencrypt.org/certs/2024/r13.pem
+      checksum: sha256:6c595b12bcc415caa5ac38c60ad01414131a8b1944c21c7a0c5b1c97631968c9
     - url: https://letsencrypt.org/certs/isrgrootx1.pem
       checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
 
-- name: Retrieve LetsEncrypt R10 cert
+- name: Retrieve LetsEncrypt R12 cert
   slurp:
-    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r10.pem"
-  register: intermediate_cert_r10
+    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r12.pem"
+  register: intermediate_cert_r12
 
-- name: Retrieve LetsEncrypt R11 cert
+- name: Retrieve LetsEncrypt R13 cert
   slurp:
-    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r11.pem"
-  register: intermediate_cert_r11
+    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r13.pem"
+  register: intermediate_cert_r13
 
 - name: Retrieve LetsEncrypt root X1 cert
   slurp:
     src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/isrgrootx1.pem"
   register: root_cert
 
-- name: Combine R10, R11 and root X1 certs to create Letsencrypt CA bundle
+- name: Combine R12, R13 and root X1 certs to create Letsencrypt CA bundle
   copy:
     content: |
       {{ root_cert.content|b64decode }}
-      {{ intermediate_cert_r10.content | b64decode }}
-      {{ intermediate_cert_r11.content | b64decode }}
+      {{ intermediate_cert_r12.content | b64decode }}
+      {{ intermediate_cert_r13.content | b64decode }}
     dest: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/letsencrypt-ca-bundle.pem" 
 
 - name: Start httpd


### PR DESCRIPTION
##### SUMMARY
R10 and R11 intermediate certificates are expired, R12 and R13 intermediate certificates are currently up to date.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_bu_satellite role
