### PR TITLE
[infra-aws-open-environment] Add hosted zone id to user data

### DIFF
--- a/ansible/roles-infra/infra-aws-open-environment/tasks/print_user_info.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/print_user_info.yaml
@@ -44,6 +44,7 @@
       aws_default_region: "{{ aws_region }}"
       aws_route53_domain: "{{ subdomain_base_suffix }}"
       aws_sandbox_account_id: "{{ sandbox_account_id }}"
+      aws_route53_zone_id: "{{ sandbox_hosted_zone_id }}"
 
 - name: Record sandbox web console access as user data
   when:


### PR DESCRIPTION
##### SUMMARY

Add hosted zone id to user data, useful when this config is used as component

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

infra-aws-open-environment config
