### PR TITLE
Move ODCR role destroy to top-level destroy

### DIFF
--- a/ansible/cloud_providers/ec2_destroy_env.yml
+++ b/ansible/cloud_providers/ec2_destroy_env.yml
@@ -7,12 +7,6 @@
   gather_facts: false
   become: false
   tasks:
-    - name: Run infra-aws-capacity-reservation
-      include_role:
-        name: infra-aws-capacity-reservation
-      vars:
-        ACTION: destroy
-
     - name: Set facts for ssh provision SSH key
       include_role:
         name: create_ssh_provision_key

--- a/ansible/destroy.yml
+++ b/ansible/destroy.yml
@@ -32,6 +32,13 @@
         - target_regions is not defined
       include_tasks: cloud_providers/ec2_detect_region_tasks.yml
 
+    - name: Run infra-aws-capacity-reservation
+      when: cloud_provider == 'ec2'
+      include_role:
+        name: infra-aws-capacity-reservation
+      vars:
+        ACTION: destroy
+
 - import_playbook: >-
     {{ lookup('first_found', {
          'files': [ 'destroy_env.yml',


### PR DESCRIPTION
In case a config has its own destroy, the infra-aws-capacity-reservation role doesn't run at destroy. Thus, aws_region var is undefined. That can cause issues in some config destroy if they don't explicitely call the role or set the variables back from agnosticd_user_data.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
