### PR TITLE
Change workload platform-engineering-workshop to add Web Terminal Operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/defaults/main.yml
@@ -190,6 +190,12 @@ ocp4_workload_platform_engineering_workshop_noobaa_gitops_repo_path: noobaa
 
 ocp4_workload_platform_engineering_workshop_noobaa_name: noobaa
 
+
+# ------------------------------------------------
+# Web Terminal
+# ------------------------------------------------
+ocp4_workload_platform_engineering_workshop_terminal_install: true
+
 # ------------------------------------------------
 # GitLab
 # ------------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/terminal.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/terminal.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Create Terminal application
+  when: ocp4_workload_platform_engineering_workshop_terminal_install | bool
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'terminal/terminal-subscription.yaml.j2') | from_yaml }}"
+  retries: 10
+  delay: 30
+  ignore_errors: true
+  register: terminal_result
+  until: terminal_result is not failed
+
+- name: Print terminal_result from the previous task
+  ansible.builtin.debug:
+    var: terminal_result

--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/workload.yml
@@ -41,3 +41,6 @@
 
 - name: Install Showroom
   ansible.builtin.include_tasks: showroom.yml
+
+- name: Install Terminal
+  ansible.builtin.include_tasks: terminal.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/templates/terminal/terminal-subscription.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/templates/terminal/terminal-subscription.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: web-terminal
+  namespace: openshift-operators
+spec:
+  channel: fast
+  installPlanApproval: Automatic
+  name: web-terminal
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Add the Web Terminal Operator for use by workshop attendees to execute various tasks related to TSSC - gitsign, cosign, etc.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
`ocp4_platform_engineering_workshop`

