### PR TITLE
cnv hcp install requires num_users

### DIFF
--- a/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
+++ b/ansible/roles/host-ocp4-hcp-cnv-install/defaults/main.yaml
@@ -1,4 +1,5 @@
 ---
+num_users: 1
 hcp_ssh_authorized_key: "{{ lookup('ansible.builtin.file', hostvars.localhost.ssh_provision_pubkey_path) }}"
 hcp_cluster_name: "{{ guid }}"
 hcp_cluster_version: "{{ ocp4_installer_version | default('4.16') }}"


### PR DESCRIPTION
default 1 num_users: 1

Or do you @agonzalezrh  prefer to have this error out if agv does not provide the value?

- Bugfix Pull Request
