### PR TITLE
[ocp4_workload_showroom] Set showroom to the lab when users=1

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -76,9 +76,7 @@
 
 
 - name: Report Variables to user_data (single user or users=1)
-  when: 
-    - not _showroom_user_data.users is defined
-    - _showroom_user_data.users | default([]) | length == 1
+  when: not _showroom_user_data.users is defined or _showroom_user_data.users | default([]) | length == 1
   vars:
     _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
     _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -75,8 +75,10 @@
       label: "{{ _showroom_users_item.key }}"
 
 
-- name: Report Variables to user_data (single user)
-  when: not _showroom_user_data.users is defined
+- name: Report Variables to user_data (single user or users=1)
+  when: 
+    - not _showroom_user_data.users is defined
+    - _showroom_user_data.users | default([]) | length == 1
   vars:
     _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
     _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"


### PR DESCRIPTION
##### SUMMARY

In some situations we have only one user for the lab and is assigned the showroom URL, but it doesnt help for workshops where 1 user gets one lab

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom role
