### PR TITLE
Update microshift VM template

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
@@ -8,12 +8,12 @@ metadata:
     app.kubernetes.io/name: {{ ocp4_workload_microshift_name }}
     app.openshift.io/runtime: kubevirt
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       annotations:
         vm.kubevirt.io/flavor: medium
-        vm.kubevirt.io/os: rhel8
+        vm.kubevirt.io/os: rhel9
         vm.kubevirt.io/workload: server
       labels:
         kubevirt.io/domain: {{ ocp4_workload_microshift_name }}
@@ -42,11 +42,6 @@ spec:
       networks:
       - name: default
         pod: {}
-      nodeSelector:
-        node-role.kubernetes.io/metal: ''
-      tolerations:
-      - key: metal
-        operator: Exists
       volumes:
       - name: rootdisk
         dataVolume:


### PR DESCRIPTION
##### SUMMARY

Updates to the Microshift VM template to use RHEL 9 and remove the node selector and tolerations for Metal nodes. The metal nodes were only required in AWS and we will be running this with nested virt in CNV from now on.

Only one other CI used this workload and it is being retired on August 29.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
roles_ocp_workloads/ocp4_workload_microshift


