### PR TITLE
[TEST] ocp4_workload_pipelines: Make tkn CLI installation conditional: Wait for Wolfgang to review

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/defaults/main.yml
@@ -46,3 +46,6 @@ ocp4_workload_pipelines_catalog_snapshot_image: quay.io/gpte-devops-automation/o
 
 # Catalog snapshot image tag
 ocp4_workload_pipelines_catalog_snapshot_image_tag: v4.15_2024_03_25
+
+# Install tkn CLI tool
+ocp4_workload_pipelines_install_tkn_cli: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_pipelines/tasks/workload.yml
@@ -39,83 +39,85 @@
   - r_pipeline_controller_deployment.resources[0].status.readyReplicas is defined
   - r_pipeline_controller_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
 
-- name: Wait until tkn cli download deployment is ready
-  kubernetes.core.k8s_info:
-    api_version: apps/v1
-    kind: Deployment
-    namespace: openshift-pipelines
-    name: tkn-cli-serve
-  register: r_pipeline_tkn_cli_deployment
-  retries: 60
-  delay: 30
-  until:
-  - r_pipeline_tkn_cli_deployment.resources is defined
-  - r_pipeline_tkn_cli_deployment.resources | length | int > 0
-  - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas is defined
-  - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
+- block:
+  - name: Wait until tkn cli download deployment is ready
+    kubernetes.core.k8s_info:
+      api_version: apps/v1
+      kind: Deployment
+      namespace: openshift-pipelines
+      name: tkn-cli-serve
+    register: r_pipeline_tkn_cli_deployment
+    retries: 60
+    delay: 30
+    until:
+    - r_pipeline_tkn_cli_deployment.resources is defined
+    - r_pipeline_tkn_cli_deployment.resources | length | int > 0
+    - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas is defined
+    - r_pipeline_tkn_cli_deployment.resources[0].status.readyReplicas | int == r_pipeline_controller_deployment.resources[0].spec.replicas | int
 
-- name: Get tkn ConsoleCLIDownload
-  kubernetes.core.k8s_info:
-    api_version: console.openshift.io/v1
-    kind: ConsoleCLIDownload
-    name: tkn
-  register: r_tkn_cli_download
-  retries: 20
-  delay: 10
-  ignore_errors: true
-  until:
-  - r_tkn_cli_download.resources is defined
-  - r_tkn_cli_download.resources | length | int > 0
+  - name: Get tkn ConsoleCLIDownload
+    kubernetes.core.k8s_info:
+      api_version: console.openshift.io/v1
+      kind: ConsoleCLIDownload
+      name: tkn
+    register: r_tkn_cli_download
+    retries: 20
+    delay: 10
+    ignore_errors: true
+    until:
+    - r_tkn_cli_download.resources is defined
+    - r_tkn_cli_download.resources | length | int > 0
 
-- name: Get tkn download URL from ConsoleCLIDownload
-  when: r_tkn_cli_download.resources | length | int > 0
-  ansible.builtin.set_fact:
-    _ocp4_workload_pipelines_tkn_url: >-
-      {{ r_tkn_cli_download.resources[0] | to_json | from_json
-       | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
+  - name: Get tkn download URL from ConsoleCLIDownload
+    when: r_tkn_cli_download.resources | length | int > 0
+    ansible.builtin.set_fact:
+      _ocp4_workload_pipelines_tkn_url: >-
+        {{ r_tkn_cli_download.resources[0] | to_json | from_json
+         | json_query("spec.links[?contains(href,'-linux-amd64')].href") | first }}
 
-- name: Download tkn cli tool
-  ansible.builtin.get_url:
-    url: "{{ _ocp4_workload_pipelines_tkn_url }}"
-    validate_certs: false
-    dest: /tmp/tkn-linux-amd64.tar.gz
-    mode: 0660
-  register: r_tkn
-  until: r_tkn is success
-  retries: 10
-  delay: 10
+  - name: Download tkn cli tool
+    ansible.builtin.get_url:
+      url: "{{ _ocp4_workload_pipelines_tkn_url }}"
+      validate_certs: false
+      dest: /tmp/tkn-linux-amd64.tar.gz
+      mode: 0660
+    register: r_tkn
+    until: r_tkn is success
+    retries: 10
+    delay: 10
 
-- name: Install tkn CLI on bastion
-  become: true
-  ansible.builtin.unarchive:
-    src: /tmp/tkn-linux-amd64.tar.gz
-    remote_src: true
-    dest: /usr/bin
-    mode: 0775
-    owner: root
-    group: root
-  args:
-    creates: /usr/bin/tkn
+  - name: Install tkn CLI on bastion
+    become: true
+    ansible.builtin.unarchive:
+      src: /tmp/tkn-linux-amd64.tar.gz
+      remote_src: true
+      dest: /usr/bin
+      mode: 0775
+      owner: root
+      group: root
+    args:
+      creates: /usr/bin/tkn
 
-- name: Remove downloaded file
-  ansible.builtin.file:
-    state: absent
-    path: /tmp/tkn-linux-amd64.tar.gz
+  - name: Remove downloaded file
+    ansible.builtin.file:
+      state: absent
+      path: /tmp/tkn-linux-amd64.tar.gz
 
-# command: does not work here - somehow the parameters don't get passed properly
-- name: Setup tkn bash completion
-  become: true
-  ansible.builtin.shell: "/usr/bin/tkn completion bash >/etc/bash_completion.d/tkn"
-  args:
-    creates: /etc/bash_completion.d/tkn
+  # command: does not work here - somehow the parameters don't get passed properly
+  - name: Setup tkn bash completion
+    become: true
+    ansible.builtin.shell: "/usr/bin/tkn completion bash >/etc/bash_completion.d/tkn"
+    args:
+      creates: /etc/bash_completion.d/tkn
 
-- name: Setup tkn-pac bash completion
-  become: true
-  ansible.builtin.shell: "/usr/bin/tkn-pac completion bash >/etc/bash_completion.d/tkn-pac"
-  args:
-    creates: /etc/bash_completion.d/tkn-pac
-  # Ignore errors for older pipelines versions
-  ignore_errors: true
+  - name: Setup tkn-pac bash completion
+    become: true
+    ansible.builtin.shell: "/usr/bin/tkn-pac completion bash >/etc/bash_completion.d/tkn-pac"
+    args:
+      creates: /etc/bash_completion.d/tkn-pac
+    # Ignore errors for older pipelines versions
+    ignore_errors: true
+  when: ocp4_workload_pipelines_install_tkn_cli | bool
 
 # Leave this as the last task in the playbook.
 - name: Workload tasks complete


### PR DESCRIPTION
Add configurable flag to control tkn CLI installation in OpenShift Pipelines workload. This change is needed for running workloads directly on OCP CNV pools where bastion host access may not be available or required.

Changes:
- Add ocp4_workload_pipelines_install_tkn_cli variable (default: true)
- Wrap all tkn CLI installation tasks in conditional block
- Maintains backward compatibility by defaulting to true
- Allows CNV pool deployments to skip CLI installation when not needed

The tkn CLI installation includes:
- Waiting for tkn-cli-serve deployment
- Downloading tkn binary from ConsoleCLIDownload
- Installing tkn CLI on bastion host
- Setting up bash completion for tkn and tkn-pac

