### PR TITLE
Update 52-showroom-parasol.yml

### DIFF
--- a/ansible/roles/showroom/tasks/52-showroom-parasol.yml
+++ b/ansible/roles/showroom/tasks/52-showroom-parasol.yml
@@ -7,7 +7,8 @@
   register: r_domains_output
   retries: 5
   delay: 15
-  until: r_domains_output.rc == 0
+  # This condition now checks for a successful run AND that output was produced
+  until: r_domains_output.rc == 0 and r_domains_output.stdout != ""
   vars:
     acmejsonfile: "{{ showroom_user_orchestration_dir }}/acme.json"
     outdir: "{{ showroom_user_orchestration_dir }}"


### PR DESCRIPTION
 playbook will now wait until the acme.json file is both present and populate with certificates before attempting to move on to the extraction step


