### PR TITLE
Update Microshift workload to use s3 with credential

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/defaults/main.yaml
@@ -11,7 +11,19 @@ ocp4_workload_microshift_cluster_name: "{{ ocp4_workload_microshift_vm_namespace
 
 ocp4_workload_microshift_bastion_user: "{{ student_name | default(ansible_user) }}"
 
-ocp4_workload_microshift_vm_image: https://gpte-public.s3.amazonaws.com/microshift/rhel87-microshift-latest.img
+# Set this if you want to download the image from a public URL with no authentication
+# ocp4_workload_microshift_vm_image: https://gpte-public.s3.amazonaws.com/microshift/rhel87-microshift-latest.img
+
+# S3 configuration for private bucket access (optional)
+# If these variables are defined, the role will download the image from S3 instead of using the public URL
+# ocp4_workload_microshift_s3_access_key: "your-aws-access-key"
+# ocp4_workload_microshift_s3_secret_key: "your-aws-secret-key"
+# ocp4_workload_microshift_s3_region: "us-east-1"
+# ocp4_workload_microshift_s3_bucket: "your-private-bucket"
+# ocp4_workload_microshift_name: "path/to/your/image.img"
+ocp4_workload_microshift_local_image_dir: "/tmp/microshift-images"
+
+# ocp4_workload_microshift_cleanup_downloaded_image: false  # Set to true to remove downloaded image after VM creation
 ocp4_workload_microshift_vm_ssh_key: "/home/{{ ocp4_workload_microshift_bastion_user }}/.ssh/{{ ocp4_workload_microshift_vm_namespace }}"
 ocp4_workload_microshift_vm_kubeconfig: /home/{{ ocp4_workload_microshift_bastion_user }}/.kube/{{ ocp4_workload_microshift_vm_namespace }}
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/defaults/main.yaml
@@ -11,6 +11,7 @@ ocp4_workload_microshift_cluster_name: "{{ ocp4_workload_microshift_vm_namespace
 
 ocp4_workload_microshift_bastion_user: "{{ student_name | default(ansible_user) }}"
 
+# YOU NEED TO SET ONE OF THE FOLLOWING:
 # Set this if you want to download the image from a public URL with no authentication
 # ocp4_workload_microshift_vm_image: https://gpte-public.s3.amazonaws.com/microshift/rhel87-microshift-latest.img
 
@@ -19,9 +20,6 @@ ocp4_workload_microshift_bastion_user: "{{ student_name | default(ansible_user) 
 # ocp4_workload_microshift_s3_access_key: "your-aws-access-key"
 # ocp4_workload_microshift_s3_secret_key: "your-aws-secret-key"
 # ocp4_workload_microshift_s3_region: "us-east-1"
-# ocp4_workload_microshift_s3_bucket: "your-private-bucket"
-# ocp4_workload_microshift_name: "path/to/your/image.img"
-ocp4_workload_microshift_local_image_dir: "/tmp/microshift-images"
 
 # ocp4_workload_microshift_cleanup_downloaded_image: false  # Set to true to remove downloaded image after VM creation
 ocp4_workload_microshift_vm_ssh_key: "/home/{{ ocp4_workload_microshift_bastion_user }}/.ssh/{{ ocp4_workload_microshift_vm_namespace }}"
@@ -31,7 +29,7 @@ ocp4_workload_microshift_vm_kubeconfig: /home/{{ ocp4_workload_microshift_bastio
 # this is not the rhel root disk size.
 ocp4_workload_microshift_disk_size: 10Gi
 # name of the disk used by microshift storage, also the name of the backing pvc.
-ocp4_workload_microshift_disk_name: rhel87-microshift-mshiftdisk
+ocp4_workload_microshift_disk_name: rhel96-microshift-mshiftdisk
 
 # helm chart repo for the app that is deployed on microshift in the edge.
 ocp4_workload_microshift_app_repo: https://redhat-gpte-devopsautomation.github.io/microshift

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/defaults/main.yaml
@@ -15,11 +15,12 @@ ocp4_workload_microshift_bastion_user: "{{ student_name | default(ansible_user) 
 # Set this if you want to download the image from a public URL with no authentication
 # ocp4_workload_microshift_vm_image: https://gpte-public.s3.amazonaws.com/microshift/rhel87-microshift-latest.img
 
-# S3 configuration for private bucket access (optional)
+# S3 configuration for private bucket access
 # If these variables are defined, the role will download the image from S3 instead of using the public URL
 # ocp4_workload_microshift_s3_access_key: "your-aws-access-key"
 # ocp4_workload_microshift_s3_secret_key: "your-aws-secret-key"
 # ocp4_workload_microshift_s3_region: "us-east-1"
+# ocp4_workload_microshift_vm_image: https://s3.us-east-1.amazonaws.com/rhdp-images/rhel96-microshift419.qcow2
 
 # ocp4_workload_microshift_cleanup_downloaded_image: false  # Set to true to remove downloaded image after VM creation
 ocp4_workload_microshift_vm_ssh_key: "/home/{{ ocp4_workload_microshift_bastion_user }}/.ssh/{{ ocp4_workload_microshift_vm_namespace }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/tasks/workload.yml
@@ -32,68 +32,23 @@
       data:
         openshift-pull-secret: "{{ ocp_pull_secret.resources[0].data['.dockerconfigjson'] }}"
 
-- name: Download VM image from S3 (if S3 credentials provided)
-  block:
-    - name: Create local directory for VM images
-      ansible.builtin.file:
-        path: "{{ ocp4_workload_microshift_local_image_dir }}"
-        state: directory
-        mode: '0755'
-
-    - name: Download image from S3 using Ansible AWS module
-      amazon.aws.s3_object:
-        bucket: "{{ ocp4_workload_microshift_s3_bucket }}"
-        object: "{{ ocp4_workload_microshift_name }}"
-        dest: "{{ ocp4_workload_microshift_local_image_dir }}/{{ ocp4_workload_microshift_name }}.qcow2"
-        aws_access_key: "{{ ocp4_workload_microshift_s3_access_key }}"
-        aws_secret_key: "{{ ocp4_workload_microshift_s3_secret_key }}"
+- name: Create AWS S3 credentials Secret (if credentials provided)
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: aws-s3-microshift-credentials
+        namespace: "{{ ocp4_workload_microshift_vm_namespace }}"
+      type: Opaque
+      stringData:
+        accessKeyId: "{{ ocp4_workload_microshift_s3_access_key }}"
+        secretKey: "{{ ocp4_workload_microshift_s3_secret_key }}"
         region: "{{ ocp4_workload_microshift_s3_region | default('us-east-1') }}"
-        mode: get
-
-    - name: Create PV from local image file
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: PersistentVolume
-          metadata:
-            name: microshift-image-pv
-          spec:
-            capacity:
-              storage: 30Gi
-            accessModes:
-              - ReadWriteOnce
-            persistentVolumeReclaimPolicy: Retain
-            storageClassName: ""
-            local:
-              path: "{{ ocp4_workload_microshift_local_image_dir }}/{{ ocp4_workload_microshift_name }}.qcow2"
-      
-    - name: Create PVC for local image
-      kubernetes.core.k8s:
-        state: present
-        definition:
-          apiVersion: v1
-          kind: PersistentVolumeClaim
-          metadata:
-            name: microshift-image-pvc
-            namespace: "{{ ocp4_workload_microshift_vm_namespace }}"
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 30Gi
-            storageClassName: ""
-            volumeName: microshift-image-pv
-      
-    - name: Set PVC source for VM template
-      ansible.builtin.set_fact:
-        ocp4_workload_microshift_vm_image: "pvc://microshift-image-pvc"
-  when: 
+  when:
     - ocp4_workload_microshift_s3_access_key is defined
     - ocp4_workload_microshift_s3_secret_key is defined
-    - ocp4_workload_microshift_s3_bucket is defined
-    - ocp4_workload_microshift_name is defined
 
 - name: openssh key pair for the microshift vm
   become: true
@@ -231,10 +186,4 @@
     state: present
     definition: "{{ lookup('template', 'rhacm/acm-application.yaml.j2') | from_yaml_all | list }}"
 
-- name: Clean up downloaded S3 image (optional)
-  ansible.builtin.file:
-    path: "{{ ocp4_workload_microshift_local_image_dir }}/{{ ocp4_workload_microshift_name }}.qcow2"
-    state: absent
-  when: 
-    - ocp4_workload_microshift_name is defined
-    - ocp4_workload_microshift_cleanup_downloaded_image | default(true)
+

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/tasks/workload.yml
@@ -54,28 +54,28 @@
   become: true
   become_user: "{{ ocp4_workload_microshift_bastion_user }}"
   block:
-  - name: create openssh key pair for the microshift vm
-    community.crypto.openssh_keypair:
-      path: "{{ ocp4_workload_microshift_vm_ssh_key }}"
-      owner: "{{ ocp4_workload_microshift_bastion_user }}"
-      group: users
-      mode: 0600
-    register: r_microshift_key
-  - name: read the public key from filesystem
-    ansible.builtin.slurp:
-      src: "{{ ocp4_workload_microshift_vm_ssh_key }}.pub"
-    register: r_microshift_public_key
+    - name: create openssh key pair for the microshift vm
+      community.crypto.openssh_keypair:
+        path: "{{ ocp4_workload_microshift_vm_ssh_key }}"
+        owner: "{{ ocp4_workload_microshift_bastion_user }}"
+        group: users
+        mode: 0600
+      register: r_microshift_key
+    - name: read the public key from filesystem
+      ansible.builtin.slurp:
+        src: "{{ ocp4_workload_microshift_vm_ssh_key }}.pub"
+      register: r_microshift_public_key
 
 - name: create microshfit vm
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
-  - kubevirt/vm-microshift-pvc.yaml.j2
-  - kubevirt/vm-microshift.yaml.j2
-  - kubevirt/vm-microshift-service.yaml.j2
-  - kubevirt/vm-microshift-route-ingress.yaml.j2
-  - kubevirt/vm-microshift-route-api.yaml.j2
+    - kubevirt/vm-microshift-pvc.yaml.j2
+    - kubevirt/vm-microshift.yaml.j2
+    - kubevirt/vm-microshift-service.yaml.j2
+    - kubevirt/vm-microshift-route-ingress.yaml.j2
+    - kubevirt/vm-microshift-route-api.yaml.j2
 
 # The download of the vm image takes too long when the cluster is not
 # colocated in the same region as the s3 bucket (us-east-2).
@@ -90,8 +90,8 @@
   retries: 180
   delay: 30
   until:
-  - vm_microshift.resources[0].status is defined
-  - vm_microshift.resources[0].status.ready is true
+    - vm_microshift.resources[0].status is defined
+    - vm_microshift.resources[0].status.ready is true
 
 # needs a pause here or better wait / readiness probe for vm
 - name: pause until microshift vm is ready
@@ -102,29 +102,29 @@
   become: true
   become_user: "{{ ocp4_workload_microshift_bastion_user }}"
   block:
-  - name: setup microshift .kube/config
-    ansible.builtin.shell: >-
-      virtctl ssh
-      cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}
-      --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
-      --local-ssh-opts="-o StrictHostKeyChecking=no"
-      --command='{{ item }}'
-    loop:
-    - sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig > /home/cloud-user/.kube/config
-    - chmod go-r /home/cloud-user/.kube/config
-  - name: copy microshift .kube/config to the bastion
-    ansible.builtin.shell: >-
-      virtctl scp
-      cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}:/home/cloud-user/.kube/config
-      {{ ocp4_workload_microshift_vm_kubeconfig }}
-      --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
-      --local-ssh-opts="-o StrictHostKeyChecking=no"
-  - name: setup microshift .kube/config in the bastion
-    ansible.builtin.replace:
-      path: "{{ ocp4_workload_microshift_vm_kubeconfig }}"
-      regexp: 'https://127.0.0.1:6443'
-      # yamllint disable-line rule:line-length
-      replace: "https://api-{{ ocp4_workload_microshift_vm_namespace }}.{{ _ocp4_workload_microshift_wildcard_domain }}"
+    - name: setup microshift .kube/config
+      ansible.builtin.shell: >-
+        virtctl ssh
+        cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}
+        --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+        --command='{{ item }}'
+      loop:
+        - sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig > /home/cloud-user/.kube/config
+        - chmod go-r /home/cloud-user/.kube/config
+    - name: copy microshift .kube/config to the bastion
+      ansible.builtin.shell: >-
+        virtctl scp
+        cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}:/home/cloud-user/.kube/config
+        {{ ocp4_workload_microshift_vm_kubeconfig }}
+        --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+    - name: setup microshift .kube/config in the bastion
+      ansible.builtin.replace:
+        path: "{{ ocp4_workload_microshift_vm_kubeconfig }}"
+        regexp: 'https://127.0.0.1:6443'
+        # yamllint disable-line rule:line-length
+        replace: "https://api-{{ ocp4_workload_microshift_vm_namespace }}.{{ _ocp4_workload_microshift_wildcard_domain }}"
 
 - name: create namespace {{ ocp4_workload_microshift_cluster_name }}
   kubernetes.core.k8s:
@@ -143,12 +143,12 @@
     state: present
     definition: "{{ lookup('template', item) | from_yaml }}"
   loop:
-  - rhacm/managed-clusterset.yaml.j2
-  - rhacm/managed-clusterset-binding.yaml.j2
-  - rhacm/placement.yaml.j2
-  - rhacm/gitops-cluster.yaml.j2
-  - rhacm/managed-cluster.yaml.j2
-  - rhacm/klusterlet-addon-config.yaml.j2
+    - rhacm/managed-clusterset.yaml.j2
+    - rhacm/managed-clusterset-binding.yaml.j2
+    - rhacm/placement.yaml.j2
+    - rhacm/gitops-cluster.yaml.j2
+    - rhacm/managed-cluster.yaml.j2
+    - rhacm/klusterlet-addon-config.yaml.j2
 
 # yamllint disable rule:line-length
 - name: obtain klusterlet-crd.yaml and import.yaml from hub cluster
@@ -163,27 +163,25 @@
   become: true
   become_user: "{{ ocp4_workload_microshift_bastion_user }}"
   block:
-  - name: copy klusterlet-crd.yaml and import.yaml to microshift
-    ansible.builtin.shell: >-
-      virtctl scp -r
-      /tmp/microshift
-      cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}:/tmp/microshift
-      --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
-      --local-ssh-opts="-o StrictHostKeyChecking=no"
-  - name: oc apply klusterlet-crd.yaml and import.yaml to microshift
-    ansible.builtin.shell: >-
-      virtctl ssh
-      cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}
-      --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
-      --local-ssh-opts="-o StrictHostKeyChecking=no"
-      --command='oc apply -f {{ item }}'
-    loop:
-    - /tmp/microshift/klusterlet-crd.yaml
-    - /tmp/microshift/import.yaml
+    - name: copy klusterlet-crd.yaml and import.yaml to microshift
+      ansible.builtin.shell: >-
+        virtctl scp -r
+        /tmp/microshift
+        cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}:/tmp/microshift
+        --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+    - name: oc apply klusterlet-crd.yaml and import.yaml to microshift
+      ansible.builtin.shell: >-
+        virtctl ssh
+        cloud-user@{{ ocp4_workload_microshift_name }}.{{ ocp4_workload_microshift_vm_namespace }}
+        --identity-file={{ ocp4_workload_microshift_vm_ssh_key }}
+        --local-ssh-opts="-o StrictHostKeyChecking=no"
+        --command='oc apply -f {{ item }}'
+      loop:
+        - /tmp/microshift/klusterlet-crd.yaml
+        - /tmp/microshift/import.yaml
 
 - name: create rhacm application hello microshift
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'rhacm/acm-application.yaml.j2') | from_yaml_all | list }}"
-
-

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/tasks/workload.yml
@@ -32,6 +32,69 @@
       data:
         openshift-pull-secret: "{{ ocp_pull_secret.resources[0].data['.dockerconfigjson'] }}"
 
+- name: Download VM image from S3 (if S3 credentials provided)
+  block:
+    - name: Create local directory for VM images
+      ansible.builtin.file:
+        path: "{{ ocp4_workload_microshift_local_image_dir }}"
+        state: directory
+        mode: '0755'
+
+    - name: Download image from S3 using Ansible AWS module
+      amazon.aws.s3_object:
+        bucket: "{{ ocp4_workload_microshift_s3_bucket }}"
+        object: "{{ ocp4_workload_microshift_name }}"
+        dest: "{{ ocp4_workload_microshift_local_image_dir }}/{{ ocp4_workload_microshift_name }}.qcow2"
+        aws_access_key: "{{ ocp4_workload_microshift_s3_access_key }}"
+        aws_secret_key: "{{ ocp4_workload_microshift_s3_secret_key }}"
+        region: "{{ ocp4_workload_microshift_s3_region | default('us-east-1') }}"
+        mode: get
+
+    - name: Create PV from local image file
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolume
+          metadata:
+            name: microshift-image-pv
+          spec:
+            capacity:
+              storage: 30Gi
+            accessModes:
+              - ReadWriteOnce
+            persistentVolumeReclaimPolicy: Retain
+            storageClassName: ""
+            local:
+              path: "{{ ocp4_workload_microshift_local_image_dir }}/{{ ocp4_workload_microshift_name }}.qcow2"
+      
+    - name: Create PVC for local image
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: microshift-image-pvc
+            namespace: "{{ ocp4_workload_microshift_vm_namespace }}"
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 30Gi
+            storageClassName: ""
+            volumeName: microshift-image-pv
+      
+    - name: Set PVC source for VM template
+      ansible.builtin.set_fact:
+        ocp4_workload_microshift_vm_image: "pvc://microshift-image-pvc"
+  when: 
+    - ocp4_workload_microshift_s3_access_key is defined
+    - ocp4_workload_microshift_s3_secret_key is defined
+    - ocp4_workload_microshift_s3_bucket is defined
+    - ocp4_workload_microshift_name is defined
+
 - name: openssh key pair for the microshift vm
   become: true
   become_user: "{{ ocp4_workload_microshift_bastion_user }}"
@@ -167,3 +230,11 @@
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'rhacm/acm-application.yaml.j2') | from_yaml_all | list }}"
+
+- name: Clean up downloaded S3 image (optional)
+  ansible.builtin.file:
+    path: "{{ ocp4_workload_microshift_local_image_dir }}/{{ ocp4_workload_microshift_name }}.qcow2"
+    state: absent
+  when: 
+    - ocp4_workload_microshift_name is defined
+    - ocp4_workload_microshift_cleanup_downloaded_image | default(true)

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
@@ -78,14 +78,14 @@ spec:
       #   name: rhel8
       #   namespace: openshift-virtualization-os-images
       source:
-        {% if ocp4_workload_microshift_s3_bucket is defined and ocp4_workload_microshift_s3_access_key is defined and ocp4_workload_microshift_s3_secret_key is defined %}
+{% if ocp4_workload_microshift_s3_access_key is defined and ocp4_workload_microshift_s3_secret_key is defined %}
         s3:
           url: {{ ocp4_workload_microshift_vm_image }}
           secretRef: aws-s3-microshift-credentials
-        {% else %}
+{% else %}
         http:
           url: {{ ocp4_workload_microshift_vm_image }}
-        {% endif %}
+{% endif %}
       storage:
         resources:
           requests:

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
@@ -78,8 +78,14 @@ spec:
       #   name: rhel8
       #   namespace: openshift-virtualization-os-images
       source:
+        {% if ocp4_workload_microshift_vm_image.startswith('pvc://') %}
+        pvc:
+          name: microshift-image-pvc
+          namespace: {{ ocp4_workload_microshift_vm_namespace }}
+        {% else %}
         http:
           url: {{ ocp4_workload_microshift_vm_image }}
+        {% endif %}
       storage:
         resources:
           requests:

--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
@@ -78,10 +78,10 @@ spec:
       #   name: rhel8
       #   namespace: openshift-virtualization-os-images
       source:
-        {% if ocp4_workload_microshift_vm_image.startswith('pvc://') %}
-        pvc:
-          name: microshift-image-pvc
-          namespace: {{ ocp4_workload_microshift_vm_namespace }}
+        {% if ocp4_workload_microshift_s3_bucket is defined and ocp4_workload_microshift_s3_access_key is defined and ocp4_workload_microshift_s3_secret_key is defined %}
+        s3:
+          url: {{ ocp4_workload_microshift_vm_image }}
+          secretRef: aws-s3-microshift-credentials
         {% else %}
         http:
           url: {{ ocp4_workload_microshift_vm_image }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_ols/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ols/defaults/main.yml
@@ -78,6 +78,9 @@ ocp4_workload_ols_catalog_snapshot_image_tag: "alpha-0.0.3"
 # OLS Config variables.
 ocp4_workload_ols_api_version: ols.openshift.io/v1alpha1
 ocp4_workload_ai_platform: azure #openai, azure, watson, openshiftai
+ocp4_workload_ols_introspection_enabled: false
+ocp4_workload_ols_enable_rag: false
+ocp4_workload_ols_rag_image: 'quay.io/dialvare/acme-byok:latest'
 
 # Token to Access GPT Model for OpenShift LightSpeed
 ocp4_workload_ols_api_token_secret: "{{ ocp4_workload_ols_api_token }}" #Coming from Vault

--- a/ansible/roles_ocp_workloads/ocp4_workload_ols/templates/install_azure_app_sp_olsconfig.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ols/templates/install_azure_app_sp_olsconfig.yml.j2
@@ -25,3 +25,8 @@ spec:
     defaultModel: "{{ ocp4_workload_ols_defaultmodel }}"
     defaultProvider: "{{ ocp4_workload_ols_defaultprovider }}"
     logLevel: "{{ ocp4_workload_ols_loglevel }}"
+    introspectionEnabled: "{{ ocp4_workload_ols_introspection_enabled | default(false) }}"
+{% if ocp4_workload_ols_enable_rag %}
+    rag:
+      - image: "{{ ocp4_workload_ols_rag_image }}"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

The current workload downloads the microshift image from a public URL, which shouldn't be allowed. This will gives the option of providing s3 credentials to download from an S3 bucket.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
roles_ocp_workloads/ocp4_workload_microshift


