### PR TITLE
Enable defining number of OpenShift AI Dashboard replicas

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/defaults/main.yml
@@ -29,6 +29,7 @@ ocp4_workload_openshift_ai_deploy_dsc: true
 # Data Science Cluster Configuration
 ocp4_workload_openshift_ai_codeflare: Removed
 ocp4_workload_openshift_ai_dashboard: Managed
+ocp4_workload_openshift_ai_dashboard_replicas: 2
 ocp4_workload_openshift_ai_datasciencepipelines: Managed
 ocp4_workload_openshift_ai_kserve: Removed
 ocp4_workload_openshift_ai_kueue: Removed

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
@@ -62,7 +62,7 @@
             name: rhods-dashboard
             namespace: redhat-ods-applications
           spec:
-            replicas: "{{ ocp4_workload_openshift_ai_dashboard_replicas | int }}"
+            replicas: {{ ocp4_workload_openshift_ai_dashboard_replicas | int }}
 
 - name: Get the OpenShift AI dashboard route
   kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
@@ -33,6 +33,37 @@
     msg: r_ds_cluster
     verbosity: 2
 
+- name: Configure rhods-dashboard deployment replicas
+  when: 
+    - ocp4_workload_openshift_ai_deploy_dsc | bool
+    - ocp4_workload_openshift_ai_dashboard == "Managed"
+    - ocp4_workload_openshift_ai_dashboard_replicas is defined
+  block:
+    - name: Wait for rhods-dashboard deployment to be created
+      kubernetes.core.k8s_info:
+        api_version: apps/v1
+        kind: Deployment
+        name: rhods-dashboard
+        namespace: redhat-ods-applications
+      register: r_dashboard_deployment
+      until:
+      - r_dashboard_deployment.resources is defined
+      - r_dashboard_deployment.resources | length > 0
+      retries: 10
+      delay: 30
+
+    - name: Patch rhods-dashboard deployment replicas
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: rhods-dashboard
+            namespace: redhat-ods-applications
+          spec:
+            replicas: "{{ ocp4_workload_openshift_ai_dashboard_replicas | int }}"
+
 - name: Get the OpenShift AI dashboard route
   kubernetes.core.k8s_info:
     api_version: route.openshift.io/v1

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
@@ -35,8 +35,6 @@
 
 - name: Configure rhods-dashboard deployment replicas
   when:
-    - ocp4_workload_openshift_ai_deploy_dsc | bool
-    - ocp4_workload_openshift_ai_dashboard == "Managed"
     - ocp4_workload_openshift_ai_dashboard_replicas is defined
   block:
     - name: Wait for rhods-dashboard deployment to be created
@@ -54,7 +52,7 @@
 
     - name: Patch rhods-dashboard deployment replicas
       kubernetes.core.k8s:
-        state: present
+        state: patched
         definition:
           apiVersion: apps/v1
           kind: Deployment
@@ -62,7 +60,7 @@
             name: rhods-dashboard
             namespace: redhat-ods-applications
           spec:
-            replicas: {{ ocp4_workload_openshift_ai_dashboard_replicas | int }}
+            replicas: "{{ ocp4_workload_openshift_ai_dashboard_replicas | int }}"
 
 - name: Get the OpenShift AI dashboard route
   kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
@@ -50,17 +50,13 @@
       retries: 10
       delay: 30
 
-    - name: Patch rhods-dashboard deployment replicas
-      kubernetes.core.k8s:
-        state: patched
-        definition:
-          apiVersion: apps/v1
-          kind: Deployment
-          metadata:
-            name: rhods-dashboard
-            namespace: redhat-ods-applications
-          spec:
-            replicas: "{{ ocp4_workload_openshift_ai_dashboard_replicas | int }}"
+    - name: Scale rhods-dashboard deployment replicas
+      kubernetes.core.k8s_scale:
+        api_version: apps/v1
+        kind: Deployment
+        name: rhods-dashboard
+        namespace: redhat-ods-applications
+        replicas: "{{ ocp4_workload_openshift_ai_dashboard_replicas | int }}"
 
 - name: Get the OpenShift AI dashboard route
   kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
@@ -34,7 +34,7 @@
     verbosity: 2
 
 - name: Configure rhods-dashboard deployment replicas
-  when: 
+  when:
     - ocp4_workload_openshift_ai_deploy_dsc | bool
     - ocp4_workload_openshift_ai_dashboard == "Managed"
     - ocp4_workload_openshift_ai_dashboard_replicas is defined
@@ -47,8 +47,8 @@
         namespace: redhat-ods-applications
       register: r_dashboard_deployment
       until:
-      - r_dashboard_deployment.resources is defined
-      - r_dashboard_deployment.resources | length > 0
+        - r_dashboard_deployment.resources is defined
+        - r_dashboard_deployment.resources | length > 0
       retries: 10
       delay: 30
 
@@ -72,10 +72,10 @@
     namespace: redhat-ods-applications
   register: r_odh_dashboard_route
   until:
-  - r_odh_dashboard_route.resources is defined
-  - r_odh_dashboard_route.resources | length > 0
-  - r_odh_dashboard_route.resources.0.status.ingress.0.host is defined
-  - r_odh_dashboard_route.resources.0.status.ingress.0.host | length > 0
+    - r_odh_dashboard_route.resources is defined
+    - r_odh_dashboard_route.resources | length > 0
+    - r_odh_dashboard_route.resources.0.status.ingress.0.host is defined
+    - r_odh_dashboard_route.resources.0.status.ingress.0.host | length > 0
   retries: 80
   delay: 30
 


### PR DESCRIPTION

##### SUMMARY

Adds functionality to define the number of replicas required by the rhods-dashboard deployment.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
roles_ocp_workloads/ocp4_workload_openshift_ai