### PR TITLE
[ocp4_workload_rhsso_authentication] Improve role to handle better when user count = 1

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/defaults/main.yml
@@ -18,12 +18,21 @@ ocp4_workload_rhsso_authentication_admin_password: "{{
 
 ocp4_workload_rhsso_authentication_user_count: "{{ num_users | default(0) }}"
 ocp4_workload_rhsso_authentication_user_name_base: user
+# Override option for user name when user_count==1
+ocp4_workload_rhsso_authentication_user_name: "{{ ocp4_workload_rhsso_authentication_user_name_base }}1"
 ocp4_workload_rhsso_authentication_user_password: "{{
   common_password | default(lookup('password', '/dev/null chars=ascii_letters,digits '~ 'length=' ~ 10)) }}"
 
 ocp4_workload_rhsso_authentication_remove_kubeadmin: true
 
 ocp4_workload_rhsso_authentication_env_type: "{{ env_type | default('default') }}"
+
+
+# agnosticd_user_info controls
+# If set to false then no agnosticd_user_info will be reported
+ocp4_workload_rhsso_authentication_enable_user_info_messages: true
+# Only report per-user messages if number of users is greater than one
+ocp4_workload_rhsso_authentication_enable_user_info_data: "{{ ocp4_workload_rhsso_authentication_user_count | int > 1 }}"
 
 # If you're creating the "openshift" realm and want to add Realm Roles:
 # ocp4_workload_rhsso_authentication_openshift_realm_roles:

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/tasks/workload.yml
@@ -171,18 +171,18 @@
         is cluster admin.
 
   - name: Print user information
-    when: 
-      - ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
-      - ocp4_workload_rhsso_authentication_user_count | int == 1
+    when:
+    - ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
+    - ocp4_workload_rhsso_authentication_user_count | int == 1
     agnosticd_user_info:
       msg: >-
         User `{{ ocp4_workload_rhsso_authentication_user_name }}`
         created with password `{{ ocp4_workload_rhsso_authentication_user_password }}`
 
   - name: Print user(s) information
-    when: 
-      - ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
-      - ocp4_workload_rhsso_authentication_user_count | int > 1
+    when:
+    - ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
+    - ocp4_workload_rhsso_authentication_user_count | int > 1
     agnosticd_user_info:
       msg: >-
         Users `{{ ocp4_workload_rhsso_authentication_user_name_base }}1` ..

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/tasks/workload.yml
@@ -116,7 +116,13 @@
     state: present
     definition: "{{ lookup('template', 'rhsso-user-openshift.yml.j2') }}"
   vars:
-    username: "{{ ocp4_workload_rhsso_authentication_user_name_base }}{{ n + 1 }}"
+    username: >-
+      {%- if ocp4_workload_rhsso_authentication_user_count | int == 1 -%}
+      {{ ocp4_workload_rhsso_authentication_user_name }}
+      {%- else -%}
+      {{ ocp4_workload_rhsso_authentication_user_name_base }}{{ item + 1 }}
+      {%- endif -%}
+
     password: "{{ ocp4_workload_rhsso_authentication_user_password }}"
   loop: "{{ range(0, ocp4_workload_rhsso_authentication_user_count | int) | list }}"
   loop_control:
@@ -148,6 +154,7 @@
 - name: Print user information messages
   block:
   - name: RHSSO info message
+    when: ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
     agnosticd_user_info:
       msg: >-
         Authentication via RHSSO is enabled on this cluster.
@@ -164,7 +171,7 @@
         is cluster admin.
 
   - name: Print user information
-    when: ocp4_workload_rhsso_authentication_user_count | int > 0
+    when: ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
     agnosticd_user_info:
       msg: >-
         Users `{{ ocp4_workload_rhsso_authentication_user_name_base }}1` ..
@@ -208,6 +215,7 @@
       }}
 
 - name: Save user information
+  when: ocp4_workload_rhsso_authentication_enable_user_info_data | bool
   block:
   - name: Save user information for user access
     agnosticd_user_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rhsso_authentication/tasks/workload.yml
@@ -171,7 +171,18 @@
         is cluster admin.
 
   - name: Print user information
-    when: ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
+    when: 
+      - ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
+      - ocp4_workload_rhsso_authentication_user_count | int == 1
+    agnosticd_user_info:
+      msg: >-
+        User `{{ ocp4_workload_rhsso_authentication_user_name }}`
+        created with password `{{ ocp4_workload_rhsso_authentication_user_password }}`
+
+  - name: Print user(s) information
+    when: 
+      - ocp4_workload_rhsso_authentication_enable_user_info_messages | bool
+      - ocp4_workload_rhsso_authentication_user_count | int > 1
     agnosticd_user_info:
       msg: >-
         Users `{{ ocp4_workload_rhsso_authentication_user_name_base }}1` ..


### PR DESCRIPTION
##### SUMMARY

When user count = 1, the information for agnosticd (user data) should be treated as a single user lab and not a multi user lab 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_rhsso_authentication role