### PR TITLE
[ocp4_workload_machinesets] Improve selector to detect nodes and set retries as variable

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_machinesets/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_machinesets/defaults/main.yml
@@ -21,6 +21,9 @@ ocp4_workload_machinesets_disable_default_machinesets: false
 # nodes are not immediately necessary
 ocp4_workload_machinesets_wait_for_nodes: true
 
+# Specify how many retries to wait for nodes
+ocp4_workload_machinesets_wait_for_nodes_retries: 30
+
 # The Machineset groups to set up
 ocp4_workload_machinesets_machineset_groups:
 # Infranodes: Must be named "infra"

--- a/ansible/roles_ocp_workloads/ocp4_workload_machinesets/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_machinesets/tasks/workload.yml
@@ -22,11 +22,12 @@
     kind: Node
     label_selectors:
     - "node-role.kubernetes.io/{{ item.role }}="
+    - "node.kubernetes.io/instance-type={{ item.instance_type }}"
   register: r_nodes
   until:
   - r_nodes.resources | length | int == item.total_replicas | int
   delay: 30
-  retries: 100
+  retries: "{{ ocp4_workload_machinesets_wait_for_nodes_retries }}"
   loop: "{{ ocp4_workload_machinesets_machineset_groups }}"
 
 - name: Set up Infra nodes when one MaschineSet group is called 'infra'


### PR DESCRIPTION
##### SUMMARY

This PR is to solve this use case, where we want to have 2 machineset groups with the same role but different instance_type.

```
ocp4_workload_machinesets_machineset_groups:
  - name: worker-gpu-1
    role: worker-gpu
    instance_type: "{{ gpu_instance_type_1 }}"
    autoscale: false
    total_replicas: 1
    total_replicas_min: 1
    total_replicas_max: 1
    taints:
      - key: nvidia.com/gpu
        value: l40-gpu
        effect: NoSchedule
  - name: worker-gpu-2
    role: worker-gpu
    instance_type: "{{ gpu_instance_type_2 }}"
    autoscale: false
    total_replicas: 1
    total_replicas_min: 1
    total_replicas_max: 1
    taints:
      - key: nvidia.com/gpu
        value: l4-gpu
        effect: NoSchedule
```

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_machinesets role