### PR TITLE
Fix role ocp4-workload-quarkus-workshop add workshop ui support

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/post_workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/post_workload.yml
@@ -8,8 +8,11 @@
     user: "{{ item }}"
     msg: |
       Username: {{ item }}
-      {% for m in modules %}
-      Workshop User Guide: https://web-{{ m }}-guides.{{ route_subdomain }}
+      Password: {{ workshop_openshift_user_password }}
+      {% for m in module_titles %}
+      {% if m.name in modules %}
+      {{ m.title }}: https://web-{{ m.name }}-guides.{{ route_subdomain }}{{ m.path }}?userid={{ item }}
+      {% endif %}
       {% endfor %}
   loop: "{{ users }}"
 


### PR DESCRIPTION
##### SUMMARY
The "Workshop UI" is an available configuration option for this catalog item, but when enabled, it is doesn't load the course content correctly.
This change repairs the workshop ui config input, allowing admins to enable the **workshop ui** for attendees.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4-workload-quarkus-workshop

##### ADDITIONAL INFORMATION
This workshop already provides a `get-a-username` service to assist with onboarding attendees.  However, workshop administrators may not know that this service exists, and may attempt to **enable the workshop user interface** for this catalog item (unsuccessfully)! 🙅  

This change adds support for the standard workshop user interface to be used as an alternative attendee onboarding mechanism (instead of using the cluster's included `get-a-username` service).

**Current state:** When the workshop ui is enabled, the resulting content links lack any userid parameters and fails to load the correct username into the workshop material
**Expected state after merge & publish:** Workshop UI content links include a path and a `userid` parameter - just like the built-in `get-a-username` service!

#### Rollout / Release plan
See https://github.com/rhpds/agnosticv/pull/22684#issue-3392329074