### PR TITLE
Fix showroom URL missing from provision data

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_dynamic_user_provisioning/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dynamic_user_provisioning/tasks/post_workload.yml
@@ -39,6 +39,12 @@
     - r_showroom_route.resources | length > 0
 
 
+- name: Add showroom URL to user data
+  agnosticd_user_info:
+    user: "{{ _dynamic_username }}"
+    data:
+      showroom_url: "{{ _showroom_url | default('') }}"
+
 - name: Report user creation status
   agnosticd_user_info:
     msg: |

--- a/ansible/roles_ocp_workloads/ocp4_workload_dynamic_user_provisioning/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_dynamic_user_provisioning/tasks/workload.yml
@@ -406,10 +406,6 @@
       openshift_api_url: "{{ openshift_api_url }}"
       openshift_cluster_admin_token: "{{ openshift_api_key }}"
       openshift_api_ca_cert: "{{ openshift_api_ca_cert }}"
-      showroom_url: >-
-        {{ 'https://' + r_showroom_route.resources[0].spec.host
-           if (r_showroom_route is defined and r_showroom_route.resources | length > 0)
-           else '' }}
       rhdh_url: "{{ _rhdh_url | default('') }}"
       rhdh_auth: oidc
       rhdh_user: "{{ _dynamic_username }}"


### PR DESCRIPTION
- Remove showroom_url from comprehensive userdata in workload.yml (was using undefined r_showroom_route)
- Add dedicated showroom_url userdata save in post_workload.yml after route discovery
- Fix timing issue where userdata save happened before route was discovered
- Ensures showroom_url appears in both provision messages and provision data


