### PR TITLE
Change role ocp4_workload_ols to enable cluster interaction and BYOK

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ols/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ols/defaults/main.yml
@@ -78,6 +78,9 @@ ocp4_workload_ols_catalog_snapshot_image_tag: "alpha-0.0.3"
 # OLS Config variables.
 ocp4_workload_ols_api_version: ols.openshift.io/v1alpha1
 ocp4_workload_ai_platform: azure #openai, azure, watson, openshiftai
+ocp4_workload_ols_introspection_enabled: false
+ocp4_workload_ols_enable_rag: false
+ocp4_workload_ols_rag_image: 'quay.io/dialvare/acme-byok:latest'
 
 # Token to Access GPT Model for OpenShift LightSpeed
 ocp4_workload_ols_api_token_secret: "{{ ocp4_workload_ols_api_token }}" #Coming from Vault

--- a/ansible/roles_ocp_workloads/ocp4_workload_ols/templates/install_azure_app_sp_olsconfig.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ols/templates/install_azure_app_sp_olsconfig.yml.j2
@@ -25,3 +25,8 @@ spec:
     defaultModel: "{{ ocp4_workload_ols_defaultmodel }}"
     defaultProvider: "{{ ocp4_workload_ols_defaultprovider }}"
     logLevel: "{{ ocp4_workload_ols_loglevel }}"
+    introspectionEnabled: "{{ ocp4_workload_ols_introspection_enabled | default(false) }}"
+{% if ocp4_workload_ols_enable_rag %}
+    rag:
+      - image: "{{ ocp4_workload_ols_rag_image }}"
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

With this change, the OLSConfig resource now supports enabling two new features. To enable Cluster Interaction, the `introspectionEnabled` flag has been added, which is set to `false` by default in the default variables. In addition, Bring Your Own Knowledge can be enabled through a conditional. If `ocp4_workload_ols_enable_rag` is set to `true`, the necessary lines of code are included for this feature to work. By default, this variable is also set to `false` in the default variables. The image that is pulled when this feature is enabled can also be customized through the `ocp4_workload_ols_rag_image` variable.

##### ISSUE TYPE

- New config Pull Request

##### COMPONENT NAME

ocp4_workload_ols

##### ADDITIONAL INFORMATION

```
By default, the new features are disabled. The corresponding variables must be overridden from the AgnosticV CI to enable them.
```