### PR TITLE
[ocp4_workload_showroom] Add options hostSuffix and omitHost for configuring the showroom domain

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -100,6 +100,9 @@ ocp4_workload_showroom_use_sandbox_domain: false
 
 ocp4_workload_showroom_terminal_enable: false
 
+# When true, omit Route host and let OpenShift generate it (zerotouch chart only)
+ocp4_workload_showroom_route_omit_host: false
+
 # Project zero
 ocp4_workload_showroom_ironrdp_enable: false
 ocp4_workload_showroom_ironrdp_image: quay.io/agonzalezrh/ironrdp:v0.0.2

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -34,6 +34,9 @@
         activationkey: "{{ satellite_activationkey | default('') }}"
       deployer:
         domain: "{{ _deployer_domain }}"
+      route:
+        hostSuffix: "{{ _showroom_user | default('') }}"
+        omitHost: "{{ (ocp4_workload_showroom_route_omit_host | bool) | ternary('true','false') }}"
         registry_pull_token: "{{ registry_pull_token | default('') }}"
       stacked_terminals:
         setup: "{{ ocp4_workload_showroom_stacked_terminals_enable | bool | string | lower }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -30,6 +30,9 @@
       guid: "{{ guid }}"
       deployer:
         domain: "{{ _deployer_domain }}"
+      route:
+        hostSuffix: "{{ _showroom_user | default('') }}"
+        omitHost: "{{ (ocp4_workload_showroom_route_omit_host | bool) | ternary('true','false') }}"
       stacked_terminals:
         setup: "{{ ocp4_workload_showroom_stacked_terminals_enable | bool | string | lower }}"
         display_name: "{{ ocp4_workload_showroom_stacked_terminals_display_name }}"


### PR DESCRIPTION
##### SUMMARY
Add options for hostSuffix where the showroom route will be showroom-<guid>-<hostSuffix>.<domain>.  Also setting omitHost to true will not set a host on the route and ocp will use the namespace instead.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_showroom
