### PR TITLE
[openshift-cnv provider] Set sandbox information on the user_info

### DIFF
--- a/ansible/cloud_providers/openshift_cnv_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/openshift_cnv_infrastructure_deployment.yml
@@ -16,6 +16,18 @@
       validate_certs: false
 
   tasks:
+    - name: Provide sandbox provision data
+      when:
+        - openshift_cnv_set_sandbox_provision_data | default(false) | bool
+      agnosticd_user_info:
+        data:
+          sandbox_openshift_namespace: "{{ sandbox_openshift_namespace }}"
+          sandbox_openshift_cluster: "{{ sandbox_openshift_cluster }}"
+          sandbox_openshift_api_url: "{{ sandbox_openshift_api_url }}"
+          sandbox_openshift_apps_domain: "{{ sandbox_openshift_apps_domain }}"
+          sandbox_openshift_console_url: "{{ sandbox_openshift_console_url }}"
+          sandbox_openshift_api_key: "{{ sandbox_openshift_api_key}}"
+
     - name: Create ssh provision key
       ansible.builtin.include_role:
         name: create_ssh_provision_key


### PR DESCRIPTION
##### SUMMARY

If variable **openshift_cnv_set_sandbox_provision_data** is set to true, then is set the sandbox_ variables from sandbox-api in the user data to be used by a binder

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
openshift_cnv cloud provider
