### PR TITLE
[infra-openshift-cnv-resources] Improve create_networks.yaml

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_networks.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_networks.yaml
@@ -1,5 +1,6 @@
 ---
 - name: Create Networks
+  when: networks | default("") != ""
   register: r_openshift_cnv_networks
   loop: "{{ networks|default([])}}"
   loop_control:


### PR DESCRIPTION
##### SUMMARY

For Project Zero allow to don't specify any network, it is sending "networks" variable as empty string. This PR is to ignore the task in case we receive empty string

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-openshift-cnv-resources role
