### PR TITLE
fix: include ingress domain in showroom info

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/showroom.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_platform_engineering_workshop/tasks/showroom.yml
@@ -1,6 +1,14 @@
 ---
 
+- name: Get OpenShift Ingress Domain
+  kubernetes.core.k8s_info:
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  register: r_openshift_ingress
+
 - name: Set user info for showroom
   agnosticd_user_info:
     data:
       common_password: "{{ common_password }}"
+      openshift_cluster_ingress_domain: "{{ r_openshift_ingress.resources[0].spec.domain }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Ensures that the OpenShift Ingress domain is included in showroom.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

`ocp4_workload_platform_engineering_workshop`
