### PR TITLE
Change role ocp4_workload_ols to enable cluster interaction and BYOK

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ols/templates/install_azure_app_sp_olsconfig.yml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ols/templates/install_azure_app_sp_olsconfig.yml.j2
@@ -25,8 +25,8 @@ spec:
     defaultModel: "{{ ocp4_workload_ols_defaultmodel }}"
     defaultProvider: "{{ ocp4_workload_ols_defaultprovider }}"
     logLevel: "{{ ocp4_workload_ols_loglevel }}"
-    introspectionEnabled: "{{ ocp4_workload_ols_introspection_enabled | default(false) }}"
-{% if ocp4_workload_ols_enable_rag %}
+    introspectionEnabled: {{ ocp4_workload_ols_introspection_enabled | default(false) | bool }}
+{% if ocp4_workload_ols_enable_rag | bool %}
     rag:
       - image: "{{ ocp4_workload_ols_rag_image }}"
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Previously the `install_azure_app_sp_olsconfig.yml.j2` template was configured to support Cluster Interaction and BYOK enablement. However, when tested, the OLSConfig was always created without both flags, even when enabled from agV. This PR aims to fix both issues. It seems like the `ocp4_workload_ols_introspection_enabled` was never considered as boolean because it was encapsulated between `""`, considering it as string. Also adds `| boolean` when the rag condition is assessed. 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ols

##### ADDITIONAL INFORMATION

```
File modified: /templates/install_azure_app_sp_olsconfig.yml.j2
```