### PR TITLE
Showroom role to use ZeroSSL for TLS via ACME; allow Let’s Encrypt override.

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_routes_container.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_routes_container.yaml
@@ -8,7 +8,13 @@
         name: "{{ route.name }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        host: "{{ route.host|default(route.name) }}-{{ guid }}.{{ sandbox_openshift_apps_domain }}"
+        host: >-
+          {{
+            (route.host | default(route.name) ~ '.' ~ guid ~ '.' ~ sandbox_openshift_apps_domain)
+            if openshift_cnv_legacy_routes | default(false)
+            else
+            (route.host | default(route.name) ~ '-' ~ guid ~ '.' ~ sandbox_openshift_apps_domain)
+          }}
         port:
           targetPort: "{{ route.targetPort }}"
         tls:
@@ -37,7 +43,13 @@
         name: "{{ route.name }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        host: "{{ route.host|default(route.name) }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}"
+        host: >-
+          {{
+            (route.host | default(route.name) ~ '.' ~ guid ~ '.' ~ sandbox_openshift_apps_domain)
+            if openshift_cnv_legacy_routes | default(false)
+            else
+            (route.host | default(route.name) ~ '-' ~ guid ~ '.' ~ sandbox_openshift_apps_domain)
+          }}
         path: "{{ route.path|default('/') }}"
         port:
           targetPort: "{{ route.targetPort }}"

--- a/ansible/roles/showroom/README.adoc
+++ b/ansible/roles/showroom/README.adoc
@@ -1,20 +1,20 @@
 == Showroom
 
 Showroom is an Ansible role that installs and configures Showroom, a replacement for bookbag.
-Showroom provides views (1 or more webpages) onto external web based resouces (e.g. websites, webapps, etc.).
-It's primary use case is to provide a 1 stop console for demos, workshops, and labs.
+Showroom provides views (1 or more webpages) onto external web-based resources (e.g. websites, webapps, etc.).
+Its primary use case is to provide a one-stop console for demos, workshops, and labs.
 
 === Core Concepts
 
 * Views - a view is a webpage that is displayed in the browser, it can include:
 ** Demo, lab, workshop content - typically created in asciidoc with Antora or similar
-** Tabs (iframed) - internal or external http based services e.g.
+** Tabs (iframed) - internal or external HTTP-based services e.g.
 *** Terminal(s) (tty) e.g. Butterfly, xtermjs etc
-*** IDEs such as VSCode/CodeServer, JupyterNotes etc
+*** IDEs such as VSCode/CodeServer, Jupyter Notebooks etc
 *** Consoles e.g. OpenShift, ArgoCD, Automation Controller etc
 
 NOTE: Consoles are typically iframed into a view, but can be opened in a new tab/window.
-Issues *may* arise with iframing some consoles, e.g. OpenShift, ArgoCD, Automation Controller etc and these are actively being investiagted.
+Issues *may* arise with iframing some consoles, e.g. OpenShift, ArgoCD, Automation Controller etc and these are actively being investigated.
 
 
 === Requirements
@@ -27,6 +27,45 @@ Any pre-requisites that may not be covered by Ansible itself or the role should 
 
 
 A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+==== TLS / ACME
+
+The role supports automatic TLS using Traefik's ACME integration. By default, ZeroSSL is used. You can switch to Let's Encrypt.
+
+Variables (see `defaults/main.yml`):
+
+* `showroom_tls_provider` (default: `zerossl`) — values: `letsencrypt` | `zerossl`
+* `showroom_acme_email` — ACME account email (required)
+* `showroom_http_port` (default: `80`) — host port for HTTP-01 (ZeroSSL only)
+
+ZeroSSL-specific:
+
+* `showroom_acme_zerossl_caserver` (default: `https://acme.zerossl.com/v2/DV90`)
+* `showroom_acme_zerossl_eab_kid`
+* `showroom_acme_zerossl_eab_hmac_key`
+
+Example (ZeroSSL):
+
+```
+showroom_tls_provider: zerossl
+showroom_acme_email: you@example.com
+showroom_acme_zerossl_eab_kid: "<your-eab-kid>"
+showroom_acme_zerossl_eab_hmac_key: "<your-eab-hmac>"
+```
+
+Notes:
+
+* ZeroSSL uses HTTP-01 and requires EAB (kid/hmac) values.
+* Let's Encrypt uses TLS-ALPN-01 and does not require EAB.
+* Both providers require inbound TCP/443 to be reachable for certificate issuance and access.
+* ZeroSSL additionally requires inbound TCP/80 for the HTTP-01 challenge; Let's Encrypt (TLS-ALPN-01) does not require port 80.
+
+===== Provider behavior
+
+Provider choice sets sane defaults; you may override via variables:
+
+* `zerossl` → default caserver `https://acme.zerossl.com/v2/DV90`, default challenge `http`, requires EAB
+* `letsencrypt` → default caserver `https://acme-v02.api.letsencrypt.org/directory`, default challenge `tlsalpn`
 
 === Dependencies
 
@@ -46,4 +85,3 @@ BSD
 ===== Author Information
 
 - Tony Kay (tok@redhat.com)
-

--- a/ansible/roles/showroom/README.adoc
+++ b/ansible/roles/showroom/README.adoc
@@ -30,11 +30,11 @@ A description of the settable variables for this role should go here, including 
 
 ==== TLS / ACME
 
-The role supports automatic TLS using Traefik's ACME integration. By default, ZeroSSL is used. You can switch to Let's Encrypt.
+The role supports automatic TLS using Traefik's ACME integration. By default, ZeroSSL is used. You can switch to Let's Encrypt, or disable TLS entirely.
 
 Variables (see `defaults/main.yml`):
 
-* `showroom_tls_provider` (default: `zerossl`) — values: `letsencrypt` | `zerossl`
+* `showroom_tls_provider` (default: `zerossl`) — values: `letsencrypt` | `zerossl` | `none`
 * `showroom_acme_email` — ACME account email (required)
 * `showroom_http_port` (default: `80`) — host port for HTTP-01 (ZeroSSL only)
 
@@ -57,8 +57,9 @@ Notes:
 
 * ZeroSSL uses HTTP-01 and requires EAB (kid/hmac) values.
 * Let's Encrypt uses TLS-ALPN-01 and does not require EAB.
-* Both providers require inbound TCP/443 to be reachable for certificate issuance and access.
+* Both ACME providers require inbound TCP/443 to be reachable for certificate issuance and access.
 * ZeroSSL additionally requires inbound TCP/80 for the HTTP-01 challenge; Let's Encrypt (TLS-ALPN-01) does not require port 80.
+* `none` disables TLS and ACME entirely. Traefik serves HTTP on `showroom_http_port` (default 80) only; port 443 is not exposed.
 
 ===== Provider behavior
 
@@ -66,6 +67,14 @@ Provider choice sets sane defaults; you may override via variables:
 
 * `zerossl` → default caserver `https://acme.zerossl.com/v2/DV90`, default challenge `http`, requires EAB
 * `letsencrypt` → default caserver `https://acme-v02.api.letsencrypt.org/directory`, default challenge `tlsalpn`
+* `none` → disables TLS/ACME; only `web` entrypoint on port 80 is enabled
+
+Example (HTTP-only):
+
+```
+showroom_tls_provider: none
+showroom_http_port: 80
+```
 
 === Dependencies
 

--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -141,7 +141,7 @@ showroom_work_dirs:
 # ----------------------------------------------------------------------
 # TLS and ACME configuration
 # ----------------------------------------------------------------------
-showroom_tls_provider: zerossl            # letsencrypt | zerossl
+showroom_tls_provider: zerossl            # letsencrypt | zerossl | none
 showroom_acme_email: john.doe@rhdp.net    # email used for ACME account
 showroom_http_port: 80                    # host port to bind for HTTP-01 challenge when enabled
 

--- a/ansible/roles/showroom/defaults/main.yml
+++ b/ansible/roles/showroom/defaults/main.yml
@@ -9,8 +9,8 @@ showroom_deploy: true
 showroom_antora_image: quay.io/redhat-gpte/showroom/antora
 showroom_antora_image_tag: latest
 
-showroom_reverse_proxy_image: quay.io/redhat-gpte/showroom/traefik
-showroom_reverse_proxy_image_tag: v2.4
+showroom_reverse_proxy_image: quay.io/rhpds/traefik
+showroom_reverse_proxy_image_tag: v2
 
 showroom_httpd_image: quay.io/redhat-gpte/showroom/httpd
 showroom_httpd_image_tag: latest
@@ -18,8 +18,8 @@ showroom_httpd_image_tag: latest
 showroom_codeserver_image: quay.io/redhat-gpte/showroom/code-server
 showroom_codeserver_image_tag: latest
 
-showroom_tty_image: quay.io/redhat-gpte/showroom/wetty
-showroom_tty_image_tag: latest
+showroom_tty_image: quay.io/rhpds/wetty
+showroom_tty_image_tag: v2
 
 showroom_nginx_image: quay.io/redhat-gpte/showroom/nginx
 showroom_nginx_image_tag: latest
@@ -137,3 +137,20 @@ showroom_pip_packages:
 showroom_work_dirs:
   - "{{ showroom_user_home_dir }}/content"               # The showroom repo itself, asciidoc source e.g. Antora
   - "{{ showroom_user_home_dir }}/orchestration"         # compose, kube files etc
+
+# ----------------------------------------------------------------------
+# TLS and ACME configuration
+# ----------------------------------------------------------------------
+showroom_tls_provider: zerossl            # letsencrypt | zerossl
+showroom_acme_email: john.doe@rhdp.net    # email used for ACME account
+showroom_http_port: 80                    # host port to bind for HTTP-01 challenge when enabled
+
+# ZeroSSL settings
+showroom_acme_zerossl_caserver: https://acme.zerossl.com/v2/DV90
+showroom_acme_zerossl_acme_challenge: http
+showroom_acme_zerossl_eab_kid: ""
+showroom_acme_zerossl_eab_hmac_key: ""
+
+# Let's Encrypt settings
+showroom_acme_letsencrypt_caserver: https://acme-v02.api.letsencrypt.org/directory
+showroom_acme_letsencrypt_acme_challenge: tlsalpn

--- a/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
+++ b/ansible/roles/showroom/tasks/20-showroom-user-setup.yml
@@ -89,7 +89,7 @@
 
     - name: "Enable linger for the showroom_user"
       ansible.builtin.command: "loginctl enable-linger {{ showroom_user }}"
-      become: yes
+      become: true
       changed_when: true
       #      when: r_showroom_linger_status != "Linger=yes"
 

--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -35,7 +35,7 @@
       ansible.builtin.copy:
         content: "{{ default_site_data | to_nice_yaml(indent=2) }}"
         dest: "{{ showroom_user_content_dir }}/default-site.yml"
-        backup: yes
+        backup: true
         owner: "{{ showroom_user }}"
         group: "{{ showroom_user_group }}"
         mode: "u=rw,g=r,o=r"

--- a/ansible/roles/showroom/tasks/50-showroom-service.yml
+++ b/ansible/roles/showroom/tasks/50-showroom-service.yml
@@ -47,10 +47,12 @@
     state: started
 
 - name: Pause before TLS verification attempts
+  when: (showroom_tls_provider | default('zerossl') | lower) != 'none'
   ansible.builtin.pause:
     seconds: 30
 
 - name: Verify TLS and restart on failure (up to 3 retries)
+  when: (showroom_tls_provider | default('zerossl') | lower) != 'none'
   ansible.builtin.set_fact:
     f_tls_verified: false
 
@@ -60,9 +62,12 @@
   loop: "{{ range(1, 4) | list }}"
   loop_control:
     loop_var: tls_attempt
-  when: not f_tls_verified | default(false)
+  when:
+    - (showroom_tls_provider | default('zerossl') | lower) != 'none'
+    - not f_tls_verified | default(false)
 
 - name: Assert TLS became ready
+  when: (showroom_tls_provider | default('zerossl') | lower) != 'none'
   ansible.builtin.assert:
     that:
       - f_tls_verified | default(false)

--- a/ansible/roles/showroom/tasks/50-showroom-service.yml
+++ b/ansible/roles/showroom/tasks/50-showroom-service.yml
@@ -1,7 +1,6 @@
 ---
 
 # Orchestrate showroom containers and setup orchestration pre-requisites
-
 - name: Insert showroom orchestration files, compose, scripts, and systemd
   ansible.builtin.template:
     src: "{{ __orchestration.src }}"
@@ -46,3 +45,44 @@
     name: showroom.service
     enabled: true
     state: started
+
+- name: Pause before TLS verification attempts
+  ansible.builtin.pause:
+    seconds: 30
+
+- name: Verify TLS and restart on failure (up to 3 retries)
+  ansible.builtin.set_fact:
+    f_tls_verified: false
+
+- name: Verify TLS and restart on failure (up to 3 attempts)
+  ansible.builtin.include_tasks:
+    file: verify_tls_attempt.yml
+  loop: "{{ range(1, 4) | list }}"
+  loop_control:
+    loop_var: tls_attempt
+  when: not f_tls_verified | default(false)
+
+- name: Assert TLS became ready
+  ansible.builtin.assert:
+    that:
+      - f_tls_verified | default(false)
+    fail_msg: >-
+      TLS not ready after 3 attempts for host '{{ showroom_host }}'.
+      Provider='{{ showroom_tls_provider | default('zerossl') }}',
+      Challenge='{{ f_acme_challenge_type | default('unknown') }}'.
+      We attempted an OpenSSL SNI handshake to
+      127.0.0.1:{{ showroom_primary_port | default(443) }}
+      using hostname '{{ showroom_host }}',
+      and restarted the showroom service between attempts
+      when the handshake failed.
+      If using HTTP-01 (ZeroSSL), ensure inbound TCP/80 is reachable
+      from the Internet and DNS points to this host.
+      If using TLS-ALPN-01 (Let's Encrypt), ensure inbound TCP/443
+      is reachable and hostname/SNI resolves correctly.
+      For troubleshooting, review the reverse-proxy container logs as user
+      '{{ showroom_user | default('showroom') }}':
+      sudo -u {{ showroom_user | default('showroom') }}
+      XDG_RUNTIME_DIR=/run/user/{{ showroom_user_uid }}
+      podman logs --tail 200 reverse-proxy
+      See ansible/roles/showroom/README.adoc for provider requirements
+      and additional tips.

--- a/ansible/roles/showroom/tasks/60-showroom-verify.yml
+++ b/ansible/roles/showroom/tasks/60-showroom-verify.yml
@@ -3,10 +3,13 @@
 # TODO: Basic verification of the showroom service
 #   - does it run, all of it?
 
+- name: Compute port suffix when non-standard port is used
+  ansible.builtin.set_fact:
+    f_port_suffix: "{% if (showroom_primary_port | default(443) | int) != 443 %}:{{ showroom_primary_port }}{% endif %}"
+
 - name: Capture lab_ui_url as fact
   ansible.builtin.set_fact:
-    f_lab_ui_url:
-      "https://{{ showroom_host }}{% if (showroom_primary_port | default(443) | int) != 443 %}:{{ showroom_primary_port }}{% endif %}/{{ showroom_primary_path }}"
+    f_lab_ui_url: "https://{{ showroom_host }}{{ f_port_suffix | default('') }}/{{ showroom_primary_path }}"
 
 - name: Output showroom view(s) URLs as userinfo and userdata
   agnosticd_user_info:

--- a/ansible/roles/showroom/tasks/60-showroom-verify.yml
+++ b/ansible/roles/showroom/tasks/60-showroom-verify.yml
@@ -6,7 +6,7 @@
 - name: Capture lab_ui_url as fact
   ansible.builtin.set_fact:
     f_lab_ui_url:
-      "https://{{ showroom_host }}:{{ showroom_primary_port }}/{{ showroom_primary_path }}"
+      "https://{{ showroom_host }}{% if (showroom_primary_port | default(443) | int) != 443 %}:{{ showroom_primary_port }}{% endif %}/{{ showroom_primary_path }}"
 
 - name: Output showroom view(s) URLs as userinfo and userdata
   agnosticd_user_info:

--- a/ansible/roles/showroom/tasks/verify_tls_attempt.yml
+++ b/ansible/roles/showroom/tasks/verify_tls_attempt.yml
@@ -1,0 +1,48 @@
+---
+- name: Capture reverse-proxy logs
+  ansible.builtin.command: podman logs --tail 200 reverse-proxy
+  register: r_reverse_proxy_logs
+  changed_when: false
+  failed_when: false
+  become: true
+  become_user: "{{ showroom_user | default('showroom') }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ showroom_user_uid }}"
+
+- name: Print reverse-proxy logs on failure
+  ansible.builtin.debug:
+    msg:
+      - "reverse-proxy logs (last 200 lines):"
+      - "{{ r_reverse_proxy_logs.stdout | default('') }}"
+      - "{{ r_reverse_proxy_logs.stderr | default('') }}"
+
+- name: Check TLS handshake for issued cert (hostname verified)
+  ansible.builtin.shell: |
+    set -o pipefail
+    echo | openssl s_client \
+      -verify 5 \
+      -verify_return_error \
+      -verify_hostname {{ showroom_host }} \
+      -servername {{ showroom_host }} \
+      -connect 127.0.0.1:{{ showroom_primary_port | default(443) }}
+  args:
+    executable: /bin/bash
+  register: r_tls_check
+  changed_when: false
+  failed_when: false
+
+- name: Mark TLS as verified when handshake succeeds
+  when: r_tls_check.rc == 0
+  ansible.builtin.set_fact:
+    f_tls_verified: true
+
+- name: Restart showroom service on failure
+  when: r_tls_check.rc != 0
+  ansible.builtin.service:
+    name: showroom.service
+    state: restarted
+
+- name: Pause before next TLS verification attempt
+  when: r_tls_check.rc != 0
+  ansible.builtin.pause:
+    seconds: 30

--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 ansible-runner-api:
   image: {{ showroom_ansible_runner_image }}:{{ showroom_ansible_runner_image_tag }}
   container_name: ansible-runner-api
@@ -16,7 +17,10 @@ ansible-runner-api:
 
   labels:
     - "traefic.enable=true"
+    - "traefik.http.routers.ansible-runner-api.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.ansible-runner-api.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefic.http.services.ansible-runner-api.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
     - "traefik.http.routers.ansible-runner-api.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"
     - "traefik.http.routers.ansible-runner-api.middlewares=runner-stripprefix"

--- a/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
+++ b/ansible/roles/showroom/templates/ansible_runner_api_service/ansible_runner_api_service.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 ansible-runner-api:
   image: {{ showroom_ansible_runner_image }}:{{ showroom_ansible_runner_image_tag }}
   container_name: ansible-runner-api
@@ -15,9 +16,8 @@ ansible-runner-api:
 
   labels:
     - "traefic.enable=true"
-    - "traefik.http.routers.ansible-runner-api.tls.certresolver=le"
+    - "traefik.http.routers.ansible-runner-api.tls.certresolver={{ _provider }}"
     - "traefic.http.services.ansible-runner-api.loadbalancer.server.port={{ showroom_ansible_runner_api_port | default(8501) }}"
     - "traefik.http.routers.ansible-runner-api.rule=Host(`{{ showroom_host }}`) && PathPrefix(`{{ showroom_ansible_runner_path }}`)"
     - "traefik.http.routers.ansible-runner-api.middlewares=runner-stripprefix"
     - "traefik.http.middlewares.runner-stripprefix.stripprefix.prefixes={{ showroom_ansible_runner_path }}"
-

--- a/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
+++ b/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
@@ -1,18 +1,53 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% if _provider == 'zerossl' %}
+{% set _caserver = showroom_acme_zerossl_caserver | default(certbot_cert_manager_acme_url, true) %}
+{% set _challenge = showroom_acme_zerossl_acme_challenge %}
+{% set _zerossl_eab_kid = showroom_acme_zerossl_eab_kid | default(certbot_cert_manager_zerossl_eab_key_id, true) %}
+{% set _zerossl_eab_hmac = showroom_acme_zerossl_eab_hmac_key | default(certbot_cert_manager_zerossl_hmac_key, true) %}
+{% else %}
+{% set _caserver = showroom_acme_letsencrypt_caserver | default(certbot_cert_manager_acme_url, true) %}
+{% set _challenge = showroom_acme_letsencrypt_acme_challenge %}
+{% set _zerossl_eab_kid = '' %}
+{% set _zerossl_eab_hmac = '' %}
+{% endif %}
+
 reverse-proxy:
   image: {{ showroom_reverse_proxy_image }}:{{ showroom_reverse_proxy_image_tag }}
   name: reverse-proxy
   command:
+    - "--global.checknewversion=false"
+    - "--global.sendanonymoususage=false"
     - "--providers.docker=true"
+    - "--providers.docker.exposedbydefault=false"
+    - "--log.level=info"
+    - "--accesslog=true"
     - "--entrypoints.websecure.address=:{{ showroom_primary_port | default(443) }}"
-    - "--certificatesresolvers.le.acme.email=john.doe@opentlc.com"
-    - "--certificatesresolvers.le.acme.tlschallenge=true"
-    - "--certificatesresolvers.le.acme.storage=/acme.json"
-
+{% if _challenge == 'http' %}
+    - "--entrypoints.web.address=:{{ showroom_http_port | default(80) }}"
+{% endif %}
+    - "--certificatesresolvers.{{ _provider }}.acme.email={{ showroom_acme_email }}"
+    - "--certificatesresolvers.{{ _provider }}.acme.caserver={{ _caserver }}"
+{% if _zerossl_eab_kid %}
+    - "--certificatesresolvers.{{ _provider }}.acme.eab.kid={{ _zerossl_eab_kid }}"
+{% endif %}
+{% if _zerossl_eab_hmac %}
+    - "--certificatesresolvers.{{ _provider }}.acme.eab.hmacencoded={{ _zerossl_eab_hmac }}"
+{% endif %}
+{% if _challenge == 'http' %}
+    - "--certificatesresolvers.{{ _provider }}.acme.httpchallenge=true"
+    - "--certificatesresolvers.{{ _provider }}.acme.httpchallenge.entrypoint=web"
+{% else %}
+    - "--certificatesresolvers.{{ _provider }}.acme.tlschallenge=true"
+{% endif %}
+    - "--certificatesresolvers.{{ _provider }}.acme.storage=/acme.json"
   volumes:
     - "/run/user/{{ showroom_user_uid }}/podman/podman.sock:/var/run/docker.sock:z"
     - "{{ showroom_user_orchestration_dir }}/acme.json:/acme.json:z"
   ports:
     - "{{ showroom_primary_port | default(443) }}:443"
+{% if _challenge == 'http' %}
+    - "{{ showroom_http_port | default(80) }}:80"
+{% endif %}
   labels:
     - traefik.enable=false
 
@@ -23,15 +58,15 @@ showroom:
   restart: always
   volumes:
 {% if showroom_ui == "zero" %}
-  - "{{ showroom_user_content_dir }}:/usr/local/apache2/htdocs:z,ro"
+    - "{{ showroom_user_content_dir }}:/usr/local/apache2/htdocs:z,ro"
 {% else %}
-  - "{{ showroom_user_content_dir }}/www:/usr/local/apache2/htdocs:z,ro"
+    - "{{ showroom_user_content_dir }}/www:/usr/local/apache2/htdocs:z,ro"
 {% endif %}
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.showroom.loadbalancer.server.port=80"
-    - "traefik.http.routers.entrypoints=showroomsecure"
-    - "traefik.http.routers.showroom.tls.certresolver=le"
+    - "traefik.http.routers.showroom.entrypoints=websecure"
+    - "traefik.http.routers.showroom.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.showroom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/showroom`)"
     - "traefik.http.routers.showroom.middlewares=showroom-stripprefix"
     - "traefik.http.middlewares.showroom-stripprefix.stripprefix.prefixes=/showroom"

--- a/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
+++ b/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
@@ -4,12 +4,19 @@
 {% set _challenge = showroom_acme_zerossl_acme_challenge %}
 {% set _zerossl_eab_kid = showroom_acme_zerossl_eab_kid | default(certbot_cert_manager_zerossl_eab_key_id, true) %}
 {% set _zerossl_eab_hmac = showroom_acme_zerossl_eab_hmac_key | default(certbot_cert_manager_zerossl_hmac_key, true) %}
-{% else %}
+{% elif _provider == 'letsencrypt' %}
 {% set _caserver = showroom_acme_letsencrypt_caserver | default(certbot_cert_manager_acme_url, true) %}
 {% set _challenge = showroom_acme_letsencrypt_acme_challenge %}
 {% set _zerossl_eab_kid = '' %}
 {% set _zerossl_eab_hmac = '' %}
+{% else %}
+{% set _caserver = '' %}
+{% set _challenge = '' %}
+{% set _zerossl_eab_kid = '' %}
+{% set _zerossl_eab_hmac = '' %}
 {% endif %}
+
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 
 reverse-proxy:
   image: {{ showroom_reverse_proxy_image }}:{{ showroom_reverse_proxy_image_tag }}
@@ -21,6 +28,9 @@ reverse-proxy:
     - "--providers.docker.exposedbydefault=false"
     - "--log.level=info"
     - "--accesslog=true"
+{% if _provider == 'none' %}
+    - "--entrypoints.web.address=:{{ showroom_http_port | default(80) }}"
+{% else %}
     - "--entrypoints.websecure.address=:{{ showroom_primary_port | default(443) }}"
 {% if _challenge == 'http' %}
     - "--entrypoints.web.address=:{{ showroom_http_port | default(80) }}"
@@ -40,13 +50,20 @@ reverse-proxy:
     - "--certificatesresolvers.{{ _provider }}.acme.tlschallenge=true"
 {% endif %}
     - "--certificatesresolvers.{{ _provider }}.acme.storage=/acme.json"
+{% endif %}
   volumes:
     - "/run/user/{{ showroom_user_uid }}/podman/podman.sock:/var/run/docker.sock:z"
+{% if _provider != 'none' %}
     - "{{ showroom_user_orchestration_dir }}/acme.json:/acme.json:z"
+{% endif %}
   ports:
+{% if _provider == 'none' %}
+    - "{{ showroom_http_port | default(80) }}:80"
+{% else %}
     - "{{ showroom_primary_port | default(443) }}:443"
 {% if _challenge == 'http' %}
     - "{{ showroom_http_port | default(80) }}:80"
+{% endif %}
 {% endif %}
   labels:
     - traefik.enable=false
@@ -65,8 +82,10 @@ showroom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.showroom.loadbalancer.server.port=80"
-    - "traefik.http.routers.showroom.entrypoints=websecure"
+    - "traefik.http.routers.showroom.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.showroom.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.showroom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/showroom`)"
     - "traefik.http.routers.showroom.middlewares=showroom-stripprefix"
     - "traefik.http.middlewares.showroom-stripprefix.stripprefix.prefixes=/showroom"

--- a/ansible/roles/showroom/templates/service_codeserver/service_codeserver.j2
+++ b/ansible/roles/showroom/templates/service_codeserver/service_codeserver.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 codeserver:
   image: {{ showroom_codeserver_image }}:{{ showroom_codeserver_image_tag }}
   container_name: codeserver
@@ -16,7 +17,7 @@ codeserver:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.vscode.loadbalancer.server.port=8080"
-    - "traefik.http.routers.vscode.tls.certresolver=le"
+    - "traefik.http.routers.vscode.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.vscode.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/codeserver`)"
     - "traefik.http.routers.vscode.middlewares=vscode-stripprefix"
     - "traefik.http.middlewares.vscode-stripprefix.stripprefix.prefixes=/codeserver"

--- a/ansible/roles/showroom/templates/service_codeserver/service_codeserver.j2
+++ b/ansible/roles/showroom/templates/service_codeserver/service_codeserver.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 codeserver:
   image: {{ showroom_codeserver_image }}:{{ showroom_codeserver_image_tag }}
   container_name: codeserver
@@ -17,7 +18,10 @@ codeserver:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.vscode.loadbalancer.server.port=8080"
+    - "traefik.http.routers.vscode.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.vscode.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.vscode.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/codeserver`)"
     - "traefik.http.routers.vscode.middlewares=vscode-stripprefix"
     - "traefik.http.middlewares.vscode-stripprefix.stripprefix.prefixes=/codeserver"

--- a/ansible/roles/showroom/templates/service_double_tty/service_double_tty.j2
+++ b/ansible/roles/showroom/templates/service_double_tty/service_double_tty.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 tty-top:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty-top
@@ -25,8 +26,8 @@ tty-top:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-top.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-topentrypoints=terminalsecure"
-    - "traefik.http.routers.tty-top.tls.certresolver=le"
+    - "traefik.http.routers.tty-top.entrypoints=websecure"
+    - "traefik.http.routers.tty-top.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty-top.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-top`)"
     - "traefik.http.routers.tty-top.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-top.middlewares=tty-toptheader"
@@ -60,8 +61,8 @@ tty-bottom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-bottom.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-bottomentrypoints=terminalsecure"
-    - "traefik.http.routers.tty-bottom.tls.certresolver=le"
+    - "traefik.http.routers.tty-bottom.entrypoints=websecure"
+    - "traefik.http.routers.tty-bottom.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty-bottom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-bottom`)"
     - "traefik.http.routers.tty-bottom.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-bottom.middlewares=tty-bottomtheader"

--- a/ansible/roles/showroom/templates/service_double_tty/service_double_tty.j2
+++ b/ansible/roles/showroom/templates/service_double_tty/service_double_tty.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 tty-top:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty-top
@@ -26,8 +27,10 @@ tty-top:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-top.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-top.entrypoints=websecure"
+    - "traefik.http.routers.tty-top.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty-top.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty-top.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-top`)"
     - "traefik.http.routers.tty-top.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-top.middlewares=tty-toptheader"
@@ -61,8 +64,10 @@ tty-bottom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-bottom.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-bottom.entrypoints=websecure"
+    - "traefik.http.routers.tty-bottom.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty-bottom.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty-bottom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-bottom`)"
     - "traefik.http.routers.tty-bottom.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-bottom.middlewares=tty-bottomtheader"

--- a/ansible/roles/showroom/templates/service_second_terminal/service_second_terminal.j2
+++ b/ansible/roles/showroom/templates/service_second_terminal/service_second_terminal.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 terminal-02:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: terminal-02
@@ -14,8 +15,10 @@ terminal-02:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.terminal2.loadbalancer.server.port=3001"
-    - "traefik.http.routers.terminal2.entrypoints=websecure"
+    - "traefik.http.routers.terminal2.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.terminal2.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.terminal2.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty2`)"
     - "traefik.http.routers.terminal2.middlewares=terminal-stripprefix"
     - "traefik.http.routers.terminal2.middlewares=testheader"

--- a/ansible/roles/showroom/templates/service_second_terminal/service_second_terminal.j2
+++ b/ansible/roles/showroom/templates/service_second_terminal/service_second_terminal.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 terminal-02:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: terminal-02
@@ -13,8 +14,8 @@ terminal-02:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.terminal2.loadbalancer.server.port=3001"
-    - "traefik.http.routers.terminalentrypoints2=terminalsecure2"
-    - "traefik.http.routers.terminal2.tls.certresolver=le"
+    - "traefik.http.routers.terminal2.entrypoints=websecure"
+    - "traefik.http.routers.terminal2.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.terminal2.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty2`)"
     - "traefik.http.routers.terminal2.middlewares=terminal-stripprefix"
     - "traefik.http.routers.terminal2.middlewares=testheader"

--- a/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
+++ b/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 terminal-01:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: terminal-01
@@ -25,8 +26,8 @@ terminal-01:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.terminal.loadbalancer.server.port=3000"
-    - "traefik.http.routers.terminalentrypoints=terminalsecure"
-    - "traefik.http.routers.terminal.tls.certresolver=le"
+    - "traefik.http.routers.terminal.entrypoints=websecure"
+    - "traefik.http.routers.terminal.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.terminal.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/wetty`)"
     - "traefik.http.routers.terminal.middlewares=terminal-stripprefix"
     - "traefik.http.routers.terminal.middlewares=testheader"

--- a/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
+++ b/ansible/roles/showroom/templates/service_single_terminal/service_single_terminal.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 terminal-01:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: terminal-01
@@ -26,8 +27,10 @@ terminal-01:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.terminal.loadbalancer.server.port=3000"
-    - "traefik.http.routers.terminal.entrypoints=websecure"
+    - "traefik.http.routers.terminal.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.terminal.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.terminal.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/wetty`)"
     - "traefik.http.routers.terminal.middlewares=terminal-stripprefix"
     - "traefik.http.routers.terminal.middlewares=testheader"

--- a/ansible/roles/showroom/templates/service_triple_tty/service_triple_tty.j2
+++ b/ansible/roles/showroom/templates/service_triple_tty/service_triple_tty.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 tty-triple-top:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty-triple-top
@@ -26,8 +27,10 @@ tty-triple-top:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-triple-top.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-triple-top.entrypoints=websecure"
+    - "traefik.http.routers.tty-triple-top.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty-triple-top.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty-triple-top.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-triple-top`)"
     - "traefik.http.routers.tty-triple-top.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-triple-top.middlewares=tty-triple-toptheader"
@@ -62,8 +65,10 @@ tty-triple-middle:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-triple-middle.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-triple-middle.entrypoints=websecure"
+    - "traefik.http.routers.tty-triple-middle.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty-triple-middle.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty-triple-middle.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-triple-middle`)"
     - "traefik.http.routers.tty-triple-middle.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-triple-middle.middlewares=tty-triple-middletheader"
@@ -98,8 +103,10 @@ tty-triple-bottom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-triple-bottom.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-triple-bottom.entrypoints=websecure"
+    - "traefik.http.routers.tty-triple-bottom.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty-triple-bottom.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty-triple-bottom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-triple-bottom`)"
     - "traefik.http.routers.tty-triple-bottom.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-triple-bottom.middlewares=tty-triple-bottomtheader"

--- a/ansible/roles/showroom/templates/service_triple_tty/service_triple_tty.j2
+++ b/ansible/roles/showroom/templates/service_triple_tty/service_triple_tty.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 tty-triple-top:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty-triple-top
@@ -25,8 +26,8 @@ tty-triple-top:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-triple-top.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-triple-topentrypoints=terminalsecure"
-    - "traefik.http.routers.tty-triple-top.tls.certresolver=le"
+    - "traefik.http.routers.tty-triple-top.entrypoints=websecure"
+    - "traefik.http.routers.tty-triple-top.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty-triple-top.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-triple-top`)"
     - "traefik.http.routers.tty-triple-top.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-triple-top.middlewares=tty-triple-toptheader"
@@ -61,8 +62,8 @@ tty-triple-middle:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-triple-middle.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-triple-middleentrypoints=terminalsecure"
-    - "traefik.http.routers.tty-triple-middle.tls.certresolver=le"
+    - "traefik.http.routers.tty-triple-middle.entrypoints=websecure"
+    - "traefik.http.routers.tty-triple-middle.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty-triple-middle.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-triple-middle`)"
     - "traefik.http.routers.tty-triple-middle.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-triple-middle.middlewares=tty-triple-middletheader"
@@ -97,8 +98,8 @@ tty-triple-bottom:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty-triple-bottom.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty-triple-bottomentrypoints=terminalsecure"
-    - "traefik.http.routers.tty-triple-bottom.tls.certresolver=le"
+    - "traefik.http.routers.tty-triple-bottom.entrypoints=websecure"
+    - "traefik.http.routers.tty-triple-bottom.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty-triple-bottom.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty-triple-bottom`)"
     - "traefik.http.routers.tty-triple-bottom.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty-triple-bottom.middlewares=tty-triple-bottomtheader"

--- a/ansible/roles/showroom/templates/service_tty1/service_tty1.j2
+++ b/ansible/roles/showroom/templates/service_tty1/service_tty1.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 tty1:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty1
@@ -25,8 +26,8 @@ tty1:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty1.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty1entrypoints=terminalsecure"
-    - "traefik.http.routers.tty1.tls.certresolver=le"
+    - "traefik.http.routers.tty1.entrypoints=websecure"
+    - "traefik.http.routers.tty1.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty1.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty1`)"
     - "traefik.http.routers.tty1.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty1.middlewares=tty1theader"

--- a/ansible/roles/showroom/templates/service_tty1/service_tty1.j2
+++ b/ansible/roles/showroom/templates/service_tty1/service_tty1.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 tty1:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty1
@@ -26,8 +27,10 @@ tty1:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty1.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty1.entrypoints=websecure"
+    - "traefik.http.routers.tty1.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty1.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty1.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty1`)"
     - "traefik.http.routers.tty1.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty1.middlewares=tty1theader"

--- a/ansible/roles/showroom/templates/service_tty2/service_tty2.j2
+++ b/ansible/roles/showroom/templates/service_tty2/service_tty2.j2
@@ -1,4 +1,5 @@
 {% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _entrypoint = 'web' if _provider == 'none' else 'websecure' %}
 tty2:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty2
@@ -26,8 +27,10 @@ tty2:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty2.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty2.entrypoints=websecure"
+    - "traefik.http.routers.tty2.entrypoints={{ _entrypoint }}"
+{% if _provider != 'none' %}
     - "traefik.http.routers.tty2.tls.certresolver={{ _provider }}"
+{% endif %}
     - "traefik.http.routers.tty2.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty2`)"
     - "traefik.http.routers.tty2.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty2.middlewares=tty2theader"

--- a/ansible/roles/showroom/templates/service_tty2/service_tty2.j2
+++ b/ansible/roles/showroom/templates/service_tty2/service_tty2.j2
@@ -1,3 +1,4 @@
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
 tty2:
   image: {{ showroom_tty_image }}:{{ showroom_tty_image_tag }}
   container_name: tty2
@@ -25,8 +26,8 @@ tty2:
   labels:
     - "traefik.enable=true"
     - "traefik.http.services.tty2.loadbalancer.server.port=3000"
-    - "traefik.http.routers.tty2entrypoints=terminalsecure"
-    - "traefik.http.routers.tty2.tls.certresolver=le"
+    - "traefik.http.routers.tty2.entrypoints=websecure"
+    - "traefik.http.routers.tty2.tls.certresolver={{ _provider }}"
     - "traefik.http.routers.tty2.rule=Host(`{{ showroom_host }}`) && PathPrefix(`/tty2`)"
     - "traefik.http.routers.tty2.middlewares=terminal-stripprefix"
     - "traefik.http.routers.tty2.middlewares=tty2theader"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

- Default the `showroom` role to use ZeroSSL for TLS via ACME; allow Let’s Encrypt override.
- Add TLS/ACME variables in `defaults/main.yml`: provider, account email, HTTP port, per‑provider CA servers/challenge types, and ZeroSSL EAB kid/hmac.
- Drive Traefik config from provider choice in `base_service_traefik_httpd.j2`: set resolver name, CA server, support EAB, and toggle HTTP‑01 (ZeroSSL adds `web` entrypoint and binds host port 80) vs TLS‑ALPN‑01 (Let’s Encrypt).
- Standardize Traefik router labels across services to use `entrypoints=websecure` and `tls.certresolver={{ provider }}`; fix prior label typos/indentation in compose templates.
- Update service templates (`ansible_runner_api_service`, `codeserver`, single/double/triple tty, `second_terminal`, `tty1`, `tty2`) to use the provider‑based resolver and correct entrypoints.
- Add TLS readiness verification: new `tasks/verify_tls_attempt.yml` performs OpenSSL SNI handshake checks, collects reverse‑proxy logs, restarts the service on failure, and retries up to 3 times. Integrated into tasks/50-showroom-service.yml with pauses and a clear assert/fail message.
- Expand `README.adoc` with a TLS/ACME section, examples, and provider behavior notes (ZeroSSL requires EAB + HTTP‑01 on port 80; Let’s Encrypt uses TLS‑ALPN‑01 without EAB).
- Provide sane fallbacks in templates to shared `certbot_cert_manager_*` variables when role‑specific values are unset.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- showroom
