### PR TITLE
[ocp-workloads] New variable to decide which workloads should be cleaned up

### DIFF
--- a/ansible/configs/ocp-workloads/default_vars.yml
+++ b/ansible/configs/ocp-workloads/default_vars.yml
@@ -45,6 +45,10 @@ cluster_workloads: >-
 ocp_workloads: >-
   {{ infra_workloads | default([ocp_workload] if ocp_workload is defined else []) }}
 
+# Simple list of workloads roles to remove to all clusters
+ocp_remove_workloads: >-
+  {{ remove_workloads | default([ocp_workload] if ocp_workload is defined else []) }}
+
 # Alternative name for ocp_workloads for compatibility
 #infra_workloads: []
 

--- a/ansible/configs/ocp-workloads/destroy_env.yml
+++ b/ansible/configs/ocp-workloads/destroy_env.yml
@@ -14,7 +14,7 @@
       name: openshift_workloads
     vars:
       ACTION: destroy
-      openshift_workloads: "{{ cluster_workloads }}"
+      openshift_workloads: "{{ remove_workloads | default([]) }}"
 
 - name: Cleanup
   ansible.builtin.import_playbook: cleanup.yml

--- a/ansible/configs/ocp-workloads/destroy_env.yml
+++ b/ansible/configs/ocp-workloads/destroy_env.yml
@@ -14,7 +14,7 @@
       name: openshift_workloads
     vars:
       ACTION: destroy
-      openshift_workloads: "{{ remove_workloads | default([]) }}"
+      openshift_workloads: "{{ ocp_remove_workloads | default([]) }}"
 
 - name: Cleanup
   ansible.builtin.import_playbook: cleanup.yml


### PR DESCRIPTION
##### SUMMARY

Currently all the workloads are trying to be deleted, this is not the expected behave as maybe the cluster stopped or even destroyed (from a previous try).

Adding the variable **ocp_remove_workloads** to define which workloads should be removed, it can defined by cluster or using original behave from **remove_workloads** a list of workloads

use case: remove the vms/permissions from vmware


##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ocp-workloads role
