### PR TITLE
Use to_nice_yaml filter for application values

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -13,7 +13,11 @@ spec:
 {% if ocp4_workload_gitops_bootstrap_helm_values | length > 0 %}
     helm:
       values: |
-        {{ ocp4_workload_gitops_bootstrap_helm_values | combine(_ocp4_workload_gitops_bootstrap_deployer_values) }}
+        {{ ocp4_workload_gitops_bootstrap_helm_values
+         | combine(_ocp4_workload_gitops_bootstrap_deployer_values)
+         | to_nice_yaml
+         | indent(width=8, first=False)
+        }}
 {% else %}
     plugin:
       name: kustomize-envvar


### PR DESCRIPTION
##### SUMMARY

In `ocp4_workload_gitops_bootstrap` the yaml values were passed as raw Python objects. This is dangerous as not all python data is valid YAML. This updates the template to use `to_nice_yaml` to encode the values and this also makes the values easier to read and troubleshoot.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role ocp4_workload_gitops_bootstrap.