### PR TITLE
openshift_workloads: update tasks (main, setup_cluster_kubeconfig)

### DIFF
--- a/ansible/roles/openshift_workloads/tasks/main.yml
+++ b/ansible/roles/openshift_workloads/tasks/main.yml
@@ -8,7 +8,7 @@
       {{
         {
           "api_ca_cert": openshift_api_ca_cert | default(''),
-          "api_key": openshift_api_key,
+          "api_key": openshift_api_key | default(openshift_cluster_admin_token),
           "api_url": openshift_api_url,
         } if __cluster_name == 'default' else lookup('ansible.builtin.vars', __cluster_name)
       }}

--- a/ansible/roles/openshift_workloads/tasks/setup_cluster_kubeconfig.yml
+++ b/ansible/roles/openshift_workloads/tasks/setup_cluster_kubeconfig.yml
@@ -26,7 +26,11 @@
           {%- else +%}
           insecure-skip-tls-verify: true
           {%- endif +%}
+          {% if 'https' in __api_url +%}
           server: {{ __api_url | to_json }}
+          {%- else +%}
+          server: {{ ('https://' + __api_url  + ':6443') | to_json}}
+          {%- endif +%}
       contexts:
       - name: {{ __cluster_name }}
         context:


### PR DESCRIPTION
##### SUMMARY

Default to openshift_cluster_admin_token the api_key and if the api_url has not "https", just add it with the port 6443

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
openshift_workloads role
