### PR TITLE
[ocp4_workload_showroom_ocp_integration] Update workload.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom_ocp_integration/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom_ocp_integration/tasks/workload.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get OpenShift token without touching kubeconfig
   command: >
-    oc login https://{{ openshift_api_url }}:6443
+    oc login {{ openshift_api_url if 'https' in openshift_api_url else 'https' + openshift_api_url + ':6443' }}
     -u {{ lookup('agnosticd_user_data', 'openshift_cluster_admin_username') }}
     -p {{ lookup('agnosticd_user_data', 'openshift_cluster_admin_password') }}
     --insecure-skip-tls-verify


### PR DESCRIPTION
##### SUMMARY

openshift_api_url can have https://api:6443 format or just api.address (temporary mistake), this cover both cases

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_showroom_ocp_integration role
