### PR TITLE
ocp4_workload_showroom: mirrors.openshift fails too often, use s3

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/check-and-install-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/check-and-install-helm.yaml
@@ -15,7 +15,7 @@
   - name: Set URL for helm
     ansible.builtin.set_fact:
       helm_url: >-
-        {{ ocp4_workload_showroom_tools_root_url }}/helm/{{ ocp4_workload_showroom_helm_version }}/helm-linux-amd64.tar.gz
+        https://catalog-item-assets.s3.us-east-2.amazonaws.com/helm-linux-amd64.tar.gz
 
   - name: Install Helm as root
     become: true


### PR DESCRIPTION
https://catalog-item-assets.s3.us-east-2.amazonaws.com/helm-linux-amd64.tar.gz

will be a reliable location