### PR TITLE
[ocp4_workload_cert_manager] Add variable to define the timeout

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -25,7 +25,7 @@ ocp4_workload_cert_manager_wait_after_api_cert_setup: 12
 ocp4_workload_cert_manager_wait_for_rollout: false
 
 # How many seconds wait till the certificate is issued
-ocp4_workload_cert_manager_wait_for_certificates: 600
+ocp4_workload_cert_manager_wait_timeout: 600
 
 # Set to the cloud provider to be used:
 # Valid values are: ec2, azure, gcp, osp, vmc

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -24,6 +24,9 @@ ocp4_workload_cert_manager_wait_after_api_cert_setup: 12
 # In the future change to check the cluster operators instead of just pausing
 ocp4_workload_cert_manager_wait_for_rollout: false
 
+# How many seconds wait till the certificate is issued
+ocp4_workload_cert_manager_wait_for_certificates: 600
+
 # Set to the cloud provider to be used:
 # Valid values are: ec2, azure, gcp, osp, vmc
 # NOTE: Right now only ec2, gcp and azure are implemented

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
@@ -75,7 +75,7 @@
       delay: 30
       until: r_clusterissuer is success
 
-    - name: Wait until Ingress Certificate is ready
+    - name: Wait until API Certificate is ready
       when: not ingress_cert_ready | default(false) | bool
       kubernetes.core.k8s_info:
         api_version: cert-manager.io/v1
@@ -84,7 +84,7 @@
         namespace: openshift-config
         wait: true
         wait_sleep: 5
-        wait_timeout: 1200
+        wait_timeout: "{{ ocp4_workload_cert_manager_wait_timeout | int }}"
         wait_condition:
           type: "Ready"
           status: "True"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
@@ -9,7 +9,7 @@
       namespace: openshift-config
       wait: true
       wait_sleep: 5
-      wait_timeout: 800
+      wait_timeout: "{{ ocp4_workload_cert_manager_wait_timeout | int }}"
       wait_condition:
         type: "Ready"
         status: "True"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_api_cert_check.yml
@@ -76,7 +76,7 @@
       until: r_clusterissuer is success
 
     - name: Wait until API Certificate is ready
-      when: not ingress_cert_ready | default(false) | bool
+      when: not api_cert_ready | default(false) | bool
       kubernetes.core.k8s_info:
         api_version: cert-manager.io/v1
         kind: Certificate
@@ -88,9 +88,9 @@
         wait_condition:
           type: "Ready"
           status: "True"
-      register: r_certificate_ingress
+      register: r_certificate_api
 
     - name: Mark cert ready
-      when: not r_certificate_ingress is failed
+      when: not r_certificate_api is failed
       ansible.builtin.set_fact:
         api_cert_ready: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
@@ -9,7 +9,7 @@
       namespace: openshift-ingress
       wait: true
       wait_sleep: 5
-      wait_timeout: 1200
+      wait_timeout: "{{ ocp4_workload_cert_manager_wait_timeout | int }}"
       wait_condition:
         type: "Ready"
         status: "True"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/cert_manager_ingress_cert_check.yml
@@ -84,7 +84,7 @@
         namespace: openshift-ingress
         wait: true
         wait_sleep: 5
-        wait_timeout: 1200
+        wait_timeout: "{{ ocp4_workload_cert_manager_wait_timeout | int }}"
         wait_condition:
           type: "Ready"
           status: "True"


### PR DESCRIPTION
##### SUMMARY

Currently it is set to a high fix value, 1200. This PR sets to a more reasonable value, 600.

As we have implemented retries (long time ago) and fallback (recently)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_cert_manager role
