### PR TITLE
[host-ocp4-assisted-installer] Add variables to define root/etcd disk sizes

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -125,7 +125,7 @@
           storage:
             resources:
               requests:
-                storage: 100Gi
+                storage: "{{ ai_control_plane_root_disk_size }}"
             storageClassName: "{{ storageclass }}"
 
       - metadata:
@@ -137,7 +137,7 @@
           storage:
             resources:
               requests:
-                storage: 30Gi
+                storage: "{{ ai_control_plane_etcd_disk_size }}"
             storageClassName: "{{ ai_local_storageclass }}"
             volumeMode: Filesystem
     _spec: |

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -118,7 +118,7 @@
           storage:
             resources:
               requests:
-                storage: 100Gi
+                storage: "{{ ai_workers_root_disk_size }}"
             storageClassName: "{{ storageclass }}"
     _spec: |
       domain:

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -7,8 +7,11 @@ ai_cluster_version: "{{ ocp4_installer_version | default('4.13') }}"
 ai_cluster_iso_type: "minimal-iso"
 ai_control_plane_cores: 8
 ai_control_plane_memory: 16Gi
+ai_control_plane_root_disk_size: 100Gi
+ai_control_plane_etcd_disk_size: 8Gi
 ai_workers_cores: 16
 ai_workers_memory: 64Gi
+ai_workers_root_disk_size: 100Gi
 ai_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 ai_ocp_vmname_sno: "sno-{{ cluster_name }}"
 ai_ocp_vmname_master_prefix: "control-plane-{{ cluster_name }}"


### PR DESCRIPTION
##### SUMMARY

This PR is to add new three variables, to be able to define the size for root disk or etcd disk

* **ai_control_plane_root_disk_size**, defaults to 100Gi
* **ai_control_plane_etcd_disk_size**, defaults to 8Gi, a better size than previous fix 30Gi
* **ai_workers_root_disk_size**, defaults to 100Gi

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
