### PR TITLE
[infra-openshift-cnv-resources] Fail before create VM if the image doesn't exist (pvc mode only)

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -110,6 +110,20 @@
         }
     ] }}"
 
+- name: Fail if image (pvc) doesn't exist on namespace cnv-images
+  when: _instance.image_type | default('pvc') == 'pvc' 
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    name: "{{ _instance.image }}"
+    namespace: cnv-images
+  register: r_pvc_info
+
+- name: Fail if PVC does not exist
+  ansible.builtin.fail:
+    msg: "PersistentVolumeClaim {{ _instance.image }} does not exist in namespace cnv-images"
+  when: r_pvc_info.resources | length == 0  
+
 
 - name: Create instance(s) "{{ _instance.name }}"
   vars:

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -113,8 +113,8 @@
 - name: Fail if image (pvc) doesn't exist on namespace cnv-images
   when: _instance.image_type | default('pvc') == 'pvc' 
   kubernetes.core.k8s_info:
-    api_version: v1
-    kind: PersistentVolumeClaim
+    api_version: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
     name: "{{ _instance.image }}"
     namespace: cnv-images
   register: r_pvc_info

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -113,8 +113,8 @@
 - name: Fail if image (pvc) doesn't exist on namespace cnv-images
   when: _instance.image_type | default('pvc') == 'pvc' 
   kubernetes.core.k8s_info:
-    api_version: cdi.kubevirt.io/v1beta1
-    kind: DataVolume
+    api_version: v1
+    kind: PersistentVolumeClaim
     name: "{{ _instance.image }}"
     namespace: cnv-images
   register: r_pvc_info


### PR DESCRIPTION
##### SUMMARY

Many recent failure deployments on CNV were caused because image wasn't propagated properly to production clusters, this PR improves the error handling showing the reason.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
infra-openshift-cnv-resources role
