### PR TITLE
[host-ocp4-assisted-installer] Check quota before install OCP

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
@@ -2,13 +2,13 @@
     _control_plane_memory_bytes:
       "{{ ai_control_plane_memory | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
     _worker_plane_memory_bytes:
-      "{{ ai_workers_memory | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+      "{{ ai_workers_memory | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
     _control_plane_root_disk_bytes:
       "{{ ai_control_plane_root_disk_size | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
     _control_plane_etcd_disk_bytes:
       "{{ ai_control_plane_etcd_disk_size | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
     _worker_plane_root_disk_bytes: 
-      "{{ ai_workers_root_disk_size | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+      "{{ ai_workers_root_disk_size | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
 
 - name: Calculate required cpu/memory/storage
   ansible.builtin.set_fact:
@@ -24,55 +24,58 @@
          (_worker_plane_root_disk_bytes | int * worker_instance_count | int) }}"
 
 - name: Get Quota information
-  register: result
+  register: r_quota
   kubernetes.core.k8s_info:
     kind: "ResourceQuota"
     api_version: "v1"
     namespace: "{{ ai_ocp_namespace }}"
     name: "sandbox-quota"
 
-- name: Set used variables and limit variables
-  ansible.builtin.set_fact:
-    _used_memory:
-      "{{ result.resources[0].status.used['limits.memory'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
-          | ansible.builtin.human_to_bytes }}"
-    _used_cpu:
-      "{{ (result.resources[0].status.used['limits.cpu'] | default(0) | regex_replace('^(m)?$', '') | int) / 1000  | int}}"
-    _used_storage:
-      "{{ result.resources[0].status.used['requests.storage'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
-            | ansible.builtin.human_to_bytes }}"
-
-- name: Set hard quota variables and limit variables
-  ansible.builtin.set_fact:
-    _hard_memory:
-      "{{ result.resources[0].status.hard['limits.memory'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
-          | ansible.builtin.human_to_bytes }}"
-    _hard_cpu:
-      "{{ result.resources[0].status.hard['limits.cpu'] | default(0) | regex_replace('^(m)?$', '') | int }}"
-    _hard_storage:
-      "{{ result.resources[0].status.hard['requests.storage'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
-            | ansible.builtin.human_to_bytes }}"
-
-- name: Check if quota allows to requested memory
-  ansible.builtin.assert:
-    that:
-      - (_used_memory|int + _required_memory|int) <  _hard_memory|int
-    fail_msg: >-
-      memory quota has to be increased to at least {{ (_used_memory|int + _required_memory|int) | ansible.builtin.human_readable }},
-      currently {{ _hard_memory  | int | ansible.builtin.human_readable }}
-
-- name: Check if quota allows to requested cpu
-  ansible.builtin.assert:
-    that:
-      - (_used_cpu|int + _required_cpu|int) <  _hard_cpu|int
-    fail_msg: >-
-      cpu quota has to be increased to at least {{ (_used_cpu|int + _required_cpu|int) | ansible.builtin.human_readable }},
-      currently {{ _hard_cpu  | int | ansible.builtin.human_readable }}
-
-- name: Check if quota allows to requested storage
-  ansible.builtin.assert:
-    that:
-      - (_used_storage|int + _required_storage|int) <  _hard_storage|int
-    fail_msg: >-
-      storage quota has to be increased to at least {{ (_used_storage|int + _required_storage|int) | ansible.builtin.human_readable }},
-      currently {{ _hard_storage  | int | ansible.builtin.human_readable }}
+- name: Check if quota is enough if defined
+  when: r_quota.resources | length > 0
+  block:
+    - name: Set used variables and limit variables
+      ansible.builtin.set_fact:
+        _used_memory:
+          "{{ r_quota.resources[0].status.used['limits.memory'] | default(0) | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+              | ansible.builtin.human_to_bytes }}"
+        _used_cpu:
+          "{{ (r_quota.resources[0].status.used['limits.cpu'] | default(0) | ansible.builtin.regex_replace('^(m)?$', '') | int) / 1000  | int}}"
+        _used_storage:
+          "{{ r_quota.resources[0].status.used['requests.storage'] | default(0) | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+                | ansible.builtin.human_to_bytes }}"
+    
+    - name: Set hard quota variables and limit variables
+      ansible.builtin.set_fact:
+        _hard_memory:
+          "{{ r_quota.resources[0].status.hard['limits.memory'] | default(0) | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+              | ansible.builtin.human_to_bytes }}"
+        _hard_cpu:
+          "{{ r_quota.resources[0].status.hard['limits.cpu'] | default(0) | ansible.builtin.regex_replace('^(m)?$', '') | int }}"
+        _hard_storage:
+          "{{ r_quota.resources[0].status.hard['requests.storage'] | default(0) | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+                | ansible.builtin.human_to_bytes }}"
+    
+    - name: Check if quota allows to requested memory
+      ansible.builtin.assert:
+        that:
+          - (_used_memory | int + _required_memory | int) <  _hard_memory | int
+        fail_msg: >-
+          memory quota has to be increased to at least {{ (_used_memory | int + _required_memory | int) | ansible.builtin.human_readable }},
+          currently {{ _hard_memory  | int | ansible.builtin.human_readable }}
+    
+    - name: Check if quota allows to requested cpu
+      ansible.builtin.assert:
+        that:
+          - (_used_cpu | int + _required_cpu | int) <  _hard_cpu | int
+        fail_msg: >-
+          cpu quota has to be increased to at least {{ (_used_cpu | int + _required_cpu | int) | ansible.builtin.human_readable }},
+          currently {{ _hard_cpu  | int | ansible.builtin.human_readable }}
+    
+    - name: Check if quota allows to requested storage
+      ansible.builtin.assert:
+        that:
+          - (_used_storage | int + _required_storage | int) <  _hard_storage | int
+        fail_msg: >-
+          storage quota has to be increased to at least {{ (_used_storage | int + _required_storage | int) | ansible.builtin.human_readable }},
+          currently {{ _hard_storage  | int | ansible.builtin.human_readable }}

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
@@ -14,10 +14,10 @@
   ansible.builtin.set_fact:
     _required_memory:
       "{{ (_control_plane_memory_bytes | int  * master_instance_count | int) +
-         (_worker_plane_memory_bytes | int * worker_instance_count | int ) }}"
+         (_worker_plane_memory_bytes | int * worker_instance_count | int) }}"
     _required_cpu:
-      "{{ (ai_control_plane_cores | int * master_instance_count) +
-         (ai_workers_cores | int * worker_instance_count) }}"
+      "{{ (ai_control_plane_cores | int * master_instance_count | int) +
+         (ai_workers_cores | int * worker_instance_count | int) }}"
     _required_storage:
       "{{ (_control_plane_root_disk_bytes | int * master_instance_count | int) +
          (_control_plane_etcd_disk_bytes | int * master_instance_count | int) +

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
@@ -30,9 +30,6 @@
     api_version: "v1"
     namespace: "{{ ai_ocp_namespace }}"
     name: "sandbox-quota"
-- name: Print Quota information
-  ansible.builtin.debug:
-    msg: "{{ result.resources[0].status.used }}"
 
 - name: Set used variables and limit variables
   ansible.builtin.set_fact:
@@ -56,12 +53,26 @@
       "{{ result.resources[0].status.hard['requests.storage'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
             | ansible.builtin.human_to_bytes }}"
 
-- debug:
-    msg: "{{ _used_storage|int + _required_storage|int }}"
-
-- name: Check if quota allows to perform installation
+- name: Check if quota allows to requested memory
   ansible.builtin.assert:
     that:
       - (_used_memory|int + _required_memory|int) <  _hard_memory|int
+    fail_msg: >-
+      memory quota has to be increased to at least {{ (_used_memory|int + _required_memory|int) | ansible.builtin.human_readable }},
+      currently {{ _hard_memory  | int | ansible.builtin.human_readable }}
+
+- name: Check if quota allows to requested cpu
+  ansible.builtin.assert:
+    that:
       - (_used_cpu|int + _required_cpu|int) <  _hard_cpu|int
+    fail_msg: >-
+      cpu quota has to be increased to at least {{ (_used_cpu|int + _required_cpu|int) | ansible.builtin.human_readable }},
+      currently {{ _hard_cpu  | int | ansible.builtin.human_readable }}
+
+- name: Check if quota allows to requested storage
+  ansible.builtin.assert:
+    that:
       - (_used_storage|int + _required_storage|int) <  _hard_storage|int
+    fail_msg: >-
+      storage quota has to be increased to at least {{ (_used_storage|int + _required_storage|int) | ansible.builtin.human_readable }},
+      currently {{ _hard_storage  | int | ansible.builtin.human_readable }}

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
@@ -12,16 +12,16 @@
 
 - name: Calculate required cpu/memory/storage
   ansible.builtin.set_fact:
-    _required_memory: >-
-      {{ (_control_plane_memory_bytes | int  * master_instance_count | int) +
-         (_worker_plane_memory_bytes | int * worker_instance_count | int ) }}
-    _required_cpu: >-
-      {{ (ai_control_plane_cores | int * master_instance_count) +
-         (ai_workers_cores | int * worker_instance_count) }}
-    _required_storage: >-
-      {{ (_control_plane_root_disk_bytes | int * master_instance_count | int) +
+    _required_memory:
+      "{{ (_control_plane_memory_bytes | int  * master_instance_count | int) +
+         (_worker_plane_memory_bytes | int * worker_instance_count | int ) }}"
+    _required_cpu:
+      "{{ (ai_control_plane_cores | int * master_instance_count) +
+         (ai_workers_cores | int * worker_instance_count) }}"
+    _required_storage:
+      "{{ (_control_plane_root_disk_bytes | int * master_instance_count | int) +
          (_control_plane_etcd_disk_bytes | int * master_instance_count | int) +
-         (_worker_plane_root_disk_bytes | int * worker_instance_count | int) }}
+         (_worker_plane_root_disk_bytes | int * worker_instance_count | int) }}"
 
 - name: Get Quota information
   register: result

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/check_namespace_quota.yaml
@@ -1,0 +1,67 @@
+- ansible.builtin.set_fact:
+    _control_plane_memory_bytes:
+      "{{ ai_control_plane_memory | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+    _worker_plane_memory_bytes:
+      "{{ ai_workers_memory | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+    _control_plane_root_disk_bytes:
+      "{{ ai_control_plane_root_disk_size | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+    _control_plane_etcd_disk_bytes:
+      "{{ ai_control_plane_etcd_disk_size | ansible.builtin.regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+    _worker_plane_root_disk_bytes: 
+      "{{ ai_workers_root_disk_size | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2') | ansible.builtin.human_to_bytes }}"
+
+- name: Calculate required cpu/memory/storage
+  ansible.builtin.set_fact:
+    _required_memory: >-
+      {{ (_control_plane_memory_bytes | int  * master_instance_count | int) +
+         (_worker_plane_memory_bytes | int * worker_instance_count | int ) }}
+    _required_cpu: >-
+      {{ (ai_control_plane_cores | int * master_instance_count) +
+         (ai_workers_cores | int * worker_instance_count) }}
+    _required_storage: >-
+      {{ (_control_plane_root_disk_bytes | int * master_instance_count | int) +
+         (_control_plane_etcd_disk_bytes | int * master_instance_count | int) +
+         (_worker_plane_root_disk_bytes | int * worker_instance_count | int) }}
+
+- name: Get Quota information
+  register: result
+  kubernetes.core.k8s_info:
+    kind: "ResourceQuota"
+    api_version: "v1"
+    namespace: "{{ ai_ocp_namespace }}"
+    name: "sandbox-quota"
+- name: Print Quota information
+  ansible.builtin.debug:
+    msg: "{{ result.resources[0].status.used }}"
+
+- name: Set used variables and limit variables
+  ansible.builtin.set_fact:
+    _used_memory:
+      "{{ result.resources[0].status.used['limits.memory'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+          | ansible.builtin.human_to_bytes }}"
+    _used_cpu:
+      "{{ (result.resources[0].status.used['limits.cpu'] | default(0) | regex_replace('^(m)?$', '') | int) / 1000  | int}}"
+    _used_storage:
+      "{{ result.resources[0].status.used['requests.storage'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+            | ansible.builtin.human_to_bytes }}"
+
+- name: Set hard quota variables and limit variables
+  ansible.builtin.set_fact:
+    _hard_memory:
+      "{{ result.resources[0].status.hard['limits.memory'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+          | ansible.builtin.human_to_bytes }}"
+    _hard_cpu:
+      "{{ result.resources[0].status.hard['limits.cpu'] | default(0) | regex_replace('^(m)?$', '') | int }}"
+    _hard_storage:
+      "{{ result.resources[0].status.hard['requests.storage'] | default(0) | regex_replace('^([0-9.]+)([KMGTP])i?B?$', '\\1 \\2')
+            | ansible.builtin.human_to_bytes }}"
+
+- debug:
+    msg: "{{ _used_storage|int + _required_storage|int }}"
+
+- name: Check if quota allows to perform installation
+  ansible.builtin.assert:
+    that:
+      - (_used_memory|int + _required_memory|int) <  _hard_memory|int
+      - (_used_cpu|int + _required_cpu|int) <  _hard_cpu|int
+      - (_used_storage|int + _required_storage|int) <  _hard_storage|int

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -55,6 +55,9 @@
       validate_certs: false
 
   block:
+    - name: Check if the quota in the namespace allows install OCP
+      ansible.builtin.include_tasks: check_namespace_quota.yaml
+  
     - name: Configure a SNO cluster
       when: worker_instance_count | int == 0
       block:


### PR DESCRIPTION
##### SUMMARY

To avoid errors related to Quota, check if there is enough Quota for create the environment on the namespace.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
