### PR TITLE
trident-binder: import from v2

### DIFF
--- a/ansible/configs/trident-binder/default_vars.yml
+++ b/ansible/configs/trident-binder/default_vars.yml
@@ -1,0 +1,37 @@
+---
+workloads: []
+
+ocp_dr_trident_starting_csv: "trident-operator.v25.6.2"
+ocp_dr_trident_operator_channel: "stable"
+ocp_dr_trident_helm_chart_version: "100.2506.0"
+
+ocp_dr_trident_first_rosa_cidr: "10.0.0.0/16"
+ocp_dr_trident_second_rosa_name: "dr-{{ guid }}"
+ocp_dr_trident_second_rosa_cidr: "10.10.0.0/16"
+ocp_dr_trident_second_rosa_compute_replicas: 2
+ocp_dr_trident_second_rosa_version: "4.16.37"
+
+ocp_dr_trident_second_rosa_binary_path: "/usr/local/bin"
+ocp_dr_trident_second_rosa_installer_version: latest
+ocp_dr_trident_second_rosa_installer_url: >-
+  https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/rosa/{{ rosa_installer_version }}/rosa-linux.tar.gz
+
+ocp_dr_trident_bastion_cidr: "192.168.0.0/16"
+
+ocp_dr_trident_fsx_name1: PROD-FSXONTAP
+ocp_dr_trident_fsx_name2: DR-FSXONTAP
+
+ocp_dr_trident_fsx_storage_vm_name1: SVM1
+ocp_dr_trident_fsx_storage_vm_name2: SVM2
+
+ocp_dr_trident_policy_name1: ProdTridentIAMPolicy
+ocp_dr_trident_policy_name2: DRTridentIAMPolicy
+
+# Passwords will be generated.
+# If hardcoding: Passwords must be between 8 and 128 characters in length, must contain at least one English letter
+#                and one number, and must not contain the word 'admin'.
+ocp_dr_trident_fsx_admin_password: ""
+ocp_dr_trident_svm_admin_password: ""
+
+# Name of the S3 Bucket to be created
+ocp4_workload_dr_trident_s3_bucket_name: "bucket-{{ guid }}"

--- a/ansible/configs/trident-binder/destroy_env.yml
+++ b/ansible/configs/trident-binder/destroy_env.yml
@@ -1,0 +1,10 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Print stage message
+    ansible.builtin.debug:
+      msg: "Step 007 Destroy"

--- a/ansible/configs/trident-binder/files/FSxONTAP.yml
+++ b/ansible/configs/trident-binder/files/FSxONTAP.yml
@@ -1,0 +1,309 @@
+#yamllint disable-file
+AWSTemplateFormatVersion: '2010-09-09'
+Description: This template creates Amazon FSx for NetApp ONTAP file system into private subnets in separate Availability Zones
+  inside a VPC *WARNING**
+  This template creates Amazon resources. You will be billed for the AWS resources used if you create a stack from this template.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Network configuration
+        Parameters:
+          - Subnet1ID
+          - myVpc
+      - Label:
+          default: Configurations for FSx ONTAP File System
+        Parameters:
+          - FileSystemName
+          - StorageVMName
+          - StorageCapacity
+          - ThroughputCapacity
+          - FSxAllowedCIDR
+          - WeeklyMaintenanceTime
+          - FsxAdminPassword
+          - WeeklyMaintenanceTime
+          - TridentIAMPolicyName
+      - Label:
+          default: Storage Virtual Machine configurations
+        Parameters:
+          - RootVolumeSecurityStyle
+          - SvmAdminPassword
+
+    ParameterLabels:
+      myVpc:
+        default: VPC ID
+      Subnet1ID:
+        default: Private Subent 1 ID
+      FileSystemName:
+        default: Name of your File System
+      StorageVMName:
+        default: Name of your Storage VM
+      StorageCapacity:
+        default: Storage size
+      ThroughputCapacity:
+        default: Throughput capacity of Amazon FSx file system
+      FSxAllowedCIDR:
+        default: CIDR range allowed to connect to Amazon FSx file system
+      WeeklyMaintenanceTime:
+        default: Weekly Maintenance Time
+      FsxAdminPassword:
+        default: Admin password for managing FSx file system
+      RootVolumeSecurityStyle:
+        default: The security style of the root volume of the SVM
+      SvmAdminPassword:
+        default: Password for managing SVM in your FSxONTAP File System
+      TridentIAMPolicyName:
+        default: The name of the security policy to create
+
+Parameters:
+  FileSystemName:
+    Description: Specify a name for your file system to make it easier to find and manage.
+    Type: String
+  StorageVMName:
+    Description: Specify a name for your Storage VM
+    Type: String
+  myVpc:
+    Description: Choose the VPC to which you want to deploy the FSxONTAP cluster
+    Type: AWS::EC2::VPC::Id
+  Subnet1ID:
+    Description: Choose the first Subnet where FSxONTAP file system's network interface will be created
+    Type: AWS::EC2::Subnet::Id
+  StorageCapacity:
+    Default: 1024
+    Description: Specify the storage capacity of the file system being created, in gibibytes. Minimum 1024 GiB; Maximum 192 TiB.
+    Type: Number
+  FSxAllowedCIDR:
+    #AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$
+    #ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/16-28
+    Description: Specify the CIDR block that is allowed access to FSx for Windows File Server.
+    Type: String
+  ThroughputCapacity:
+    Description: Sets the throughput capacity for the file system that you're creating. Valid values are 512, 1024, and 2048 MBps.
+    ConstraintDescription: Valid values are 512, 1024, and 2048 MBps.
+    AllowedValues: [512, 1024, 2048]
+    Type: Number
+  WeeklyMaintenanceTime:
+     Description: Specify the preferred start time to perform weekly maintenance, formatted d:HH:MM in the UTC time zone
+     Default: '7:01:00'
+     Type: String
+  FsxAdminPassword:
+     NoEcho: true
+     Description: Password for this file system's “fsxadmin“ user, which you can use to access the ONTAP CLI or REST API.
+     Type: String
+     MinLength: 5
+     MaxLength: 40
+     AllowedPattern: ^[a-zA-Z0-9]*$
+  RootVolumeSecurityStyle:
+     Description: The security style of the root volume of the SVM. Specify one of the following values, UNIX, NTFS or MIXED.
+     Type: String
+     Default: UNIX
+     AllowedValues: ["UNIX", "NTFS", "MIXED"]
+  SvmAdminPassword:
+     NoEcho: true
+     Description: The password to use when managing the SVM using the NetApp ONTAP CLI or REST API. If you do not specify a password, you can still use the file system's vsadmin user to manage the SVM.
+     Type: String
+     MinLength: 5
+     MaxLength: 40
+     AllowedPattern: ^[a-zA-Z0-9]*$
+  TridentIAMPolicyName:
+     Description: The name of the security policy to create
+     Type: String
+     Default: 'TridentIAMPolicy'
+
+Resources:
+  FSxONTAPSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId: !Ref myVpc
+      GroupDescription: Security Group for FSx for Windows File Storage Access
+      SecurityGroupIngress:
+        - IpProtocol: icmp
+          FromPort: -1
+          ToPort: -1
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 111
+          ToPort: 111
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 135
+          ToPort: 135
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 139
+          ToPort: 139
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 161
+          ToPort: 161
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 162
+          ToPort: 162
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 445
+          ToPort: 445
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 635
+          ToPort: 635
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 749
+          ToPort: 749
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 2049
+          ToPort: 2049
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 3260
+          ToPort: 3260
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 4045
+          ToPort: 4045
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 4046
+          ToPort: 4046
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 11104
+          ToPort: 11104
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: tcp
+          FromPort: 11105
+          ToPort: 11105
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 111
+          ToPort: 111
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 135
+          ToPort: 135
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 137
+          ToPort: 137
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 139
+          ToPort: 139
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 161
+          ToPort: 161
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 162
+          ToPort: 162
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 635
+          ToPort: 635
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 2049
+          ToPort: 2049
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 4045
+          ToPort: 4045
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 4046
+          ToPort: 4046
+          CidrIp: !Ref FSxAllowedCIDR
+        - IpProtocol: udp
+          FromPort: 4049
+          ToPort: 4049
+          CidrIp: !Ref FSxAllowedCIDR
+  FSxONTAP:
+    Type: AWS::FSx::FileSystem
+    Properties:
+      FileSystemType: ONTAP
+      StorageCapacity: !Ref StorageCapacity
+      StorageType: SSD
+      SecurityGroupIds:
+        - !GetAtt FSxONTAPSecurityGroup.GroupId
+      SubnetIds:
+        - !Ref Subnet1ID
+      OntapConfiguration:
+        AutomaticBackupRetentionDays: 3
+        DailyAutomaticBackupStartTime: "01:00"
+        DeploymentType: SINGLE_AZ_1
+        DiskIopsConfiguration:
+          Mode: AUTOMATIC
+        ThroughputCapacity: !Ref ThroughputCapacity
+        WeeklyMaintenanceStartTime: !Ref WeeklyMaintenanceTime
+        FsxAdminPassword: !Ref FsxAdminPassword
+      Tags:
+        - Key: "Name"
+          Value: "OntapFileSystem_SAZ"
+  FSxStorageVM:
+    Type: AWS::FSx::StorageVirtualMachine
+    DependsOn: FSxONTAP
+    Properties:
+      FileSystemId: !Ref FSxONTAP
+      Name: !Ref StorageVMName
+      RootVolumeSecurityStyle: !Ref RootVolumeSecurityStyle
+      SvmAdminPassword: !Ref SvmAdminPassword
+  ## Secret Manager
+  SMFsxAdminPassword:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: FsxAdminPassword
+      Name: !Sub "${AWS::StackName}-FsxAdminPassword"
+      SecretString: !Sub '{"username":"fsxadmin","password":"${FsxAdminPassword}"}'
+      Tags:
+        - Key: "Name"
+          Value: "OntapFileSystem_MAZ"
+  SMSVMAdminPassword:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: SVMAdminPassword
+      Name: !Sub "${AWS::StackName}-SVMAdminPassword"
+      SecretString: !Sub '{"username":"vsadmin","password":"${SvmAdminPassword}"}'
+      Tags:
+        - Key: "Name"
+          Value: "OntapFileSystem_SAZ"
+  ## Create IAM Role and Policy to be able to retrieve Secrets Manager
+  SecretsManagerIAMPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Ref TridentIAMPolicyName
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'secretsmanager:GetSecretValue'
+              - 'secretsmanager:DescribeSecret'
+            Resource:
+              - !Ref SMFsxAdminPassword
+              - !Ref SMSVMAdminPassword
+Outputs:
+  FSxFileSystemID:
+    Description: File System ID for FSx for NetAPP ONTAP
+    Value: !Ref FSxONTAP
+  SMFSxSecretManager:
+    Description: Secret Manager ARN for FSx for NetAPP ONTAP
+    Value: !Ref SMFsxAdminPassword
+  SMSVMSecretManager:
+    Description: Secret Manager ARN for FSx for NetAPP ONTAP Storage Virtual Machine (SVM)
+    Value: !Ref SMSVMAdminPassword
+  SecretsManagerIAMPolicyARN:
+    Description: Trident IAM Policy ARN for Trident Backend Configuration IAM Role for Service Account
+    Value: !Ref SecretsManagerIAMPolicy

--- a/ansible/configs/trident-binder/lifecycle.yml
+++ b/ansible/configs/trident-binder/lifecycle.yml
@@ -1,0 +1,29 @@
+---
+- name: Build inventory
+  ansible.builtin.import_playbook: post_infra.yml
+
+- name: Destroy workload(s)
+  hosts: ocp_bastions
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Fail
+    ansible.builtin.fail:
+      msg: This is not working as designed. Needs to implement start/stop
+
+  - name: Fail if no action defined
+    when: ACTION is not defined or ACTION == ''
+    ansible.builtin.fail:
+      msg: ACTION must be defined
+
+  - name: Set facts for OpenShift cluster(s)
+    ansible.builtin.include_tasks: set_cluster_facts.yml
+
+  - name: Run Workloads to perform {{ ACTION }}
+    vars:
+      ACTION: destroy
+    ansible.builtin.include_tasks: run_workload_on_clusters.yml
+    loop: "{{ cluster_workloads }}"
+    loop_control:
+      loop_var: __workload
+      label: "{{ __workload.name }}"

--- a/ansible/configs/trident-binder/post_infra.yml
+++ b/ansible/configs/trident-binder/post_infra.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 002 Post Infrastructure
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Print stage message
+    ansible.builtin.debug:
+      msg: "Step 002 Post-Infrastructure"

--- a/ansible/configs/trident-binder/post_software.yml
+++ b/ansible/configs/trident-binder/post_software.yml
@@ -1,0 +1,40 @@
+---
+- name: Step 005 Post Software
+  hosts: localhost
+  connection: local
+  become: false
+  vars:
+    ansible_async_dir: "/home/runner/.ansible_async"
+  # environment:
+  #   # Dynamically extract the directory path from the job's results_file
+  #   ANSIBLE_ASYNC_DIR: "/home/runner/.ansible_async"
+  gather_facts: false
+  tasks:
+  - name: Print stage message
+    ansible.builtin.debug:
+      msg: "Step 005 Post-Software"
+
+  # Add bastion host to allow access to the FSxN cluster
+  - name: Add trident_one bastion host to inventory
+    ansible.builtin.add_host:
+      name: trident_bastion
+      ansible_ssh_common_args: '-F /dev/null -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null'
+      ansible_connection: ssh
+      ansible_host: "{{ trident_one.bastion_public_hostname }}"
+      ansible_ssh_user: "{{ trident_one.bastion_ssh_user_name }}"
+      ansible_ssh_pass: "{{ trident_one.bastion_ssh_password }}"
+
+  - name: Set up S3 Bucket
+    ansible.builtin.include_tasks: setup_s3_bucket.yml
+
+  - name: Set up FSxONTAP
+    ansible.builtin.include_tasks: setup_fsxontap.yml
+
+  - name: Set up FSxONTAP post install configuration
+    ansible.builtin.include_tasks: setup_fsxontap_post_config.yml
+
+  - name: Create AWS credentials profiles on trident-one bastion
+    ansible.builtin.include_tasks: setup_aws_profiles.yml
+
+  - name: Deploy Showroom
+    ansible.builtin.include_tasks: setup_showroom.yml

--- a/ansible/configs/trident-binder/pre_infra.yml
+++ b/ansible/configs/trident-binder/pre_infra.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 000 Pre Infrastructure
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Print stage message
+    ansible.builtin.debug:
+      msg: "Step 000 Pre-Infrastructure"

--- a/ansible/configs/trident-binder/pre_software.yml
+++ b/ansible/configs/trident-binder/pre_software.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 003 Pre Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Print stage message
+    ansible.builtin.debug:
+      msg: "Step 003 Pre-Software"

--- a/ansible/configs/trident-binder/readme.adoc
+++ b/ansible/configs/trident-binder/readme.adoc
@@ -1,0 +1,166 @@
+:toc2:
+
+= Deploy OpenShift workloads to a cluster or clusters
+
+This config is used to run OpenShift workloads on a single cluster or a list of clusters.
+
+It is a config like any other agnosticd config and allows integration of this particular kind of deployment into our eco-system.
+
+It can access a single or multiple clusters by direct connection the the cluster apis.
+
+== Create
+
+.Example: `using-bastion.yml`
+[source,yaml]
+----
+cloud_provider: none
+config: ocp-workloads
+
+openshift_workloads:
+- ocp4-workload-fuse-ignite
+
+target_host: bastion.dev.mycluster.mydomain.com
+
+#become_override: false
+
+# If the ocp-workload supports it, you should specify the OCP user:
+# ocp_username: myuser
+
+# Usually the ocp-workloads want a GUID also:
+# guid: changeme
+----
+
+.Example: `multicluster-bastion.yml`
+----
+cloud_provider: none
+guid: changeme
+config: ocp-workloads
+
+cluster_workloads:
+- name: ocp4_workload_authentication
+  clusters:
+  - openshift_app
+  - openshift_db
+- name: ocp4_workload_mitzi_app
+  clusters:
+  - openshift_app
+- name: ocp4_workload_mitzi_db
+  clusters:
+  - openshift_db
+
+openshift_app:
+  api_ca_cert: ...
+  api_key: ...
+  api_url: ...
+  ocp4_workload_authentication_htpasswd_user_name: app-user
+
+openshift_db:
+  api_ca_cert: ...
+  api_key: ...
+  api_url: ...
+  ocp4_workload_authentication_htpasswd_user_name: db-user
+
+ocp4_workload_authentication_idm_type: htpasswd
+ocp4_workload_authentication_htpasswd_user_count: 1
+----
+
+
+.Run
+[source,shell]
+----
+cd agnosticd/ansible
+ansible-playbook main.yml -e @vars.yml
+----
+
+== Delete
+
+Just run the following:
+
+[source,shell]
+----
+cd agnosticd/ansible
+ansible-playbook destroy.yml -e @vars.yml
+----
+
+It will run the ocp-workload role with `ACTION=destroy`.
+
+
+== Lifecycle
+
+The link:../../lifecycle_entry_point.yml[`lifecycle_entry_point.yml`] playbook can be used as well.
+
+It will just run the workload passing the `ACTION` variable. Just make sure  to implement the action `stop`, `start`, `status` in the ocp-workloads.
+
+== `cluster_workloads` variable
+
+This variable allows configuration to run workloads across multiple clusters.
+This feature is currently only supported with direct connection from localhost.
+
+The `cluster_workloads` array must specify target `clusters` whose names correspond to variables than hold connection configuration for the cluster as shown in the example above.
+
+Cluster specific workload variables may be passed within the cluster variables.
+Variables must follow the convention of beginning with the workload name
+followed by an underscore and not be set at the top-level as the `set_fact` call
+used to pass the variable to the workload cannot override a variable passed with
+Ansible extra vars.
+
+== `target_host` variable
+
+This variable correspond to run workloads on a single cluster using a bastion host to run `oc` commands or `k8s` type ansible tasks.
+
+You can specify the target host in three different ways.
+
+=== As localhost
+
+[source,yaml]
+----
+target_host: localhost
+----
+
+This will execute the workload from localhost.
+It requires that whatever host the playbook is run from is authenticated to the OpenShift cluster.
+
+=== As an hostname
+
+If you want to just specify:
+
+[source,yaml]
+----
+target_host: bastion.dev.mycluster.mydomain.com
+----
+
+Then you need to configure ssh properly to be able to connect to that host.
+Just make sure the command `ssh bastion.dev.mycluster.mydomain.com` works.
+
+=== As a dictionary
+
+You can specify the bastion host using a dictionary. This is useful is you need to specify the user, port, ssh_key to use, etc.
+
+[source,yaml]
+----
+target_host:
+  ansible_host: bastion.babydev.babylon.open.redhat.com
+  ansible_port: 22
+  ansible_user: ec2-user
+  #ansible_ssh_private_key_content: "{{ ssh_private_key_content }}"
+  ansible_ssh_private_key_file: ~/.ssh/admin_key.pem
+  #ansible_ssh_extra_args:  ...
+----
+
+NOTE: you can add the `ansible_ssh_private_key_content` to a secret file or a vault. The config will create the key using that content in the directory `output_dir/` and use it to connect to the bastion. The key will then be deleted when the playbook ends, see link:cleanup.yml[`cleanup.yml`].
+
+
+== FAQ
+
+. But i want to run my workload as root on the bastion!
+
+Just use the var `become_override`. Set it to true in your var file. Most ocp-workloads implement that variable.
+
+.extract of `main.yml` in ocp-workload
+[source,yaml]
+----
+- name: Running Workload Tasks
+  import_tasks: ./workload.yml
+  become: "{{ become_override | bool }}"
+  when: ACTION == "create" or ACTION == "provision"
+----

--- a/ansible/configs/trident-binder/setup_aws_profiles.yml
+++ b/ansible/configs/trident-binder/setup_aws_profiles.yml
@@ -1,0 +1,15 @@
+- name: Use block-in-file to create AWS credentials profiles on trident-one bastion
+  delegate_to: trident_bastion
+  ansible.builtin.blockinfile:
+    path: /home/rosa/.aws/credentials
+    insertafter: "EOF"
+    marker: "# {mark} trident protect cluster prod and dr profiles"
+    block: |
+      [prod]
+      aws_access_key_id={{ trident_one.aws_access_key_id }}
+      aws_secret_access_key={{ trident_one.aws_secret_access_key }}
+      region={{ trident_one.aws_default_region }}
+      [dr]
+      aws_access_key_id={{ trident_two.aws_access_key_id }}
+      aws_secret_access_key={{ trident_two.aws_secret_access_key }}
+      region={{ trident_two.aws_default_region }}

--- a/ansible/configs/trident-binder/setup_fsxontap.yml
+++ b/ansible/configs/trident-binder/setup_fsxontap.yml
@@ -1,0 +1,203 @@
+---
+- name: Generate fsx admin password and make sure it contains numbers
+  when: ocp_dr_trident_fsx_admin_password | default('') | length == 0
+  block:
+  - name: Generate password components
+    ansible.builtin.set_fact:
+      password_fsx_admin_lower: "{{ lookup('ansible.builtin.password', '/dev/null', length=8, chars='ascii_lowercase') }}"
+      password_fsx_admin_upper: "{{ lookup('ansible.builtin.password', '/dev/null', length=4, chars='ascii_uppercase') }}"
+      password_fsx_admin_digits: "{{ lookup('ansible.builtin.password', '/dev/null', length=3, chars='digits') }}"
+
+  - name: Combine and shuffle password components
+    ansible.builtin.set_fact:
+      password_fsx_admin_combined: >-
+        {{ (password_fsx_admin_upper + password_fsx_admin_lower + password_fsx_admin_digits) | shuffle | join('') }}
+
+  - name: Ensure the first character is not a digit
+    ansible.builtin.set_fact:
+      _ocp_dr_trident_fsx_admin_password_tmp: >-
+        {% if password_fsx_admin_combined[0].isdigit() %}
+        {{ (password_fsx_admin_combined[1:] + password_fsx_admin_combined[0]) }}
+        {% else %}
+        {{ password_fsx_admin_combined }}
+        {% endif %}
+
+  - name: Trim fsx password
+    ansible.builtin.set_fact:
+      _ocp_dr_trident_fsx_admin_password: "{{ _ocp_dr_trident_fsx_admin_password_tmp | trim }}"
+
+  - name: Debug the generated fsx admin password
+    ansible.builtin.debug:
+      msg: "Generated Password: '{{ _ocp_dr_trident_fsx_admin_password }}'"
+
+- name: Use provided fsx admin password
+  when: ocp_dr_trident_fsx_admin_password | default('') | length > 0
+  ansible.builtin.set_fact:
+    _ocp_dr_trident_fsx_admin_password: >-
+      {{ ocp_dr_trident_fsx_admin_password | trim }}
+
+- name: Generate svm admin password and make sure it contains numbers
+  when: ocp_dr_trident_svm_admin_password | default('') | length == 0
+  block:
+  - name: Generate password components
+    ansible.builtin.set_fact:
+      password_svm_admin_lower: "{{ lookup('ansible.builtin.password', '/dev/null', length=8, chars='ascii_lowercase') }}"
+      password_svm_admin_upper: "{{ lookup('ansible.builtin.password', '/dev/null', length=4, chars='ascii_uppercase') }}"
+      password_svm_admin_digits: "{{ lookup('ansible.builtin.password', '/dev/null', length=3, chars='digits') }}"
+
+  - name: Combine and shuffle password components
+    ansible.builtin.set_fact:
+      password_svm_admin_combined: >-
+        {{ (password_svm_admin_upper + password_svm_admin_lower + password_svm_admin_digits) | shuffle | join('') }}
+
+  - name: Ensure the first character is not a digit
+    ansible.builtin.set_fact:
+      _ocp_dr_trident_svm_admin_password_tmp: >-
+        {% if password_svm_admin_combined[0].isdigit() %}
+        {{ (password_svm_admin_combined[1:] + password_svm_admin_combined[0]) }}
+        {% else %}
+        {{ password_svm_admin_combined }}
+        {% endif %}
+
+  - name: Trim svm password
+    ansible.builtin.set_fact:
+      _ocp_dr_trident_svm_admin_password: "{{ _ocp_dr_trident_svm_admin_password_tmp | trim }}"
+
+  - name: Debug the generated svm admin password
+    ansible.builtin.debug:
+      msg: "Generated Password: '{{ _ocp_dr_trident_svm_admin_password }}'"
+
+- name: Use provided svm admin password
+  when: ocp_dr_trident_svm_admin_password | default('') | length > 0
+  ansible.builtin.set_fact:
+    _ocp_dr_trident_svm_admin_password: >-
+      {{ ocp_dr_trident_svm_admin_password | trim }}
+
+- name: Get subnet ID for first ROSA cluster
+  amazon.aws.ec2_vpc_subnet_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      # ROSA Classic is /18, ROSA HCP is /24
+      cidr-block: "{{ ocp_dr_trident_one_rosa_cidr | replace('/16', '/24') }}"
+  register: r_subnet_rosa1
+
+- name: Get subnet ID for second ROSA cluster
+  amazon.aws.ec2_vpc_subnet_info:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    filters:
+      # ROSA Classic is /18, ROSA HCP is /24
+      cidr-block: "{{ ocp_dr_trident_two_rosa_cidr | replace('/16', '/24') }}"
+  register: r_subnet_rosa2
+
+- name: Get VPC ID for first ROSA cluster
+  amazon.aws.ec2_vpc_subnet_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      # ROSA Classic is /18, ROSA HCP is /24
+      # cidr-block: "{{ ocp_dr_trident_first_rosa_cidr | regex_replace('/16', '/18') }}"
+      cidr-block: "{{ ocp_dr_trident_one_rosa_cidr | regex_replace('/16', '/24') }}"
+  register: r_vpc_rosa1
+
+- name: Get VPC ID for second ROSA cluster
+  amazon.aws.ec2_vpc_subnet_info:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    filters:
+      # cidr-block: "{{ ocp_dr_trident_two_rosa_cidr | regex_replace('/16', '/18') }}"
+      cidr-block: "{{ ocp_dr_trident_two_rosa_cidr | regex_replace('/16', '/24') }}"
+  register: r_vpc_rosa2
+
+- name: Set facts about subnet IDs and vpc IDs
+  ansible.builtin.set_fact:
+    subnet_id_rosa1: "{{ r_subnet_rosa1.subnets[0].subnet_id }}"
+    subnet_id_rosa2: "{{ r_subnet_rosa2.subnets[0].subnet_id }}"
+    vpc_id_rosa1: "{{ r_vpc_rosa1.subnets[0].vpc_id }}"
+    vpc_id_rosa2: "{{ r_vpc_rosa2.subnets[0].vpc_id }}"
+
+- name: Print Subnet and VPC IDs
+  ansible.builtin.debug:
+    msg: "{{ item }}"
+  loop:
+  - "Rosa 1 Subnet ID: {{ subnet_id_rosa1 }}, VPC ID: {{ vpc_id_rosa1 }}"
+  - "Rosa 2 Subnet ID: {{ subnet_id_rosa2 }}, VPC ID: {{ vpc_id_rosa2 }}"
+
+# takes about 20 minutes - runs in parallel with the next
+- name: Create first FSx ONTAP stack
+  amazon.aws.cloudformation:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    stack_name: "{{ ocp_dr_trident_fsx_name1 }}"
+    region: "{{ trident_one.aws_default_region }}"
+    template_body: "{{ lookup('ansible.builtin.file', 'FSxONTAP.yml') }}"
+    disable_rollback: true
+    capabilities: CAPABILITY_NAMED_IAM
+    template_parameters:
+      Subnet1ID: "{{ subnet_id_rosa1 }}"
+      myVpc: "{{ vpc_id_rosa1 }}"
+      FileSystemName: "{{ ocp_dr_trident_fsx_name1 }}"
+      StorageVMName: "{{ ocp_dr_trident_fsx_storage_vm_name1 }}"
+      ThroughputCapacity: 512
+      FSxAllowedCIDR: "{{ ocp_dr_trident_first_rosa_cidr }}"
+      FsxAdminPassword: "{{ _ocp_dr_trident_fsx_admin_password }}"
+      SvmAdminPassword: "{{ _ocp_dr_trident_svm_admin_password }}"
+      TridentIAMPolicyName: "{{ ocp_dr_trident_policy_name1 }}"
+  async: 1800 # 30 minutes
+  poll: 0
+  register: r_cloudformation_rosa1
+
+# takes about 20 minutes
+- name: Create second FSx ONTAP stack
+  amazon.aws.cloudformation:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    stack_name: "{{ ocp_dr_trident_fsx_name2 }}"
+    region: "{{ trident_two.aws_default_region }}"
+    template_body: "{{ lookup('ansible.builtin.file', 'FSxONTAP.yml') }}"
+    disable_rollback: true
+    capabilities: CAPABILITY_NAMED_IAM
+    template_parameters:
+      Subnet1ID: "{{ subnet_id_rosa2 }}"
+      myVpc: "{{ vpc_id_rosa2 }}"
+      FileSystemName: "{{ ocp_dr_trident_fsx_name2 }}"
+      StorageVMName: "{{ ocp_dr_trident_fsx_storage_vm_name2 }}"
+      ThroughputCapacity: 512
+      FSxAllowedCIDR: "{{ ocp_dr_trident_second_rosa_cidr }}"
+      FsxAdminPassword: "{{ _ocp_dr_trident_fsx_admin_password }}"
+      SvmAdminPassword: "{{ _ocp_dr_trident_svm_admin_password }}"
+      TridentIAMPolicyName: "{{ ocp_dr_trident_policy_name2 }}"
+  async: 1800 # 30 minutes
+  poll: 0
+  register: r_cloudformation_rosa2
+
+- name: Check on an async FSx ONTAP task rosa1 - ENV
+  ansible.builtin.async_status:
+    jid: "{{ r_cloudformation_rosa1.ansible_job_id }}"
+  register:  r_cloudformation_rosa1_job_result
+  until:  r_cloudformation_rosa1_job_result.finished
+  retries: 180 # 30 minutes
+  delay: 10
+
+- name: Check on an async FSx ONTAP task rosa2 - ENV
+  ansible.builtin.async_status:
+    jid: "{{ r_cloudformation_rosa2.ansible_job_id }}"
+  register: r_cloudformation_rosa2_job_result2
+  until: r_cloudformation_rosa2_job_result2.finished
+  retries: 180 # 30 minutes
+  delay: 10
+
+- name: Save AgnosticD ROSA user data
+  agnosticd_user_info:
+    data:
+      fsxontap_name1: "{{ ocp_dr_trident_fsx_name1 }}"
+      fsxontap_name2: "{{ ocp_dr_trident_fsx_name2 }}"
+      fsxontap_storagevm_name1: "{{ ocp_dr_trident_fsx_storage_vm_name1 }}"
+      fsxontap_storagevm_name2: "{{ ocp_dr_trident_fsx_storage_vm_name2 }}"
+      fsx_admin_password: "{{ _ocp_dr_trident_fsx_admin_password }}"
+      svm_admin_password: "{{ _ocp_dr_trident_svm_admin_password }}"

--- a/ansible/configs/trident-binder/setup_fsxontap_post_config.yml
+++ b/ansible/configs/trident-binder/setup_fsxontap_post_config.yml
@@ -1,0 +1,668 @@
+---
+- name: Get Prod VPC
+  amazon.aws.ec2_vpc_net_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      "cidr": "{{ ocp_dr_trident_first_rosa_cidr }}"
+  register: prod_vpc
+
+- name: Get DR VPC
+  amazon.aws.ec2_vpc_net_info:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    filters:
+      "cidr": "{{ ocp_dr_trident_second_rosa_cidr }}"
+  register: dr_vpc
+
+- name: Get Bastion VPC
+  amazon.aws.ec2_vpc_net_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      "cidr": "{{ ocp_dr_trident_bastion_cidr }}"
+  register: bastion_vpc
+
+- name: Create cross account EC2 VPC Peering Connection
+  amazon.aws.ec2_vpc_peering:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    vpc_id: "{{ prod_vpc.vpcs[0].vpc_id }}"
+    peer_vpc_id: "{{ dr_vpc.vpcs[0].vpc_id }}"
+    peer_owner_id: "{{ trident_two.aws_sandbox_account_id }}"
+    state: "present"
+  register: vpc_peering
+
+- name: Accept EC2 VPC Peering Connection from remote account
+  amazon.aws.ec2_vpc_peering:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    peering_id: "{{ vpc_peering.peering_id }}"
+    state: "accept"
+  register: peering_accept
+
+# - name: Create VPC Peering Connection between ROSA VPCs
+#   amazon.aws.ec2_vpc_peering:
+#     access_key: "{{ trident_one.aws_access_key_id }}"
+#     secret_key: "{{ trident_one.aws_secret_access_key }}"
+#     region: "{{ trident_one.aws_default_region }}"
+#     vpc_id: "{{ prod_vpc.vpcs[0].vpc_id }}"
+#     peer_vpc_id: "{{ dr_vpc.vpcs[0].vpc_id }}"
+#   register: vpc_peering
+#
+# - name: Accept VPC Peering request for ROSA VPCs
+#   amazon.aws.ec2_vpc_peering:
+#     access_key: "{{ aws_access_key_id }}"
+#     secret_key: "{{ aws_secret_access_key }}"
+#     region: "{{ region }}"
+#     peering_id: "{{ vpc_peering.peering_id }}"
+#     state: "accept"
+#   register: peering_accept
+
+- name: Create VPC Peering Connection between Bastion and Prod FSxN (for Ontap API access in further automation)
+  amazon.aws.ec2_vpc_peering:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    vpc_id: "{{ bastion_vpc.vpcs[0].vpc_id }}"
+    peer_vpc_id: "{{ prod_vpc.vpcs[0].vpc_id }}"
+  register: vpc_peering_bastion1
+
+- name: Accept VPC Peering request between Bastion and Prod FSxN (for Ontap API access in further automation)
+  amazon.aws.ec2_vpc_peering:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    peering_id: "{{ vpc_peering_bastion1.peering_id }}"
+    state: "accept"
+  register: peering_accept_bastion1
+
+- name: Create VPC Peering Connection between Bastion and DR FSxN (for Ontap API access in further automation)
+  amazon.aws.ec2_vpc_peering:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    vpc_id: "{{ bastion_vpc.vpcs[0].vpc_id }}"
+    peer_vpc_id: "{{ dr_vpc.vpcs[0].vpc_id }}"
+    peer_owner_id: "{{ trident_two.aws_sandbox_account_id }}"
+  register: vpc_peering_bastion2
+
+- name: Accept VPC Peering request between Bastion and DR FSxN (for Ontap API access in further automation)
+  amazon.aws.ec2_vpc_peering:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    peering_id: "{{ vpc_peering_bastion2.peering_id }}"
+    state: "accept"
+  register: peering_accept_bastion2
+
+- name: Get Prod private route table
+  amazon.aws.ec2_vpc_route_table_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      "tag:Name": "prod*private*"
+  register: prod_route
+
+- name: Get DR private route table
+  amazon.aws.ec2_vpc_route_table_info:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    filters:
+      "tag:Name": "dr*private*"
+  register: dr_route
+
+- name: Get bastion private route table
+  amazon.aws.ec2_vpc_route_table_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      "tag:Stack": "rosa-consolidated*"
+      vpc-id: "{{ bastion_vpc.vpcs[0].vpc_id }}"
+  register: bastion_route
+
+- name: Setup route tables for prod
+  amazon.aws.ec2_vpc_route_table:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    vpc_id: "{{ prod_vpc.vpcs[0].vpc_id }}"
+    lookup: id
+    purge_subnets: false
+    purge_routes: false
+    route_table_id: "{{ prod_route.route_tables[0].route_table_id }}"
+    routes:
+    - dest: "{{ ocp_dr_trident_second_rosa_cidr | default('10.10.0.0/16') }}"
+      vpc_peering_connection_id: "{{ vpc_peering.vpc_peering_connection.vpc_peering_connection_id }}"
+    - dest: 192.168.0.0/16
+      vpc_peering_connection_id: "{{ vpc_peering_bastion1.vpc_peering_connection.vpc_peering_connection_id }}"
+
+- name: Setup route tables for DR
+  amazon.aws.ec2_vpc_route_table:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    vpc_id: "{{ dr_vpc.vpcs[0].vpc_id }}"
+    lookup: id
+    purge_subnets: false
+    purge_routes: false
+    route_table_id: "{{ dr_route.route_tables[0].route_table_id }}"
+    routes:
+    - dest: "{{ ocp_dr_trident_first_rosa_cidr | default('10.0.0.0/16') }}"
+      vpc_peering_connection_id: "{{ vpc_peering.vpc_peering_connection.vpc_peering_connection_id }}"
+    - dest: 192.168.0.0/16
+      vpc_peering_connection_id: "{{ vpc_peering_bastion2.vpc_peering_connection.vpc_peering_connection_id }}"
+
+- name: Setup route tables for Bastion
+  amazon.aws.ec2_vpc_route_table:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    vpc_id: "{{ bastion_vpc.vpcs[0].vpc_id }}"
+    lookup: id
+    purge_subnets: false
+    purge_routes: false
+    route_table_id: "{{ bastion_route.route_tables[0].route_table_id }}"
+    routes:
+    - dest: "{{ ocp_dr_trident_first_rosa_cidr }}"
+      vpc_peering_connection_id: "{{ vpc_peering_bastion1.vpc_peering_connection.vpc_peering_connection_id }}"
+    - dest: "{{ ocp_dr_trident_second_rosa_cidr }}"
+      vpc_peering_connection_id: "{{ vpc_peering_bastion2.vpc_peering_connection.vpc_peering_connection_id }}"
+
+- name: Get Prod FSxN Security Group
+  amazon.aws.ec2_security_group_info:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    filters:
+      "tag:aws:cloudformation:stack-name": "PROD-FSXONTAP"
+      vpc-id: "{{ prod_vpc.vpcs[0].vpc_id }}"
+  register: prod_fsxn_sg
+
+- name: Get DR FSxN Security Group
+  amazon.aws.ec2_security_group_info:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    filters:
+      "tag:aws:cloudformation:stack-name": "DR-FSXONTAP"
+      vpc-id: "{{ dr_vpc.vpcs[0].vpc_id }}"
+  register: dr_fsxn_sg
+
+- name: Setup Prod FSXN Security Group
+  amazon.aws.ec2_security_group:
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    name: "{{ prod_fsxn_sg.security_groups[0].group_name }}"
+    description: "{{ prod_fsxn_sg.security_groups[0].description }}"
+    vpc_id: "{{ prod_vpc.vpcs[0].vpc_id }}"
+    purge_rules: false
+    purge_rules_egress: false
+    purge_tags: false
+    rules:
+    - proto: tcp
+      ports:
+      - 3260
+      cidr_ip: "{{ ocp_dr_trident_first_rosa_cidr }}"
+      rule_desc: iSCSI
+    - proto: tcp
+      ports:
+      - 11104
+      cidr_ip: "{{ ocp_dr_trident_first_rosa_cidr | replace('/16', '/8') }}"
+      rule_desc: Peering1
+    - proto: tcp
+      ports:
+      - 11105
+      cidr_ip: "{{ ocp_dr_trident_first_rosa_cidr | replace('/16', '/8') }}"
+      rule_desc: Peering2
+    - proto: tcp
+      ports:
+      - 443
+      cidr_ip: "{{ ocp_dr_trident_bastion_cidr }}"
+      rule_desc: API
+
+- name: Setup DR FSXN Security Group
+  amazon.aws.ec2_security_group:
+    access_key: "{{ trident_two.aws_access_key_id }}"
+    secret_key: "{{ trident_two.aws_secret_access_key }}"
+    region: "{{ trident_two.aws_default_region }}"
+    name: "{{ dr_fsxn_sg.security_groups[0].group_name }}"
+    description: "{{ dr_fsxn_sg.security_groups[0].description }}"
+    vpc_id: "{{ dr_vpc.vpcs[0].vpc_id }}"
+    purge_rules: false
+    purge_rules_egress: false
+    purge_tags: false
+    rules:
+    - proto: tcp
+      ports:
+      - 3260
+      cidr_ip: "{{ ocp_dr_trident_second_rosa_cidr }}"
+      rule_desc: iSCSI
+    - proto: tcp
+      ports:
+      - 11104
+      cidr_ip: "{{ ocp_dr_trident_first_rosa_cidr | replace('/16', '/8') }}"
+      rule_desc: Peering1
+    - proto: tcp
+      ports:
+      - 11105
+      cidr_ip: "{{ ocp_dr_trident_first_rosa_cidr | replace('/16', '/8') }}"
+      rule_desc: Peering2
+    - proto: tcp
+      ports:
+      - 443
+      cidr_ip: "{{ ocp_dr_trident_bastion_cidr }}"
+      rule_desc: API
+
+- name: Get data of first FsxN
+  environment:
+    AWS_REGION: "{{ trident_one.aws_default_region }}"
+    AWS_ACCESS_KEY_ID: "{{ trident_one.aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ trident_one.aws_secret_access_key }}"
+  ansible.builtin.command: >-
+    aws fsx describe-file-systems --query 'FileSystems[0]'
+  register: fsxn1
+
+- name: Get data of second FsxN
+  environment:
+    AWS_REGION: "{{ trident_two.aws_default_region }}"
+    AWS_ACCESS_KEY_ID: "{{ trident_two.aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ trident_two.aws_secret_access_key }}"
+  ansible.builtin.command: >-
+    aws fsx describe-file-systems --query 'FileSystems[0]'
+  register: fsxn2
+
+- name: Disable auto-backup of first FSxN
+  environment:
+    AWS_REGION: "{{ trident_one.aws_default_region }}"
+    AWS_ACCESS_KEY_ID: "{{ trident_one.aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ trident_one.aws_secret_access_key }}"
+  ansible.builtin.command: >-
+    aws fsx update-file-system --file-system-id {{ (fsxn1.stdout | from_json).FileSystemId }} --ontap-configuration AutomaticBackupRetentionDays=0
+
+- name: Disable auto-backup of second FSxN
+  environment:
+    AWS_REGION: "{{ trident_two.aws_default_region }}"
+    AWS_ACCESS_KEY_ID: "{{ trident_two.aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ trident_two.aws_secret_access_key }}"
+  ansible.builtin.command: >-
+    aws fsx update-file-system --file-system-id {{ (fsxn2.stdout | from_json).FileSystemId }} --ontap-configuration AutomaticBackupRetentionDays=0
+
+- name: Get mgmt IP of prod SVM
+  environment:
+    AWS_REGION: "{{ trident_one.aws_default_region }}"
+    AWS_ACCESS_KEY_ID: "{{ trident_one.aws_access_key_id }}"
+    AWS_SECRET_ACCESS_KEY: "{{ trident_one.aws_secret_access_key }}"
+  ansible.builtin.command: >-
+    aws fsx describe-storage-virtual-machines --query "StorageVirtualMachines[?Name=='{{ ocp_dr_trident_fsx_storage_vm_name1 }}']"
+  register: prod_svm
+
+- name: Deploy Trident via OperatorHub onto prod cluster
+  block:
+  - name: Get OpenShift access token
+    community.okd.openshift_auth:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      username: "{{ trident_one.rosa_openshift_admin_user }}"
+      password: "{{ trident_one.rosa_openshift_admin_password }}"
+      validate_certs: false
+    register: openshift_auth_results
+    retries: 60
+    delay: 30
+    until:
+    - openshift_auth_results is defined
+    - openshift_auth_results.k8s_auth is defined
+    - openshift_auth_results.k8s_auth.api_key is defined
+
+  - name: Deploy Trident Operator
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: operators.coreos.com/v1alpha1
+        kind: Subscription
+        metadata:
+          name: trident-operator
+          namespace: openshift-operators
+        spec:
+          channel: "{{ ocp_dr_trident_operator_channel }}"
+          name: trident-operator
+          source: certified-operators
+          sourceNamespace: openshift-marketplace
+          #startingCSV: "{{ ocp_dr_trident_starting_csv }}"
+
+  - name: Wait for Trident Operator to be up and running
+    kubernetes.core.k8s_info:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      kind: Pod
+      namespace: openshift-operators
+      label_selectors:
+      - app=operator.trident.netapp.io
+    register: kubectl_get_trident_pod
+    until: kubectl_get_trident_pod | json_query('resources[*].status.phase') | unique == ["Running"]
+    retries: 30
+    delay: 20
+
+  - name: Deploy Trident Orchestrator
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: trident.netapp.io/v1
+        kind: TridentOrchestrator
+        metadata:
+          name: trident
+          namespace: openshift-operators
+        spec:
+          IPv6: false
+          debug: false
+          nodePrep: [iscsi]
+          imagePullSecrets: []
+          imageRegistry: ''
+          k8sTimeout: 30
+          kubeletDir: /var/lib/kubelet
+          namespace: trident
+          silenceAutosupport: false
+
+  - name: Wait for Trident Controller to be up and running
+    kubernetes.core.k8s_info:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      kind: Pod
+      namespace: trident
+      label_selectors:
+      - app=controller.csi.trident.netapp.io
+    register: kubectl_get_trident_controller
+    until: kubectl_get_trident_controller | json_query('resources[*].status.phase') | unique == ["Running"]
+    retries: 30
+    delay: 20
+
+  - name: Create Secret for FSxN backends
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: prod-backend-fsxn-secret
+          namespace: trident
+        type: Opaque
+        stringData:
+          username: vsadmin
+          # password: "{{ _ocp_dr_trident_svm_admin_password }}"
+          password: "{{ lookup('agnosticd_user_data', 'svm_admin_password') }}"
+
+  - name: Create Trident Backend for NFS
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: trident.netapp.io/v1
+        kind: TridentBackendConfig
+        metadata:
+          name: prod-backend-fsxn-nfs
+          namespace: trident
+        spec:
+          version: 1
+          backendName: prod-fsxn-nfs
+          storageDriverName: ontap-nas
+          managementLIF: "{{ (prod_svm.stdout | from_json)[0].Endpoints.Management.IpAddresses[0] }}"
+          nasType: nfs
+          storagePrefix: prod
+          credentials:
+            name: prod-backend-fsxn-secret
+
+  - name: Create Trident Backend for iSCSI
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: trident.netapp.io/v1
+        kind: TridentBackendConfig
+        metadata:
+          name: prod-backend-fsxn-iscsi
+          namespace: trident
+        spec:
+          version: 1
+          backendName: prod-fsxn-iscsi
+          storageDriverName: ontap-san
+          managementLIF: "{{ (prod_svm.stdout | from_json)[0].Endpoints.Management.IpAddresses[0] }}"
+          sanType: iscsi
+          storagePrefix: prod
+          credentials:
+            name: prod-backend-fsxn-secret
+
+  - name: Create Storage Class for iSCSI
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+          name: storage-class-iscsi
+          annotations:
+            storageclass.kubevirt.io/is-default-virt-class: 'true'
+        provisioner: csi.trident.netapp.io
+        parameters:
+          backendType: "ontap-san"
+          sanType: "iscsi"
+        mountOptions:
+        - discard
+        allowVolumeExpansion: true
+
+  - name: Create Storage Class for NFS
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: storage.k8s.io/v1
+        kind: StorageClass
+        metadata:
+          name: storage-class-nfs
+        provisioner: csi.trident.netapp.io
+        parameters:
+          backendType: "ontap-nas"
+          nasType: "nfs"
+        allowVolumeExpansion: true
+
+  - name: Create VolumeSnapshotClass
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: snapshot.storage.k8s.io/v1
+        kind: VolumeSnapshotClass
+        metadata:
+          name: csi-trident-vsc
+        driver: csi.trident.netapp.io
+        deletionPolicy: Delete
+
+  - name: Create Namespace for Trident protect
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: trident-protect
+
+  - name: Add Trident protect Helm repo
+    kubernetes.core.helm_repository:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      name: netapp-trident-protect
+      repo_url: "https://netapp.github.io/trident-protect-helm-chart/"
+
+#  Trident Protect install in 25.06
+# helm repo add netapp-trident-protect https://netapp.github.io/trident-protect-helm-chart
+# helm install trident-protect netapp-trident-protect/trident-protect --set clusterName=<name-of-cluster> --version 100.2506.0 --create-namespace --namespace trident-protect
+
+  - name: Deploy Trident protect Helm chart
+    kubernetes.core.helm:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      name: trident-protect
+      chart_ref: netapp-trident-protect/trident-protect
+      chart_version: "{{ ocp_dr_trident_helm_chart_version }}"
+      release_namespace: trident-protect
+      values:
+        clusterName=prod
+
+  - name: Wait for Trident protect controller manager to be available
+    kubernetes.core.k8s_info:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      kind: Pod
+      namespace: trident-protect
+      label_selectors:
+      - app=controller.protect.trident.netapp.io
+    register: kubectl_get_trident_protect_controller
+    until: kubectl_get_trident_protect_controller | json_query('resources[*].status.phase') | unique == ["Running"]
+    retries: 30
+    delay: 20
+
+  - name: Create Secret for Appvault bucket
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: aws-s3-keys
+          namespace: trident-protect
+        type: Opaque
+        data:
+          accessKeyID: "{{ trident_one.aws_access_key_id | b64encode }}"
+          secretAccessKey: "{{ trident_one.aws_secret_access_key | b64encode }}"
+
+  - name: Create Secret for Kopia encryption
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: v1
+        kind: Secret
+        metadata:
+          name: appvault-secret
+          namespace: trident-protect
+        type: Opaque
+        data:
+          KOPIA_PASSWORD: "{{ 'mypassword' | b64encode }}"
+
+  - name: Create Appvault
+    kubernetes.core.k8s:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: present
+      definition:
+        apiVersion: protect.trident.netapp.io/v1
+        kind: AppVault
+        metadata:
+          name: lab-vault
+          namespace: trident-protect
+        spec:
+          dataMoverPasswordSecretRef: appvault-secret
+          providerType: AWS
+          providerConfig:
+            s3:
+              bucketName: "{{ ocp_dr_trident_s3_bucket_name }}"
+              endpoint: "s3.{{ trident_one.aws_default_region }}.amazonaws.com"
+          providerCredentials:
+            accessKeyID:
+              valueFromSecret:
+                key: accessKeyID
+                name: aws-s3-keys
+            secretAccessKey:
+              valueFromSecret:
+                key: secretAccessKey
+                name: aws-s3-keys
+
+  always:
+  - name: If login succeeded, try to log out (revoke access token)
+    when: openshift_auth_results.openshift_auth.api_key is defined
+    community.okd.openshift_auth:
+      host: "{{ trident_one.rosa_openshift_api_url }}"
+      api_key: "{{ openshift_auth_results.openshift_auth.api_key }}"
+      state: absent
+
+# WARNING - need the user_data from previous file
+
+- name: Create FSxN cluster peering Prod --> DR
+  delegate_to: trident_bastion
+  ansible.builtin.uri:
+    url: https://{{ (fsxn1.stdout | from_json).OntapConfiguration.Endpoints.Management.IpAddresses[0] }}/api/cluster/peers/
+    user: fsxadmin
+    password: "{{ lookup('agnosticd_user_data', 'fsx_admin_password') }}"
+    method: POST
+    body:
+      initial_allowed_svms: ["*"]
+      remote:
+        ip_addresses: ["{{ (fsxn2.stdout | from_json).OntapConfiguration.Endpoints.Intercluster.IpAddresses[0] }}"]
+      authentication:
+        passphrase: "Netapp01"
+    status_code: 201, 409
+    body_format: json
+    validate_certs: false
+
+# Create FSxN cluster peering DR --> Prod (accepts the peering from the other side).
+#   Status code is 201 when successful, 409 in case this is run again
+- name: Create FSxN cluster peering DR --> Prod (accepts the peering from the other side)
+  delegate_to: trident_bastion
+  ansible.builtin.uri:
+    url: https://{{ (fsxn2.stdout | from_json).OntapConfiguration.Endpoints.Management.IpAddresses[0] }}/api/cluster/peers/
+    user: fsxadmin
+    password: "{{ lookup('agnosticd_user_data', 'fsx_admin_password') }}"
+    method: POST
+    body:
+      initial_allowed_svms: ["*"]
+      remote:
+        ip_addresses: ["{{ (fsxn1.stdout | from_json).OntapConfiguration.Endpoints.Intercluster.IpAddresses[0] }}"]
+      authentication:
+        passphrase: "Netapp01"
+    status_code: 201, 409
+    body_format: json
+    validate_certs: false
+
+- name: Create SVM peering
+  delegate_to: trident_bastion
+  ansible.builtin.uri:
+    url: https://{{ (fsxn2.stdout | from_json).OntapConfiguration.Endpoints.Management.IpAddresses[0] }}/api/svm/peers/
+    user: fsxadmin
+    password: "{{ lookup('agnosticd_user_data', 'fsx_admin_password') }}"
+    method: POST
+    body:
+      svm:
+        name: "{{ lookup('agnosticd_user_data', 'fsxontap_storagevm_name2') }}"
+      peer:
+        svm:
+          name: "{{ lookup('agnosticd_user_data', 'fsxontap_storagevm_name1') }}"
+        cluster:
+          name: FsxId{{ (fsxn1.stdout | from_json).FileSystemId | replace('fs-', '') }}
+      applications: ["snapmirror"]
+    status_code: 201, 202
+    body_format: json
+    validate_certs: false

--- a/ansible/configs/trident-binder/setup_s3_bucket.yml
+++ b/ansible/configs/trident-binder/setup_s3_bucket.yml
@@ -1,0 +1,53 @@
+---
+- name: Create S3 bucket
+  amazon.aws.s3_bucket:
+    name: "{{ ocp_dr_trident_s3_bucket_name }}"
+    state: present
+    access_key: "{{ aws_access_key_id }}"
+    secret_key: "{{ aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    public_access:
+      block_public_acls: false
+      ignore_public_acls: false
+      block_public_policy: false
+      restrict_public_buckets: false
+  register: r_bucket
+
+- name: Debug bucket
+  ansible.builtin.debug:
+    var: r_bucket
+
+- name: Apply bucket policy for public read/write access
+  amazon.aws.s3_bucket:
+    name: "{{ ocp_dr_trident_s3_bucket_name }}"
+    state: present
+    access_key: "{{ aws_access_key_id }}"
+    secret_key: "{{ aws_secret_access_key }}"
+    region: "{{ trident_one.aws_default_region }}"
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "PublicReadWrite",
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:ListBucket"
+                ],
+                "Resource": [
+                   "arn:aws:s3:::{{ ocp_dr_trident_s3_bucket_name }}/*",
+                   "arn:aws:s3:::{{ ocp_dr_trident_s3_bucket_name }}"
+                ]
+            }
+        ]
+      }
+
+- name: Save AgnosticD A3 Bucket data
+  agnosticd_user_info:
+    data:
+      s3_bucket_name: "{{ ocp_dr_trident_s3_bucket_name }}"
+      s3_bucket_region: "{{ trident_one.aws_default_region }}"

--- a/ansible/configs/trident-binder/setup_showroom.yml
+++ b/ansible/configs/trident-binder/setup_showroom.yml
@@ -1,0 +1,72 @@
+# Showroom needs specific authentication info set
+
+- name: Get OpenShift API token
+  community.okd.openshift_auth:
+    host: "{{ trident_one.rosa_openshift_api_url }}"
+    username: "{{ trident_one.rosa_openshift_admin_user }}"
+    password: "{{ trident_one.rosa_openshift_admin_password }}"
+    validate_certs: false
+  register: _openshift_auth_results
+  retries: 60
+  delay: 30
+  until:
+  - _openshift_auth_results is defined
+  - _openshift_auth_results.k8s_auth is defined
+  - _openshift_auth_results.k8s_auth.api_key is defined
+
+- name: Get OpenShift Ingress Domain
+  kubernetes.core.k8s_info:
+    host: "{{ trident_one.rosa_openshift_api_url }}"
+    api_key: "{{ _openshift_auth_results.openshift_auth.api_key }}"
+    api_version: config.openshift.io/v1
+    kind: Ingress
+    name: cluster
+  retries: 10
+  delay: 30
+  until:
+    - r_ingress_domain.resources is defined
+    - r_ingress_domain.resources | length > 0
+    - r_ingress_domain.resources[0].spec is defined
+    - r_ingress_domain.resources[0].spec.domain is defined
+  register: r_ingress_domain
+
+- name: Prepare OpenShift API AuthN facts for showroom
+  ansible.builtin.set_fact:
+    openshift_cluster_ingress_domain: "{{ r_ingress_domain.resources[0].spec.domain }}"
+    # v1
+    showroom_openshift_api_token: "{{ _openshift_auth_results.openshift_auth.api_key }}"
+    showroom_openshift_api_url: "{{ trident_one.rosa_openshift_api_url }}"
+    showroom_openshift_api_ca_cert: ""
+    # v2
+    ocp4_workload_showroom_openshift_api_token: "{{ _openshift_auth_results.openshift_auth.api_key }}"
+    ocp4_workload_showroom_openshift_api_url: "{{ trident_one.rosa_openshift_api_url }}"
+
+- name: Prepare user_data for showroom
+  agnosticd_user_info:
+    data:
+      aws_access_key_id: "{{ trident_one.aws_access_key_id }}"
+      aws_default_region: "{{ trident_one.aws_default_region }}"
+      aws_sandbox_account_id: "{{ trident_one.aws_sandbox_account_id }}"
+      aws_secret_access_key: "{{ trident_one.aws_secret_access_key }}"
+      bastion_public_hostname: "{{ trident_one.bastion_public_hostname }}"
+      bastion_ssh_password: "{{ trident_one.bastion_ssh_password }}"
+      bastion_ssh_user_name: "{{ trident_one.bastion_ssh_user_name }}"
+      ocp_dr_trident_starting_csv: "{{ ocp_dr_trident_starting_csv }}"
+      ocp_dr_trident_helm_chart_version: "{{ ocp_dr_trident_helm_chart_version }}"
+      ocp_dr_trident_cli_version: "{{ ocp_dr_trident_cli_version }}"
+      rosa_dr_openshift_api_url: "{{ trident_two.rosa_openshift_api_url }}"
+      rosa_dr_openshift_console_url: "{{ trident_two.rosa_openshift_console_url }}"
+      rosa_dr_openshift_admin_user: "{{ trident_two.rosa_openshift_admin_user }}"
+      rosa_dr_openshift_admin_password: "{{ trident_two.rosa_openshift_admin_password }}"
+      rosa_prod_openshift_api_url: "{{ trident_one.rosa_openshift_api_url }}"
+      rosa_prod_openshift_console_url: "{{ trident_one.rosa_openshift_console_url }}"
+      rosa_prod_openshift_admin_user: "{{ trident_one.rosa_openshift_admin_user }}"
+      rosa_prod_openshift_admin_password: "{{ trident_one.rosa_openshift_admin_password }}"
+      fsxontap_name1: "{{ ocp_dr_trident_fsx_name1 }}"
+      fsxontap_name2: "{{ ocp_dr_trident_fsx_name2 }}"
+      fsx_admin_password: "{{ _ocp_dr_trident_fsx_admin_password }}"
+      svm_admin_password: "{{ _ocp_dr_trident_svm_admin_password }}"
+
+- name: Deploy Showroom
+  ansible.builtin.include_role:
+    name: ocp4_workload_showroom

--- a/ansible/configs/trident-binder/software.yml
+++ b/ansible/configs/trident-binder/software.yml
@@ -1,0 +1,10 @@
+---
+- name: Step 004 Software
+  hosts: localhost
+  connection: local
+  become: false
+  gather_facts: false
+  tasks:
+  - name: Print stage message
+    ansible.builtin.debug:
+      msg: "Step 004 Software"


### PR DESCRIPTION
* use operator channel and not starting csv
* fix paths to agnosticed_user_info plugin for v1
* remove excessive v2 default_vars
* fixup how to set ansible_async_dir
* fixup how to call showroom

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
