### PR TITLE
Remove debug task from GitOps bootstrap workload

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/tasks/workload.yml
@@ -51,13 +51,6 @@
   ansible.builtin.pause:
     seconds: 60
 
-- name: Debug all applications with our label in any namespace
-  when: ocp4_workload_gitops_bootstrap_application_wait | bool
-  vars:
-    query: "[*].{App: metadata.name, Health: status.health.status, Sync: status.sync.status}"
-  ansible.builtin.debug:
-    msg: "{{ _all_apps.resources | json_query(query)}}"
-
 - name: Validate all applications with our label in any namespace are healthy and synced
   when: ocp4_workload_gitops_bootstrap_application_wait | bool
   kubernetes.core.k8s_info:


### PR DESCRIPTION
This never worked because _all_apps was undefined. It was being silently ignored but now it fails using the most recent execution environment.