### PR TITLE
ocp-dr-trident: add a randomized password for KOPIA

### DIFF
--- a/ansible/configs/trident-binder/setup_fsxontap_post_config.yml
+++ b/ansible/configs/trident-binder/setup_fsxontap_post_config.yml
@@ -578,7 +578,7 @@
           KOPIA_PASSWORD: "{{ kopia_password | b64encode }}"
 
   - name: Add kopia password to agnosticd_user_info.data
-    agnosticd_user_data:
+    agnosticd_user_info:
       data:
         kopia_password: "{{ kopia_password }}"
 

--- a/ansible/configs/trident-binder/setup_fsxontap_post_config.yml
+++ b/ansible/configs/trident-binder/setup_fsxontap_post_config.yml
@@ -558,6 +558,10 @@
           accessKeyID: "{{ trident_one.aws_access_key_id | b64encode }}"
           secretAccessKey: "{{ trident_one.aws_secret_access_key | b64encode }}"
 
+  - name: Create a fact with a random password for Kopia
+    ansible.builtin.set_fact:
+      kopia_password: "{{ lookup('password', output_dir ~ '/kopia_password length=12 chars=ascii_letters,digits') }}"
+
   - name: Create Secret for Kopia encryption
     kubernetes.core.k8s:
       host: "{{ trident_one.rosa_openshift_api_url }}"
@@ -571,7 +575,12 @@
           namespace: trident-protect
         type: Opaque
         data:
-          KOPIA_PASSWORD: "{{ 'mypassword' | b64encode }}"
+          KOPIA_PASSWORD: "{{ kopia_password | b64encode }}"
+
+  - name: Add kopia password to agnosticd_user_info.data
+    agnosticd_user_data:
+      data:
+        kopia_password: "{{ kopia_password }}"
 
   - name: Create Appvault
     kubernetes.core.k8s:

--- a/ansible/configs/trident-binder/setup_showroom.yml
+++ b/ansible/configs/trident-binder/setup_showroom.yml
@@ -66,6 +66,7 @@
       fsxontap_name2: "{{ ocp_dr_trident_fsx_name2 }}"
       fsx_admin_password: "{{ _ocp_dr_trident_fsx_admin_password }}"
       svm_admin_password: "{{ _ocp_dr_trident_svm_admin_password }}"
+      kopia_password: "{{ kopia_password }}"
 
 - name: Deploy Showroom
   ansible.builtin.include_role:


### PR DESCRIPTION
nate noticed that the password was not randomized.

So, I randomized it and saved it in output_dir, just in case.

- Bugfix Pull Request
