### PR TITLE
[zero-touch-base-rhel] set default chart url, name, version

### DIFF
--- a/ansible/configs/zero-touch-base-rhel/default_vars_openshift_cnv.yaml
+++ b/ansible/configs/zero-touch-base-rhel/default_vars_openshift_cnv.yaml
@@ -183,18 +183,15 @@ instances:
 # -------------------------------------------------------------------
 showroom_deploy_shared_cluster_enable: False
 
-ocp4_workload_showroom_chart_package_url: https://agonzalezrh.github.io/showroom-deployer
-ocp4_workload_showroom_deployer_chart_name: showroom-single-pod
-ocp4_workload_showroom_deployer_chart_version: "1.3.9"
-ocp4_workload_showroom_zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.0.4/nookbag-v0.0.4.zip"
+ocp4_workload_showroom_chart_package_url: https://rhpds.github.io/showroom-deployer
+ocp4_workload_showroom_deployer_chart_name: zerotouch
+ocp4_workload_showroom_deployer_chart_version: "^1.0.0"
 ocp4_workload_showroom_zero_touch_ui_enabled: "true"
 
 ocp4_workload_showroom_content_only: false
-ocp4_workload_showroom_content_antora_playbook: zero-touch-site.yml
+ocp4_workload_showroom_content_antora_playbook: site.yml
 ocp4_workload_showroom_terminal_type: wetty
-ocp4_workload_showroom_wetty_image: quay.io/rhpds/wetty
 ocp4_workload_showroom_wetty_ssh_bastion_login: true
-ocp4_workload_showroom_content_image: ghcr.io/agonzalezrh/showroom-content:main
 
 bastion_prefix: "{{ groups['bastions'][0] | regex_replace('\\..*$') }}"
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -48,7 +48,7 @@ ocp4_workload_showroom_terminal_requests_memory: 256Mi
 ocp4_workload_showroom_terminal_limits_cpu: 500m
 ocp4_workload_showroom_terminal_limits_memory: 1Gi
 
-ocp4_workload_showroom_content_image: ghcr.io/agonzalezrh/showroom-content:latest
+ocp4_workload_showroom_content_image: quay.io/rhpds/showroom-content:v1.3.0
 
 # Showroom Terminal Image. Options include:
 # - quay.io/rhpds/openshift-showroom-terminal-ocp:latest
@@ -103,7 +103,7 @@ ocp4_workload_showroom_test_self_provisioner: false
 ocp4_workload_showroom_zero_touch_bundle: ""
 ocp4_workload_showroom_zero_touch_ui_enabled: false
 
-ocp4_workload_showroom_cloud_image: quay.io/agonzalezrh/showroom-cloud:v0.0.12
+ocp4_workload_showroom_cloud_image: quay.io/rhpds/showroom-cloud:v1.1.3
 
 ocp4_workload_showroom_ironrdp_enable: false
 ocp4_workload_showroom_ironrdp_image: quay.io/agonzalezrh/ironrdp:v0.0.2

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -92,7 +92,9 @@ ocp4_workload_showroom_deployment_type: helm
 ocp4_workload_showroom_chart_package_url: https://rhpds.github.io/showroom-deployer
 ocp4_workload_showroom_deployer_chart_name: showroom-single-pod
 # Available versions are at https://github.com/rhpds/showroom-deployer/releases
-ocp4_workload_showroom_deployer_chart_version: "1.3.4"
+ocp4_workload_showroom_deployer_chart_version: "1.9.15"
+# Default zero-touch bundle version
+ocp4_workload_showroom_zero_touch_bundle: "https://github.com/rhpds/nookbag/releases/download/nookbag-v0.1.0/nookbag-v0.1.0.zip"
 
 # URL to download Helm from if it's not already there (for Helm type deployment)
 ocp4_workload_showroom_tools_root_url: https://mirror.openshift.com/pub/openshift-v4/clients
@@ -100,7 +102,6 @@ ocp4_workload_showroom_helm_version: latest
 
 ocp4_workload_showroom_test_self_provisioner: false
 
-ocp4_workload_showroom_zero_touch_bundle: ""
 ocp4_workload_showroom_zero_touch_ui_enabled: false
 
 ocp4_workload_showroom_cloud_image: quay.io/rhpds/showroom-cloud:v1.1.3

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -57,7 +57,7 @@ ocp4_workload_showroom_content_image: quay.io/rhpds/showroom-content:v1.3.0
 ocp4_workload_showroom_terminal_image: quay.io/rhpds/openshift-showroom-terminal-ocp:latest
 # Wetty Image
 # Don't use docker.io, I made a copy onto quay.io/rhpds
-ocp4_workload_showroom_wetty_image: quay.io/rhpds/wetty:latest
+ocp4_workload_showroom_wetty_image: quay.io/rhpds/wetty:v2.5
 
 # Log into bastion automatically from wetty
 # applies to both primary and seconary wetty terminals


### PR DESCRIPTION
##### SUMMARY

- set default chart url, name, version
- remove some images versions managed by the helm chart

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- zero-touch-base-rhel

