### PR TITLE
Change config to block scalar format in create_network.yaml

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -7,7 +7,7 @@
       metadata:
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
-      spec: >
+      spec: >-
           {{ config | to_json }}
   vars:
     config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -1,4 +1,8 @@
 ---
+- set_fact:
+    config_json: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    config_definition: "{{ {} | combine({'config': config_json|to_json }) }}"
+    
 - name: Create network {{ _network.name }}
   kubernetes.core.k8s:
     definition:
@@ -7,9 +11,7 @@
       metadata:
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
-      spec:
-        config: |
-          {{ config | to_json }}
+      spec: "{{ config_definition }}"
   vars:
     config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,7 +8,8 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        config: "{{ config | to_json }}"
+        config: |
+          {{ config | to_json }}
   vars:
     config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -1,6 +1,7 @@
 ---
 - set_fact:
     config_json: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+- set_fact:
     config_definition: "{{ {} | combine({'config': config_json|to_json }) }}"
     
 - name: Create network {{ _network.name }}

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -1,9 +1,4 @@
 ---
-- set_fact:
-    config_json: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
-- set_fact:
-    config_definition: "{{ {} | combine({'config': config_json|to_json }) }}"
-    
 - name: Create network {{ _network.name }}
   kubernetes.core.k8s:
     definition:
@@ -12,7 +7,8 @@
       metadata:
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
-      spec: "{{ config_definition }}"
+      spec: >
+          {{ config | to_json }}
   vars:
     config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,7 +8,7 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec: >-
-          {{ config | to_json }}
+          {{ config | to_json | to_json if config is mapping else config | to_json}}
   vars:
     config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork


### PR DESCRIPTION
Updated the config field to use a block scalar for better readability.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
