### PR TITLE
config: azure_subs: helm binary

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/default_vars.yml
+++ b/ansible/configs/open-environment-azure-subscription/default_vars.yml
@@ -77,7 +77,7 @@ azure_region: "{{ location }}"
 azure_config_dir: "/tmp/azure-{{ guid }}"
 
 # Azure Kube Config root directory
-azure_kube_config_root: /home/azure/ 
+azure_kube_config_root: /home/azure/
 
 # Azure Default root DNS Zone
 azure_root_dns_zone: azure.redhatworkshops.io
@@ -110,8 +110,14 @@ common_extra_packages: {}
 
 # Install helm on the bastion
 aro_install_helm: false
+helm_url: https://catalog-item-assets.s3.us-east-2.amazonaws.com/helm-linux-amd64.tar.gz
+helm_binary_src: /usr/local/bin/linux-amd64/helm
+# or use the version from mirror.openshift.com, which has been unreliable
+#helm_url: https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64.tar.gz
+#helm_binary_src: /usr/local/bin/helm-linux-amd64
 
-rhel_vm_size: Standard_DS1_v2
+# original bastion size: rhel_vm_size: Standard_DS1_v2
+rhel_vm_size: Standard_D2s_v4
 
 # Enable RHEL Gold Image
 #  rhel_publisher: redhat

--- a/ansible/configs/open-environment-azure-subscription/install_helm.yml
+++ b/ansible/configs/open-environment-azure-subscription/install_helm.yml
@@ -1,5 +1,6 @@
 ---
 - name: Set URL for helm
+  when: helm_url | default("") | length == 0
   ansible.builtin.set_fact:
     helm_url: >-
       {{ '{0}/helm/latest/helm-linux-amd64.tar.gz'.format(ocp4_tools_root_url ) }}
@@ -22,7 +23,7 @@
 
   - name: Link downloaded helm command to helm
     ansible.builtin.file:
-      src: /usr/local/bin/helm-linux-amd64
+      src: "{{ helm_binary_src }}"
       dest: /usr/local/bin/helm
       owner: root
       group: root


### PR DESCRIPTION
use helm in s3 unless helm_url set.

- Bugfix Pull Request

