### PR TITLE
Load provision-user-data.yaml in other actions

### DIFF
--- a/ansible/include_vars.yml
+++ b/ansible/include_vars.yml
@@ -42,6 +42,17 @@
     include_vars:
       file: "{{ secret_file }}"
 
+  # The file always exists, since touched in setup_output_dir.yml
+  # For now set the default to false, will change to true later
+  - name: load provision-user-data.yaml
+    when: >-
+      ACTION | default('provision') != 'provision'
+      and
+      agnosticd_load_provision_user_data | default(false)
+    include_vars:
+      file: "{{ [ output_dir, 'provision-user-data.yaml' ] | path_join }}"
+
+
   - name: Set passthrough user data
     when:
     - agnosticd_passthrough_user_data is defined


### PR DESCRIPTION
- destroy, start, stop, lifecycle

Use a variable `agnosticd_load_provision_user_data` to control this behavior.
Set it to false for now as the default.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
