### PR TITLE
Remove useless variable

### DIFF
--- a/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
+++ b/ansible/configs/ansible-bu-workshop/default_vars_ec2.yml
@@ -131,5 +131,3 @@ inventory_groups:
 
 agnosticd_aws_capacity_reservations:
   az1: "{{ instances | agnosticd_instances_to_odcr(agnosticd_images) }}"
-
-agnosticd_aws_capacity_reservations_enable: false

--- a/ansible/configs/multi-cloud-base-infra/default_vars_ec2.yml
+++ b/ansible/configs/multi-cloud-base-infra/default_vars_ec2.yml
@@ -131,5 +131,3 @@ inventory_groups:
 
 agnosticd_aws_capacity_reservations:
   az1: "{{ instances | agnosticd_instances_to_odcr(agnosticd_images) }}"
-
-agnosticd_aws_capacity_reservations_enable: false


### PR DESCRIPTION
agnosticd_aws_capacity_reservations_enable doesn't exist, it's not used anywhere

it's supposed to be

agnosticd_aws_capacity_reservation_enable  without plural form.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->