### PR TITLE
[ocp4_workload_external_odf] Use a different default storageClassName just in case disableStorageClass doesn't work

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
@@ -36,6 +36,7 @@ spec:
   managedResources:
     cephBlockPools:
       disableStorageClass: true
+      storageClassName: do-not-use
     cephFilesystems: {}
     cephObjectStoreUsers: {}
     cephObjectStores: {}


### PR DESCRIPTION
##### SUMMARY

With ODF 4.19 doesn't work the option disableStorageClass, causing our SC (with the parameters we want, and we set as default), is overriden by the operator.

Using another name through storageClassName, solves the issue, thanks WK!

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ocp4_workload_external_odf role