### PR TITLE
Enable monitoring on openshift-storage namespace

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ibm_fusion/tasks/deploy_odf_manager.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ibm_fusion/tasks/deploy_odf_manager.yml
@@ -48,6 +48,17 @@
     state: present
     definition: "{{ lookup('template', 'storagecluster.yml.j2') | from_yaml }}"
 
+- name: Label openshift-storage namespace for cluster monitoring
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Namespace
+    name: openshift-storage
+    state: patched
+    definition:
+      metadata:
+        labels:
+          openshift.io/cluster-monitoring: "true"
+
 - name: Wait for Storage Cluster to finish deploying
   kubernetes.core.k8s_info:
     api_version: ocs.openshift.io/v1


### PR DESCRIPTION
##### SUMMARY

openshift-storage namespace needs a label for monitoring to pick up data for the IBM Fusion dashboard.

Added the correct label.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_ibm_fusion