### PR TITLE
[ocp4_workload_external_odf] Set storageClassName when OCP version > 4.17 

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
@@ -36,7 +36,7 @@ spec:
   managedResources:
     cephBlockPools:
       disableStorageClass: true
-{% if ocp4_installer_version | version('4.17', '>') %}
+{% if ocp4_installer_version is version_compare('4.17', '>') %}
       storageClassName: do-not-use
 {% endif %}
     cephFilesystems: {}

--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
@@ -36,7 +36,9 @@ spec:
   managedResources:
     cephBlockPools:
       disableStorageClass: true
+{% if ocp4_installer_version | version('4.17', '>') %}
       storageClassName: do-not-use
+{% endif %}
     cephFilesystems: {}
     cephObjectStoreUsers: {}
     cephObjectStores: {}


### PR DESCRIPTION
##### SUMMARY

Version 4.19 doesn't obey the "disableStorageClass" and is creating the storage class, causing issues on the labs. Setting a different name to the storageClassName, allows create our own storageClass (and set as default). This PR is to set only when is a newer version of OCP, as in previous versions this change is causing issues with noobaa pvc (it creates with the SC name defined, which doesn't exist because old versions doesnt create the SC)

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_external_odf role

