### PR TITLE
ARO subs: remove virtenv install

### DIFF
--- a/ansible/configs/open-environment-azure-subscription/pre_software.yml
+++ b/ansible/configs/open-environment-azure-subscription/pre_software.yml
@@ -79,7 +79,7 @@
       ansible.builtin.rpm_key:
         state: present
         key: https://packages.microsoft.com/keys/microsoft.asc
-      retries: 5        
+      retries: 5
 
     - name: Add Azure CLI repository
       ansible.builtin.yum:
@@ -137,11 +137,6 @@
   gather_facts: true
   become: true
   tasks:
-  - name: Add virtualenv cli
-    ansible.builtin.yum:
-      state: present
-      name: virtualenv
-    retries: 5
 
   - name: Setup azure virtualenv
     ansible.builtin.include_role:


### PR DESCRIPTION

- Bugfix Pull Request

package install of virtenv worked before, but fails now.  Falling back to already existing role for pip install