### PR TITLE
Add ocp cpu partition mode variable to install-config file

### DIFF
--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ cluster_name | to_json }}
 baseDomain: {{ ocp4_base_domain | to_json }}
+cpuPartitioningMode: {{ ocp4_partition_mode | default('None') | to_json }}
 fips: {{ ocp4_fips_enable | bool | to_json }}
 controlPlane:
   name: master

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: {{ cluster_name | to_json }}
 baseDomain: {{ ocp4_base_domain | to_json }}
-cpuPartitioningMode: {{ ocp4_partition_mode | default('None') | to_json }}
+cpuPartitioningMode: {{ ocp4_cpu_partitioning_mode | default('None') | to_json }}
 fips: {{ ocp4_fips_enable | bool | to_json }}
 controlPlane:
   name: master


### PR DESCRIPTION
There is requirement of the lab to edit the install-config file and add the 'cpuPartitioningMode' variable to it. 

SME's repo content - https://github.com/wangzheng422/docker_env/blob/dev/redhat/ocp4/4.18/2025.08.workload.partition.md.

In 'openshift4_assisted' way, it is not possible to edit the install-config file hence going with 'openshift4' as software to deploy.