### PR TITLE
[assisted installer] Get dynamically the pull secret 

### DIFF
--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -33,4 +33,4 @@ collections:
   version: 2.0.0
 - name: https://github.com/rhpds/assisted_installer.git
   type: git
-  version: main
+  version: v0.0.9

--- a/ansible/configs/ocp4-cluster/requirements.yml
+++ b/ansible/configs/ocp4-cluster/requirements.yml
@@ -33,4 +33,4 @@ collections:
   version: 2.0.0
 - name: https://github.com/rhpds/assisted_installer.git
   type: git
-  version: v0.0.2
+  version: main

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -267,13 +267,22 @@
         network_name: "{{ cluster_name }}-openshift"
         namespace: "{{ ai_ocp_namespace }}"
 
+    - name: Get the pull secret from the account
+      rhpds.assisted_installer.get_pull_secret:
+        offline_token: "{{ ai_offline_token }}"
+      register: r_pull_secret
+
+    - name: Set varilable ai_ocp_pull_secret
+      ansible.builtin.set_fact:
+        ai_ocp_pull_secret: "{{ (r_pull_secret.result + ai_ocp_pull_secret_append | default({})) | to_json }}"
+
     - name: Create Assisted Installer Cluster
       rhpds.assisted_installer.create_cluster:
         name: "{{ cluster_name }}"
         openshift_version: "{{ ai_cluster_version }}"
         base_dns_domain: "{{ cluster_dns_zone }}"
         offline_token: "{{ ai_offline_token }}"
-        pull_secret: "{{ ai_pull_secret }}"
+        pull_secret: "{{ ai_ocp_pull_secret }}"
         high_availability_mode: "{{ 'Full' if master_instance_count|int > 1 else 'None' }}"
         schedulable_masters: false
         olm_operators: []
@@ -416,7 +425,7 @@
         openshift_version: "{{ ai_cluster_version }}"
         ssh_authorized_key: "{{ ai_ssh_authorized_key }}"
         offline_token: "{{ ai_offline_token }}"
-        pull_secret: "{{ ai_pull_secret }}"
+        pull_secret: "{{ ai_ocp_pull_secret }}"
         static_network_config: "{{ static_network_config }}"
       register: newinfraenv
 

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -274,7 +274,7 @@
 
     - name: Set varilable ai_ocp_pull_secret
       ansible.builtin.set_fact:
-        ai_ocp_pull_secret: "{{ r_pull_secret.result | ansible.builtin.combine(ai_ocp_pull_secret_append | default('{}') | from_json, recursive=true) | to_json }}"
+        ai_ocp_pull_secret: "{{ r_pull_secret.result | ansible.builtin.combine(ai_ocp_pull_secret_append | default({}), recursive=true) | to_json }}"
 
     - name: Create Assisted Installer Cluster
       rhpds.assisted_installer.create_cluster:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -274,7 +274,7 @@
 
     - name: Set varilable ai_ocp_pull_secret
       ansible.builtin.set_fact:
-        ai_ocp_pull_secret: "{{ r_pull_secret.result | ansible.builtin.combine(ai_ocp_pull_secret_append | default({}), recursive=true) | to_json }}"
+        ai_ocp_pull_secret: "{{ r_pull_secret.result | ansible.builtin.combine(ai_ocp_pull_secret_append | default({}), recursive=true) | to_json | to_json }}"
 
     - name: Create Assisted Installer Cluster
       rhpds.assisted_installer.create_cluster:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -274,7 +274,7 @@
 
     - name: Set varilable ai_ocp_pull_secret
       ansible.builtin.set_fact:
-        ai_ocp_pull_secret: "{{ (r_pull_secret.result | from_json) | ansible.builtin.combine(ai_ocp_pull_secret_append | default('{}') | from_json, recursive=true) | to_json }}"
+        ai_ocp_pull_secret: "{{ r_pull_secret.result | ansible.builtin.combine(ai_ocp_pull_secret_append | default('{}') | from_json, recursive=true) | to_json }}"
 
     - name: Create Assisted Installer Cluster
       rhpds.assisted_installer.create_cluster:

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -274,7 +274,7 @@
 
     - name: Set varilable ai_ocp_pull_secret
       ansible.builtin.set_fact:
-        ai_ocp_pull_secret: "{{ (r_pull_secret.result + ai_ocp_pull_secret_append | default({})) | to_json }}"
+        ai_ocp_pull_secret: "{{ (r_pull_secret.result | from_json) | ansible.builtin.combine(ai_ocp_pull_secret_append | default('{}') | from_json, recursive=true) | to_json }}"
 
     - name: Create Assisted Installer Cluster
       rhpds.assisted_installer.create_cluster:

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -38,3 +38,6 @@ ai_workers_extra_disks: []
 
 # This variable is used to configure the role and the installation disk
 ai_configure_hosts: []
+
+# Variable to append registries secret to the pull secret
+ai_ocp_pull_secret_append: {}


### PR DESCRIPTION
##### SUMMARY

Based on the last incidents, this PR uses the new version of rhpds.assisted_installer collection to allow download the pull secret from console.redhat.com

It adds a new variable **ai_ocp_pull_secret_append** to append credentials to other repositories (such as icr.io)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
