### PR TITLE
[host-ocp4-assisted-destroy] Add retries to delete DNS records on Route53

### DIFF
--- a/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
@@ -60,7 +60,8 @@
         - "*.apps"
       retries: 6
       delay: 30
-      register: r_dns_cleanup is success
+      register: r_dns_cleanup
+      until: r_dns_cleanup is success
 
     - name: Get a list of clusters
       rhpds.assisted_installer.list_clusters:

--- a/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
@@ -45,7 +45,7 @@
         - "api"
         - "*.apps"
 
-    - name: DNS entry ({{ _dns_state | default('present') }})
+    - name: Delete dns records
       when: route53_aws_zone_id is defined
       amazon.aws.route53:
         state: absent
@@ -58,6 +58,9 @@
       loop:
         - "api"
         - "*.apps"
+      retries: 6
+      delay: 30
+      register: r_dns_cleanup is success
 
     - name: Get a list of clusters
       rhpds.assisted_installer.list_clusters:


### PR DESCRIPTION
##### SUMMARY

We are getting:

botocore.exceptions.ClientError: An error occurred (Throttling) when calling the ListResourceRecordSets operation (reached max retries: 4): Rate exceeded\n",


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-destroy role
