### PR TITLE
🌳 added mising TektonConfig step

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ml500/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ml500/tasks/workload.yml
@@ -145,6 +145,19 @@
 
 - name: Disable affinity assistant in Tekton
   block:
+    - name: Patch TektonConfig to disable affinity assistant
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: operator.tekton.dev/v1alpha1
+          kind: TektonConfig
+          metadata:
+            name: config
+          spec:
+            pipeline:
+              disable-affinity-assistant: true
+
     - name: Patch feature-flags ConfigMap to disable affinity assistant
       kubernetes.core.k8s:
         state: present


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
We need to disable the affinity assistant for the workshop so we are adding the necessary step for it. Thanks!

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ML500 MLOps Enablement

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
