### PR TITLE
rosa-consolidated: use helm from s3

### DIFF
--- a/ansible/configs/rosa-consolidated/default_vars.yml
+++ b/ansible/configs/rosa-consolidated/default_vars.yml
@@ -142,6 +142,7 @@ rosa_host_prefix: ""
 
 # Install helm on the bastion
 rosa_install_helm: true
+helm_url: https://catalog-item-assets.s3.us-east-2.amazonaws.com/helm-linux-amd64.tar.gz
 
 # Install terraform on the bastion (necessary for HCP deploy)
 rosa_install_terraform: true

--- a/ansible/configs/rosa-consolidated/install_helm.yml
+++ b/ansible/configs/rosa-consolidated/install_helm.yml
@@ -1,32 +1,31 @@
 ---
-- name: Set URL for helm
-  ansible.builtin.set_fact:
-    helm_url: >-
-      {{ '{0}/helm/latest/helm-linux-amd64.tar.gz'.format(ocp4_tools_root_url ) }}
-
 - name: Install Helm as root
   become: true
   block:
-  - name: Install helm command
-    ansible.builtin.unarchive:
-      src: "{{ helm_url }}"
-      remote_src: true
-      dest: /usr/local/bin
-      mode: ug=rwx,o=rx
-      owner: root
-      group: root
-    retries: 10
-    register: r_client
-    until: r_client is success
-    delay: 30
 
-  - name: Link downloaded helm command to helm
-    ansible.builtin.file:
-      src: /usr/local/bin/helm-linux-amd64
-      dest: /usr/local/bin/helm
-      owner: root
-      group: root
-      state: link
+  - name: Install Helm as root
+    become: true
+    block:
+    - name: Install helm command
+      ansible.builtin.unarchive:
+        src: "{{ helm_url }}"
+        remote_src: true
+        dest: /usr/local/bin
+        mode: "0775"
+        owner: root
+        group: root
+      retries: 10
+      register: r_client
+      until: r_client is success
+      delay: 30
 
-  - name: Create Helm Bash completion file
-    ansible.builtin.shell: /usr/local/bin/helm completion bash >/etc/bash_completion.d/helm
+    - name: Link downloaded helm command to helm
+      ansible.builtin.file:
+        src: /usr/local/bin/linux-amd64/helm
+        dest: /usr/local/bin/helm
+        owner: root
+        group: root
+        state: link
+
+    - name: Create Helm Bash completion file
+      ansible.builtin.shell: /usr/local/bin/helm completion bash >/etc/bash_completion.d/helm


### PR DESCRIPTION
bug fix:

download helm from S3 instead of flakey mirrors.openshift.ocm