### PR TITLE
Revert OpenShift AI workload to stable Aug 2025 version

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/tasks/workload.yml
@@ -18,66 +18,20 @@
     install_operator_catalogsource_image: "{{ ocp4_workload_openshift_ai_catalog_snapshot_image | default('') }}"
     install_operator_catalogsource_image_tag: "{{ ocp4_workload_openshift_ai_catalog_snapshot_image_tag | default('') }}"
 
-- name: Get installed CSVs
-  kubernetes.core.k8s_info:
-    api_version: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    namespace: openshift-operators
-  register: r_csvs
-
-- name: Get cluster ingress config
-  kubernetes.core.k8s_info:
-    api_version: config.openshift.io/v1
-    kind: Ingress
-    name: cluster
-  register: r_ingress_config
-  until: r_ingress_config.resources is defined
-  retries: 10
-  delay: 30
-
-- name: Set ingress domain
-  ansible.builtin.set_fact:
-    _ocp4_workload_openshift_ai_ingress_domain: "{{ r_ingress_config.resources[0].spec.domain }}"
-
-- name: Find CSV for the rhods operator
-  set_fact:
-    _ocp4_workload_openshift_ai_installed_operator_csv: "{{ item.metadata.name }}"
-  loop: "{{ r_csvs.resources }}"
-  when: "'rhods-operator' in item.metadata.name"
-
-- name: Set Openshift AI Version 3 boolean
-  ansible.builtin.set_fact:
-    _ocp4_workload_openshift_ai_version_3: "{{ _ocp4_workload_openshift_ai_installed_operator_csv.startswith('rhods-operator.3.') }}"
-
 - name: Create OpenShift AI Data Science Cluster
+  when: ocp4_workload_openshift_ai_deploy_dsc | bool
   kubernetes.core.k8s:
     state: present
-    template: redhat-datasciencecluster.yaml.j2
+    definition: "{{ lookup('template', './templates/redhat-datasciencecluster.yaml.j2') | from_yaml }}"
   register: r_ds_cluster
   until: not r_ds_cluster.failed
   retries: 10
   delay: 30
 
-- name: Check if Data Science Cluster is ready
-  kubernetes.core.k8s_info:
-    api_version: datasciencecluster.opendatahub.io/{{ 'v2' if _ocp4_workload_openshift_ai_version_3 else 'v1' }}
-    kind: DataScienceCluster
-    name: default-dsc
-  register: r_ds_cluster
-  until:
-  - r_ds_cluster.resources is defined
-  - r_ds_cluster.resources | length > 0
-  - r_ds_cluster.resources[0].status is defined
-  - r_ds_cluster.resources[0].status.phase is defined
-  - r_ds_cluster.resources[0].status.phase == 'Ready'
-  retries: 60
-  delay: 10
-
-- name: Create OpenShift AI Dashboard Route
-  when: _ocp4_workload_openshift_ai_version_3 | bool
-  kubernetes.core.k8s:
-    state: present
-    template: rhods-dashboard-route.yaml.j2
+- name: Print Data Science Cluster for debugging
+  ansible.builtin.debug:
+    msg: r_ds_cluster
+    verbosity: 2
 
 - name: Get the OpenShift AI dashboard route
   kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
@@ -1,5 +1,4 @@
 ---
-{% if not _ocp4_workload_openshift_ai_version_3 %}
 apiVersion: datasciencecluster.opendatahub.io/v1
 kind: DataScienceCluster
 metadata:
@@ -15,52 +14,15 @@ spec:
     kserve:
       {{ ocp4_workload_openshift_ai_kserve_config | to_yaml | indent(6) }}
     kueue:
-      {{ ocp4_workload_openshift_ai_kueue_config | to_yaml | indent(6) }}
-    modelmeshserving:
-      {{ ocp4_workload_openshift_ai_modelregistry_config }}
-    modelregistry:
-      {{ ocp4_workload_openshift_ai_modelregistry_config | to_yaml | indent(6) }}
-    ray:
-      {{ ocp4_workload_openshift_ai_ray_config | to_yaml | indent(6) }}
-    trustyai:
-      {{ ocp4_workload_openshift_ai_trustyai_config | to_yaml | indent(6) }}
-    workbenches:
-      {{ ocp4_workload_openshift_ai_workbenches_config | to_yaml | indent(6) }}
-{% else %}
-apiVersion: datasciencecluster.opendatahub.io/v2
-kind: DataScienceCluster
-metadata:
-  name: default-dsc
-spec:
-  components:
-    codeflare:
-      managementState: {{ ocp4_workload_openshift_ai_codeflare }}
-    dashboard:
-      managementState: {{ ocp4_workload_openshift_ai_dashboard }}
-    datasciencepipelines:
-      managementState: {{ ocp4_workload_openshift_ai_datasciencepipelines }}
-    kserve:
-      {{ ocp4_workload_openshift_ai_kserve_config | to_yaml | indent(6) }}
-    kueue:
-      {{ ocp4_workload_openshift_ai_kueue_config }}
+      managementState: {{ ocp4_workload_openshift_ai_kueue }}
     modelmeshserving:
       managementState: {{ ocp4_workload_openshift_ai_modelmeshserving }}
     modelregistry:
-      {{ ocp4_workload_openshift_ai_modelregistry_config | to_yaml | indent(6) }}
+      managementState: {{ ocp4_workload_openshift_ai_modelregistry }}
+      registriesNamespace: {{ ocp4_workload_openshift_ai_modelregistries_namespace }}
     ray:
-      {{ ocp4_workload_openshift_ai_ray_config | to_yaml | indent(6) }}
+      managementState: {{ ocp4_workload_openshift_ai_ray }}
     trustyai:
-      {{ ocp4_workload_openshift_ai_trustyai_config | to_yaml | indent(6) }}
+      managementState: {{ ocp4_workload_openshift_ai_trustyai }}
     workbenches:
-      {{ ocp4_workload_openshift_ai_workbenches_config | to_yaml | indent(6) }}
-    feastoperator:
-      {{ ocp4_workload_openshift_ai_feastoperator_config | to_yaml | indent(6) }}
-    llamastackoperator:
-      {{ ocp4_workload_openshift_ai_llamastackoperator_config | to_yaml | indent(6) }}
-    kueue:
-      {{ ocp4_workload_openshift_ai_kueue_config | to_yaml | indent(6) }}
-    aipipelines:
-      {{ ocp4_workload_openshift_ai_aipipelines_config | to_yaml | indent(6) }}
-    trainingoperator:
-     {{ ocp4_workload_openshift_ai_trainingoperator_config | to_yaml | indent(6) }}
-{% endif %}
+      managementState: {{ ocp4_workload_openshift_ai_workbenches }}


### PR DESCRIPTION
Reverting to commit d5f135bc7 (PR #9509) which was the last known working version from August 29, 2025. This removes the problematic CSV detection and version checking logic that was causing failures.

Changes:
- Removed CSV detection logic that checked wrong namespace
- Removed version 3 boolean and conditional template logic
- Simplified workload to just install operator and create DSC
- Kept 80 retries for dashboard route check (from PR #9509)
- Reverted template to use simple v1 API without conditionals

This should fix the rock-paper-scissor lab deployment issues.

