### PR TITLE
[bugfix] Allow more than 9 workers on static_network_config_full.j2

### DIFF
--- a/ansible/roles/host-ocp4-assisted-scale/templates/static_network_config_full.j2
+++ b/ansible/roles/host-ocp4-assisted-scale/templates/static_network_config_full.j2
@@ -1,4 +1,4 @@
-{% for index in range(0,worker_instance_count|int) %}
+{% for index in range(0, worker_instance_count | int) %}
 {% set worker_loop = loop %}
 - network_yaml: |
     interfaces:
@@ -10,7 +10,7 @@
       type: ethernet
     - ipv4:
         address:
-        - ip: {{ ai_network_prefix }}.3{{ index }}
+        - ip: {{ ai_network_prefix }}.{{ 30 + index | int }}
           prefix-length: 24
         dhcp: false
         enabled: true


### PR DESCRIPTION
##### SUMMARY

Currently is using 3{{ index }}, having more than 9 workers wil cause the ip is 310 instead 40

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
host-ocp4-assisted-scale role

