### PR TITLE
[GITOPS_WORKSHOP] Update Argo CD Check to fix problem with phase undefined

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_workshop/tasks/workload.yml
@@ -32,9 +32,12 @@
     namespace: "user{{ item }}-argocd"
   loop: "{{ range(1, num_users | int + 1) | list }}"
   register: r_argo_cr
-  retries: 10
+  retries: 30
   delay: 30
-  until: r_argo_cr.resources[0].status.phase == "Available"
+  until: >
+         r_argo_cr.resources[0].status is defined and
+         r_argo_cr.resources[0].status.phase is defined and
+         r_argo_cr.resources[0].status.phase == "Available"
 
 # label the workshop namespaces for argo
 - name: Label user namespaces with argo ownership


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

This fixes an issue with newer versions of the GitOps operator where the ArgoCD CR may not have a phase defined right away which causes the ansible check to fail. This PR updates the check to match what is used in the Advanced GitOps workshop which is deploying a newer version of the operator.

This change is needed to support upgrading the GitOps Workshop to 4.20 and GitOps 1.18. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

ocp4_workload_gitops_workshop