### PR TITLE
feat: enable gitops bootstrapping to configure app-of-apps sync

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/defaults/main.yml
@@ -14,7 +14,14 @@ ocp4_workload_gitops_bootstrap_helm_values: []
 ocp4_workload_gitops_bootstrap_health_retries: 60
 ocp4_workload_gitops_bootstrap_health_ignore: true
 
-# wait 15 mninutes for apps to roll out
+# wait 15 minutes for apps to roll out
 ocp4_workload_gitops_bootstrap_application_wait: true
 ocp4_workload_gitops_bootstrap_application_health_retries: 90
 ocp4_workload_gitops_bootstrap_application_health_ignore: true
+
+# control the sync behavior for child applications
+ocp4_workload_gitops_bootstrap_sync_prune: false
+ocp4_workload_gitops_bootstrap_sync_self_heal: false
+
+# this allows you to set managed applications to unmanaged after bootstrap, in case the above are also true
+ocp4_workload_gitops_bootstrap_sync_app_of_apps_allow_sync_config: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -27,5 +27,15 @@ spec:
     server: https://kubernetes.default.svc
   syncPolicy:
     automated:
-      prune: false
-      selfHeal: false
+      prune: {{ ocp4_workload_gitops_bootstrap_sync_prune }}
+      selfHeal: {{ ocp4_workload_gitops_bootstrap_sync_self_heal }}
+{% if ocp4_workload_gitops_bootstrap_sync_app_of_apps_allow_sync_config %}
+    syncOptions:
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: argoproj.io
+      kind: Application
+      jsonPointers:
+        - /spec/syncPolicy/automated
+        - /spec/syncPolicy/ignoreDifferences
+{% endif %}


### PR DESCRIPTION
##### SUMMARY

While this defaults to the same behavior as before, it allows using the bootstrap app as an app-of-apps (see
[the docs](https://argo-cd.readthedocs.io/en/latest/operator-manual/cluster-bootstrapping/#app-of-apps-pattern) on the pattern) which is suitable for iterative development. This is unlikely to be a setting exercised at all in normal deployments, but there should be little harm in using it even there.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`roles_ocp_workloads/ocp4_workload_gitops_bootstrap`

##### ADDITIONAL INFORMATION

 The configuration is expected to be exercised with variables set like this:

```yaml
ocp4_workload_gitops_bootstrap_sync_prune: false
ocp4_workload_gitops_bootstrap_sync_self_heal: false
ocp4_workload_gitops_bootstrap_sync_app_of_apps_allow_sync_config: false
```

The result of these variables is that:

- The bootstrap app will check for updates to the app-of-apps folder, by default, every 3 minutes and apply new Argo Applications it finds there, removing ones that have been removed there. This helps with, for example, renaming applications.
- Individual apps may or may not be configured with automated sync including prune and self heal, but if they are configured with prune and self heal then they will not be reconciled back to the definitions if prune and self heal are manually disabled on that app.

This supports a workflow where bootstrapped apps all enable prune and self heal by default, and when debugging or developing changes manually before committing them the behavior can be toggled live in the ArgoCD interface. When toggled, the bootstrap "app of apps" won't reconcile the sync policy back to the originally defined value.