### PR TITLE
fix: enable argocd application template using charts without values

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/defaults/main.yml
@@ -11,6 +11,9 @@ ocp4_workload_gitops_bootstrap_namespace: openshift-gitops
 # Helm values to override in the ArgoCD bootstrap application.
 ocp4_workload_gitops_bootstrap_helm_values: []
 
+# Default to using kustomize-envvar plugin if values not provided
+ocp4_workload_gitops_bootstrap_kustomize_envvar_plugin: true
+
 ocp4_workload_gitops_bootstrap_health_retries: 60
 ocp4_workload_gitops_bootstrap_health_ignore: true
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitops_bootstrap/templates/application.yaml.j2
@@ -18,7 +18,7 @@ spec:
          | to_nice_yaml
          | indent(width=8, first=False)
         }}
-{% else %}
+{% else if ocp4_workload_gitops_bootstrap_kustomize_envvar_plugin %}
     plugin:
       name: kustomize-envvar
 {% endif %}


### PR DESCRIPTION
##### SUMMARY

Enable ArgoCD application template using charts without values.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ocp4_workload_gitops_bootstrap`

##### ADDITIONAL INFORMATION

Previously, the logic expected _either_ Helm values files _or_ would use the kustomize-envvar plugin on ArgoCD. There should be a middle ground where the plugin is not used and values are not provided, which particularly makes sense for cases where reusable elements of the workload do not need to be customized in any way, with a consistent deployment of all ArgoCD-managed workloads while keeping parameterization inside AgnosticD-managed workloads (like the Showroom template, for example).

We support this code path with a default parameter that will preserve previous behavior, while allowing us to toggle off the expectation in the boostrap workload.

cc @ritzshah 