### PR TITLE
Add special keyword INSTANCEGUID to be translate to guid value

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -89,7 +89,7 @@
         #cloud-config
         ssh_authorized_keys:
         - {{ lookup('file', ssh_provision_pubkey_path ) }}
-        {{_instance.userdata|default('')|replace('#cloud-config','')|default('')}}
+        {{ _instance.userdata | default('') | replace('#cloud-config','') | replace('INSTANCEGUID', guid) | default('') }}
 
 - name: Set cloud init disk if needed
   when: _instance.disable_cloud_init | default(false) == false


### PR DESCRIPTION
##### SUMMARY

Allow to use INSTANCEGUID on the userdata to be translated to the guid value. Useful for have unique hostnames 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
infra-openshift-cnv-resources role
