### PR TITLE
Keep Azure credentials in bastion

### DIFF
--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -28,7 +28,7 @@
   - name: Remove Azure Credentials directory from bastion
     when: 
       - cloud_provider == 'azure'
-      - ocp4_cluster_azure_remove_bastion_credentials | default(false) | bool
+      - ocp4_cluster_azure_remove_bastion_credentials | default(true) | bool
     ansible.builtin.file:
       path: "/home/{{ ansible_user }}/.azure"
       state: absent

--- a/ansible/configs/ocp4-cluster/post_software.yml
+++ b/ansible/configs/ocp4-cluster/post_software.yml
@@ -26,7 +26,9 @@
       state: absent
 
   - name: Remove Azure Credentials directory from bastion
-    when: cloud_provider == 'azure'
+    when: 
+      - cloud_provider == 'azure'
+      - ocp4_cluster_azure_remove_bastion_credentials | default(false) | bool
     ansible.builtin.file:
       path: "/home/{{ ansible_user }}/.azure"
       state: absent


### PR DESCRIPTION
Keeps the Azure credentials after deploying the ocp4-cluster

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
