### PR TITLE
🌳 added mising TektonConfig step

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ai501/README.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai501/README.adoc
@@ -2,7 +2,7 @@
 
 == Role overview
 
-* This role install link:https://github.com/rhoai-genaiops/deploy-lab.git[AI501] course content into OpenShift
+* This role install link:https://github.com/rhoai-genaiops/deploy-lab.git[AI501] GenAIOps Enablement course content into OpenShift
 ** Playbook: link:./tasks/workload.yml[workload.yml]
 
 === Deploy a Workload with the `ocp-workload` playbook
@@ -19,7 +19,7 @@ ocp_password:
 guid: guid
 
 ocp_workloads:
-  - ocp4_workload_ai500
+  - ocp4_workload_ai501
 
 target_host:
   ansible_host: bastion.guid.sandbox123.opentlc.com

--- a/ansible/roles_ocp_workloads/ocp4_workload_ai501/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai501/tasks/workload.yml
@@ -143,24 +143,57 @@
         path: /spec/defaultRoute
         value: true
 
-- name: Patch GitOps Operator with user namespaces
+- name: Disable affinity assistant in Tekton
   block:
-    - name: Create namespace list
-      set_fact:
-        namespace_list: "{{ range(1, num_users + 1) | map('regex_replace', '^(.*)$', 'user\\1-toolings') | join(',') }}"
+    - name: Patch TektonConfig to disable affinity assistant
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: operator.tekton.dev/v1alpha1
+          kind: TektonConfig
+          metadata:
+            name: config
+          spec:
+            pipeline:
+              disable-affinity-assistant: true
 
-    - name: Patch OpenShift GitOps Operator subscription
-      kubernetes.core.k8s_json_patch:
-        api_version: operators.coreos.com/v1alpha1
-        kind: Subscription
-        name: openshift-gitops-operator
-        namespace: openshift-gitops-operator
-        patch:
-          - op: add
-            path: /spec/config/env/1
-            value:
-              name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
-              value: "{{ namespace_list }}"
+    - name: Patch feature-flags ConfigMap to disable affinity assistant
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: feature-flags
+            namespace: openshift-pipelines
+          data:
+            disable-affinity-assistant: "true"
+            coschedule: "disabled"
+
+    - name: Patch config-defaults ConfigMap to clear pod templates
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: config-defaults
+            namespace: openshift-pipelines
+          data:
+            default-affinity-assistant-pod-template: ""
+            default-pod-template: ""
+
+    - name: Delete Tekton pipelines controller pods to apply changes
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Pod
+        namespace: openshift-pipelines
+        label_selectors:
+          - app=tekton-pipelines-controller
 
 # Leave this as the last task in the playbook.
 - name: workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_ml500/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ml500/tasks/workload.yml
@@ -145,6 +145,19 @@
 
 - name: Disable affinity assistant in Tekton
   block:
+    - name: Patch TektonConfig to disable affinity assistant
+      kubernetes.core.k8s:
+        state: present
+        merge_type: merge
+        definition:
+          apiVersion: operator.tekton.dev/v1alpha1
+          kind: TektonConfig
+          metadata:
+            name: config
+          spec:
+            pipeline:
+              disable-affinity-assistant: true
+
     - name: Patch feature-flags ConfigMap to disable affinity assistant
       kubernetes.core.k8s:
         state: present


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

We need to disable the affinity assistant for the workshop so we are adding the necessary step for it. Thanks!

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
AI501 GenAIOps Enablement

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
