### PR TITLE
Fix: Improve robustness of the deployment

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/post_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/post_workload.yml
@@ -15,7 +15,7 @@
     - ""
     - "Lab WebAPP: https://{{ bastion_public_hostname }}/content/"
     - ""
-  when: platform_demo_redhat_com
+  when: platform_demo_redhat_com|bool
 
 - name: Save user data
   agnosticd_user_info:
@@ -26,7 +26,7 @@
       debug_hypervisor_ip: "{{ hypervisor_public_ip }}"
       debug_hypervisor_ssh_user: "{{ bastion_ssh_user_name }}"
       debug_hypervisor_ssh_password: "{{ student_password }}"
-  when: platform_demo_redhat_com
+  when: platform_demo_redhat_com|bool
 
 # Leave this as the last task in the playbook.
 - name: post_workload tasks complete

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -132,6 +132,7 @@
   ansible.builtin.shell:
     cmd: kcli list pool | grep -c default
   register: default_pool
+  failed_when: default_pool.stderr != ""
 
 - name: Ensure default image pool is present
   ansible.builtin.command:
@@ -540,13 +541,13 @@
     body: '{"service":"2","clone_addr":"{{ item.repo_url }}","uid":1,"repo_name":"{{ item.repo_name }}"}'
     # yamllint enable rule:line-length
     body_format: json
-    status_code: 201
+    return_content: true
     force_basic_auth: true
   register: result
-  until: result.status == 201 or "The repository with the same name already exists" in result.json.message
+  until: result.status == 201 or (result.json is defined and result.json.message is defined and "The repository with the same name already exists" in result.json.message)
   retries: 10
   delay: 10
-  failed_when: result.status != 201 and "The repository with the same name already exists" not in result.json.message
+  failed_when: result.status != 201 and (result.json is not defined or result.json.message is not defined or "The repository with the same name already exists" not in result.json.message)
   # yamllint disable rule:line-length
   loop:
     - {repo_url: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab.git", repo_name: "5g-ran-deployments-on-ocp-lab"}

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/pre_workload.yml
@@ -544,10 +544,18 @@
     return_content: true
     force_basic_auth: true
   register: result
-  until: result.status == 201 or (result.json is defined and result.json.message is defined and "The repository with the same name already exists" in result.json.message)
+  until: >-
+    result.status == 201 or
+    (result.json is defined and
+     result.json.message is defined and
+     "The repository with the same name already exists" in result.json.message)
   retries: 10
   delay: 10
-  failed_when: result.status != 201 and (result.json is not defined or result.json.message is not defined or "The repository with the same name already exists" not in result.json.message)
+  failed_when: >-
+    result.status != 201 and
+    (result.json is not defined or
+     result.json.message is not defined or
+     "The repository with the same name already exists" not in result.json.message)
   # yamllint disable rule:line-length
   loop:
     - {repo_url: "https://github.com/{{ repo_user }}/5g-ran-deployments-on-ocp-lab.git", repo_name: "5g-ran-deployments-on-ocp-lab"}

--- a/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_5gran_deployments_lab/tasks/workload.yml
@@ -165,7 +165,12 @@
       - app.kubernetes.io/name = openshift-gitops-repo-server
   register: result
   until:
+    - result.resources | length > 0
+    - result.resources[0].status is defined
+    - result.resources[0].status.phase is defined
     - result.resources[0].status.phase == "Running"
+    - result.resources[0].status.containerStatuses is defined
+    - result.resources[0].status.containerStatuses | length > 0
     - result.resources[0].status.containerStatuses[0].ready == true
   retries: 10
   delay: 10
@@ -225,7 +230,11 @@
     - argocd_app_hub_operators is defined
     - argocd_app_hub_operators.resources | length > 0
     - argocd_app_hub_operators.resources[0].status is defined
+    - argocd_app_hub_operators.resources[0].status.health is defined
+    - argocd_app_hub_operators.resources[0].status.health.status is defined
     - argocd_app_hub_operators.resources[0].status.health.status == "Healthy"
+    - argocd_app_hub_operators.resources[0].status.sync is defined
+    - argocd_app_hub_operators.resources[0].status.sync.status is defined
     - argocd_app_hub_operators.resources[0].status.sync.status == "Synced"
 
 - name: Wait until ArgoCD APP for HUB Cluster Operators config is ready
@@ -242,7 +251,11 @@
     - argocd_app_hub_operators is defined
     - argocd_app_hub_operators.resources | length > 0
     - argocd_app_hub_operators.resources[0].status is defined
+    - argocd_app_hub_operators.resources[0].status.health is defined
+    - argocd_app_hub_operators.resources[0].status.health.status is defined
     - argocd_app_hub_operators.resources[0].status.health.status == "Healthy"
+    - argocd_app_hub_operators.resources[0].status.sync is defined
+    - argocd_app_hub_operators.resources[0].status.sync.status is defined
     - argocd_app_hub_operators.resources[0].status.sync.status == "Synced"
 
 - name: Wait until MultiClusterHub is ready
@@ -314,7 +327,11 @@
     - argocd_app_snoseed_deployment is defined
     - argocd_app_snoseed_deployment.resources | length > 0
     - argocd_app_snoseed_deployment.resources[0].status is defined
+    - argocd_app_snoseed_deployment.resources[0].status.health is defined
+    - argocd_app_snoseed_deployment.resources[0].status.health.status is defined
     - argocd_app_snoseed_deployment.resources[0].status.health.status == "Healthy"
+    - argocd_app_snoseed_deployment.resources[0].status.sync is defined
+    - argocd_app_snoseed_deployment.resources[0].status.sync.status is defined
     - argocd_app_snoseed_deployment.resources[0].status.sync.status == "Synced"
 
 - name: Wait for SNO Seed cluster to start deploying
@@ -349,6 +366,8 @@
     - snoseed_agentclusterinstall is defined
     - snoseed_agentclusterinstall.resources | length > 0
     - snoseed_agentclusterinstall.resources[0].status is defined
+    - snoseed_agentclusterinstall.resources[0].status.debugInfo is defined
+    - snoseed_agentclusterinstall.resources[0].status.debugInfo.state is defined
     - snoseed_agentclusterinstall.resources[0].status.debugInfo.state == "adding-hosts"
 
 - name: Extract SNO Seed kubeconfig
@@ -421,6 +440,8 @@
   until:
     - oadpoperator is defined
     - oadpoperator.resources | length > 0
+    - oadpoperator.resources[0].status is defined
+    - oadpoperator.resources[0].status.phase is defined
     - oadpoperator.resources[0].status.phase == "Succeeded"
 
 - name: Wait until LCA is installed
@@ -437,6 +458,8 @@
   until:
     - lcaoperator is defined
     - lcaoperator.resources | length > 0
+    - lcaoperator.resources[0].status is defined
+    - lcaoperator.resources[0].status.phase is defined
     - lcaoperator.resources[0].status.phase == "Succeeded"
 
 - name: Wait until LVMS is ready
@@ -453,6 +476,8 @@
   until:
     - lvmsoperator is defined
     - lvmsoperator.resources | length > 0
+    - lvmsoperator.resources[0].status is defined
+    - lvmsoperator.resources[0].status.phase is defined
     - lvmsoperator.resources[0].status.phase == "Succeeded"
 
 - name: Wait until SR-IOV is ready
@@ -469,6 +494,8 @@
   until:
     - sriovoperator is defined
     - sriovoperator.resources | length > 0
+    - sriovoperator.resources[0].status is defined
+    - sriovoperator.resources[0].status.phase is defined
     - sriovoperator.resources[0].status.phase == "Succeeded"
 
 - name: Wait until Cluster logging is ready
@@ -485,6 +512,8 @@
   until:
     - logging is defined
     - logging.resources | length > 0
+    - logging.resources[0].status is defined
+    - logging.resources[0].status.phase is defined
     - logging.resources[0].status.phase == "Succeeded"
 
 - name: Wait until PTP is ready
@@ -501,6 +530,8 @@
   until:
     - ptpoperator is defined
     - ptpoperator.resources | length > 0
+    - ptpoperator.resources[0].status is defined
+    - ptpoperator.resources[0].status.phase is defined
     - ptpoperator.resources[0].status.phase == "Succeeded"
 
 - name: Configure SR-IOV in SNO Seed


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Improve robustness of the lab deployment by checking the k8s resources and retry in case there is an issue either with the response or the status of the component.

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
- ocp4_workload_5gran_deployments_lab role
- 
##### ADDITIONAL INFORMATION
- Improve robustness of Kubernetes resource status checks
- Fixes problem when gitea is stopped or not responding
- Fixes variable platform_demo_redhat_com to boolean

cc/ @bbethell-1 @perryrivera1 @YoNoSoyVictor 