### PR TITLE
Fix RHAIIS systemd service to run podman container in foreground

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_rhaiis_on_rhel/templates/rhaiis.service.j2
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_rhaiis_on_rhel/templates/rhaiis.service.j2
@@ -7,8 +7,9 @@ Type=simple
 Environment="HUGGING_FACE_HUB_TOKEN={{ setup_rhaiis_on_rhel_hf_token }}"
 Environment="HF_HUB_OFFLINE=0"
 User={{ student_name | default('dev') }}
-ExecStart=/usr/bin/podman run --rm -it --device nvidia.com/gpu=all -p {{ setup_rhaiis_on_rhel_vllm_port }}:8000 \
+ExecStart=/usr/bin/podman run --rm --device nvidia.com/gpu=all -p {{ setup_rhaiis_on_rhel_vllm_port }}:8000 \
     --ipc=host \
+    --log-driver=journald \
     --env "HUGGING_FACE_HUB_TOKEN=${HUGGING_FACE_HUB_TOKEN}" \
     --env "HF_HUB_OFFLINE=${HF_HUB_OFFLINE}" \
     -v {{ setup_rhaiis_on_rhel_vllm_cache_dir }}:/home/vllm/.cache \


### PR DESCRIPTION
## Summary
- Removed `-it` flags from podman run command in systemd service unit
- Added `--log-driver=journald` for proper systemd logging integration

## Problem
The `-i` (interactive) and `-t` (TTY) flags are incompatible with systemd services. When used with `Type=simple`, these flags prevent proper service lifecycle management, causing systemd to not properly track the container process.

## Solution
Removed the interactive/TTY flags and added journald logging driver so the service runs in foreground mode compatible with systemd's process supervision.

## Test plan
- [ ] Deploy the RHAIIS service with the updated systemd unit file
- [ ] Verify service starts successfully with `systemctl status rhaiis`
- [ ] Verify logs appear in journalctl
- [ ] Verify service restarts on failure as configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)