### PR TITLE
[ocp4_workload_external_odf] Update storagecluster.yaml.j2 to ignore reconcile

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_external_odf/templates/storagecluster.yaml.j2
@@ -35,8 +35,7 @@ spec:
 {% endif %}
   managedResources:
     cephBlockPools:
-      disableStorageClass: true
-      storageClassName: do-not-use
+      reconcileStrategy: ignore
     cephFilesystems: {}
     cephObjectStoreUsers: {}
     cephObjectStores: {}


### PR DESCRIPTION
##### SUMMARY

New version of ODF doesn't allow to disable the creation of the storageClass. We need to change the storageClass to specify the volume prefix, for cleanup reasons. This PR disables the reconcole, so we can overwrite the storageclass definition

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_external_odf role
