### PR TITLE
trident-binder: use trident_one aws keys for bucket

### DIFF
--- a/ansible/configs/trident-binder/setup_s3_bucket.yml
+++ b/ansible/configs/trident-binder/setup_s3_bucket.yml
@@ -3,8 +3,8 @@
   amazon.aws.s3_bucket:
     name: "{{ ocp_dr_trident_s3_bucket_name }}"
     state: present
-    access_key: "{{ aws_access_key_id }}"
-    secret_key: "{{ aws_secret_access_key }}"
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
     region: "{{ trident_one.aws_default_region }}"
     public_access:
       block_public_acls: false
@@ -21,8 +21,8 @@
   amazon.aws.s3_bucket:
     name: "{{ ocp_dr_trident_s3_bucket_name }}"
     state: present
-    access_key: "{{ aws_access_key_id }}"
-    secret_key: "{{ aws_secret_access_key }}"
+    access_key: "{{ trident_one.aws_access_key_id }}"
+    secret_key: "{{ trident_one.aws_secret_access_key }}"
     region: "{{ trident_one.aws_default_region }}"
     policy: |
       {


### PR DESCRIPTION

- Bugfix Pull Request

I used the wrong account to make s3 buckets.  They kept getting reaped.