### PR TITLE
[ocp4_workload_showroom] Increase wait time for ZT showroom pods to be healthy to 15 minutes

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -155,7 +155,7 @@
     namespace: "{{ _showroom_namespace }}"
     name: "{{ _showroom_pod_name }}"
   register: r_pod_status
-  retries: 60
+  retries: 180
   delay: 5
   until:
     - r_pod_status.resources | length > 0


### PR DESCRIPTION
##### SUMMARY
Setup scripts can take > 5mins to complete, increased the timeout for healthy pods to 15 minutes


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ocp4_workload_showroom