### PR TITLE
[infra-openshift-cnv-resources] Add NodePort Service Support to infra-openshift-cnv-resources

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_service.yaml
@@ -70,3 +70,42 @@
   until: r_service is success
   retries: "{{ openshift_cnv_retries }}"
   delay: "{{ openshift_cnv_delay }}"
+
+- name: Gather NodePort allocation
+  when: service.type | default('ClusterIP') == "NodePort"
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    name: "{{ service.name }}"
+    namespace: "{{ openshift_cnv_namespace }}"
+  register: svc_np
+
+- name: If exist set the nodePorts for the instance
+  when: service.type | default("ClusterIP") == "NodePort"
+  ansible.builtin.set_fact:
+    _instance_node_ports: "{{ svc_np.resources[0].spec.ports | map(attribute='nodePort') | join(',') }}"
+
+- name: Add NodePort annotation for service {{ service.name }} to the instance
+  when: service.type | default("ClusterIP") == "NodePort"
+  kubernetes.core.k8s:
+    state: patched
+    api_version: v1
+    kind: VirtualMachine
+    name: "{{ _instance_name }}"
+    definition: |
+      apiVersion: v1
+      kind: VirtualMachine
+      metadata:
+        name: "{{ _instance_name }}"
+        namespace: "{{ openshift_cnv_namespace }}"
+        annotations:
+          NodePort-{{ service.name }}: "{{ _instance_node_ports }}"
+  vars:
+    _instance_name: "{{ _instance.name }}{{ _index+1 if _instance.count|d(1)|int > 1 }}"
+  loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
+  loop_control:
+    index_var: _index
+  register: r_service
+  until: r_service is success
+  retries: "{{ openshift_cnv_retries }}"
+  delay: "{{ openshift_cnv_delay }}"


### PR DESCRIPTION
##### SUMMARY
This PR adds NodePort service support to the `infra-openshift-cnv-resources` role. Configuration follows the same pattern as LoadBalancer services with optional explicit `nodePort` values (30000-32767 range) or OpenShift auto-assignment.
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- infra-openshift-cnv-resources