### PR TITLE
Add support for ACME Bifrost to Cert Manager

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -98,6 +98,15 @@ ocp4_workload_cert_manager_catalog_snapshot_image_tag: ""
 # Gateway URL for Acme Bifrost
 ocp4_workload_cert_manager_acme_bifrost_gateway_url: ""
 
+# CA Provider for Acme Bifrost
+ocp4_workload_cert_manager_acme_bifrost_ca_provider: "letsencrypt"
+
+# Webhook KID for Acme Bifrost
+ocp4_workload_cert_manager_acme_bifrost_webhook_kid: ""
+
+# Webhook Secret for Acme Bifrost
+ocp4_workload_cert_manager_acme_bifrost_webhook_secret: ""
+
 # Image to be used for the webhook for Acme Bifrost
 ocp4_workload_cert_manager_acme_bifrost_webhook_image: ""
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/defaults/main.yml
@@ -83,7 +83,6 @@ ocp4_workload_cert_manager_azure_resource_group_name: "{{ az_dnszone_resource_gr
 ocp4_workload_cert_manager_azure_subscription_id: "{{ azure_subscription_id }}"
 ocp4_workload_cert_manager_azure_tenant_id: "{{ azure_tenant }}"
 
-
 # ---------------------------------------------------------------
 # Operator settings
 # ---------------------------------------------------------------
@@ -95,6 +94,12 @@ ocp4_workload_cert_manager_use_catalog_snapshot: false
 ocp4_workload_cert_manager_catalogsource_name: redhat-operators-snapshot-cert-manager
 ocp4_workload_cert_manager_catalog_snapshot_image: ""
 ocp4_workload_cert_manager_catalog_snapshot_image_tag: ""
+
+# Gateway URL for Acme Bifrost
+ocp4_workload_cert_manager_acme_bifrost_gateway_url: ""
+
+# Image to be used for the webhook for Acme Bifrost
+ocp4_workload_cert_manager_acme_bifrost_webhook_image: ""
 
 # Internal vars. Don't set
 _ocp4_workload_cert_manager_api_hostname: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -57,8 +57,7 @@
 - name: Print API and wildcard domain
   ansible.builtin.debug:
     msg: >-
-      API: {{ _ocp4_workload_cert_manager_api_hostname }},
-      Wildcard Domain: *.{{ _ocp4_workload_cert_manager_wildcard_domain }}
+      API: {{ _ocp4_workload_cert_manager_api_hostname }}, Wildcard Domain: *.{{ _ocp4_workload_cert_manager_wildcard_domain }}
 
 - name: Wait until CertManager is ready
   kubernetes.core.k8s_info:
@@ -104,6 +103,16 @@
   retries: 10
   delay: 30
   until: r_clusterissuer_fallback is success
+
+- name: Deploy ACME Bifrost webhook
+  when: ocp4_workload_cert_manager_cloud_provider == "acme-bifrost"
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'webhook_acme_bifrost.yaml.j2') }}"
+  register: r_webhook_acme_bifrost
+  retries: 10
+  delay: 30
+  until: r_webhook_acme_bifrost is success
 
 - name: Install Ingress controller certificate
   when: ocp4_workload_cert_manager_install_ingress_certificates | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/tasks/workload.yml
@@ -27,7 +27,7 @@
 
 - name: Update CertManager for EC2/GCP/Azure to use external DNS
   when: >
-    ocp4_workload_cert_manager_cloud_provider in ["ec2", "gcp", "azure"]
+    ocp4_workload_cert_manager_cloud_provider in ["ec2", "gcp", "azure", "acme-bifrost"]
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'certmanager.yaml.j2') }}"
@@ -105,7 +105,7 @@
   until: r_clusterissuer_fallback is success
 
 - name: Deploy ACME Bifrost webhook
-  when: ocp4_workload_cert_manager_cloud_provider == "acme-bifrost"
+  when: ocp4_workload_cert_manager_provider == "acme-bifrost"
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('template', 'webhook_acme_bifrost.yaml.j2') }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -53,3 +53,20 @@ spec:
           subscriptionID: {{ ocp4_workload_cert_manager_azure_subscription_id }}
           tenantID: {{ ocp4_workload_cert_manager_azure_tenant_id }}
 {% endif %}
+{% if ocp4_workload_cert_manager_cloud_provider == "acme-bifrost" %}
+        webhook:
+          groupName: acme.gateway.redhat.com
+          solverName: gateway-passthrough
+          config:
+            gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
+            region: {{ ocp4_workload_cert_manager_ec2_region }}
+            zoneIDSecretRef:
+              name: cert-manager-aws-creds
+              key: aws_hosted_zone_id
+            accessKeyIDSecretRef:
+              name: cert-manager-aws-creds
+              key: aws_access_key_id
+            secretAccessKeySecretRef:
+              name: cert-manager-aws-creds
+              key: aws_secret_access_key
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -24,7 +24,7 @@ spec:
         - {{ _ocp4_workload_cert_manager_api_hostname }}
         - {{ _ocp4_workload_cert_manager_wildcard_domain }}
       dns01:
-{% if ocp4_workload_cert_manager_cloud_provider == "ec2" %}      
+{% if ocp4_workload_cert_manager_cloud_provider == "ec2" and ocp4_workload_cert_manager_provider != "acme-bifrost" %}      
         route53:
           region: {{ ocp4_workload_cert_manager_ec2_region }}
           hostedZoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
@@ -53,7 +53,7 @@ spec:
           subscriptionID: {{ ocp4_workload_cert_manager_azure_subscription_id }}
           tenantID: {{ ocp4_workload_cert_manager_azure_tenant_id }}
 {% endif %}
-{% if ocp4_workload_cert_manager_cloud_provider == "acme-bifrost" %}
+{% if ocp4_workload_cert_manager_provider == "acme-bifrost" %}
         webhook:
           groupName: acme.gateway.redhat.com
           solverName: gateway-passthrough

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -53,16 +53,14 @@ spec:
           subscriptionID: {{ ocp4_workload_cert_manager_azure_subscription_id }}
           tenantID: {{ ocp4_workload_cert_manager_azure_tenant_id }}
 {% endif %}
-{% if ocp4_workload_cert_manager_provider == "acme-bifrost" %}
+{% if ocp4_workload_cert_manager_cloud_provider == "acme-bifrost" %}
         webhook:
           groupName: acme.gateway.redhat.com
           solverName: gateway-passthrough
           config:
             gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
             region: {{ ocp4_workload_cert_manager_ec2_region }}
-            zoneIDSecretRef:
-              name: cert-manager-aws-creds
-              key: aws_hosted_zone_id
+            zoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
             accessKeyIDSecretRef:
               name: cert-manager-aws-creds
               key: aws_access_key_id

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -53,14 +53,16 @@ spec:
           subscriptionID: {{ ocp4_workload_cert_manager_azure_subscription_id }}
           tenantID: {{ ocp4_workload_cert_manager_azure_tenant_id }}
 {% endif %}
-{% if ocp4_workload_cert_manager_cloud_provider == "acme-bifrost" %}
+{% if ocp4_workload_cert_manager_provider == "acme-bifrost" %}
         webhook:
           groupName: acme.gateway.redhat.com
           solverName: gateway-passthrough
           config:
             gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
             region: {{ ocp4_workload_cert_manager_ec2_region }}
-            zoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
+            zoneIDSecretRef:
+              name: cert-manager-aws-creds
+              key: aws_hosted_zone_id
             accessKeyIDSecretRef:
               name: cert-manager-aws-creds
               key: aws_access_key_id

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -59,6 +59,7 @@ spec:
           solverName: gateway-passthrough
           config:
             gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
+            caProvider: {{ ocp4_workload_cert_manager_acme_bifrost_ca_provider | default("letsencrypt") }}
             region: {{ ocp4_workload_cert_manager_ec2_region }}
             zoneID: "{{ _ocp4_workload_cert_manager_hostedzoneid }}"  
             accessKeyIDSecretRef:

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -67,4 +67,6 @@ spec:
             secretAccessKeySecretRef:
               name: cert-manager-aws-creds
               key: aws_secret_access_key
+            webhookKID: "{{ ocp4_workload_cert_manager_acme_bifrost_webhook_kid }}"
+            webhookSecret: "{{ ocp4_workload_cert_manager_acme_bifrost_webhook_secret }}"        
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer.yaml.j2
@@ -60,9 +60,7 @@ spec:
           config:
             gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
             region: {{ ocp4_workload_cert_manager_ec2_region }}
-            zoneIDSecretRef:
-              name: cert-manager-aws-creds
-              key: aws_hosted_zone_id
+            zoneID: "{{ _ocp4_workload_cert_manager_hostedzoneid }}"  
             accessKeyIDSecretRef:
               name: cert-manager-aws-creds
               key: aws_access_key_id

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
@@ -53,3 +53,20 @@ spec:
           subscriptionID: {{ ocp4_workload_cert_manager_azure_subscription_id }}
           tenantID: {{ ocp4_workload_cert_manager_azure_tenant_id }}
 {% endif %}
+{% if ocp4_workload_cert_manager_cloud_provider == "acme-bifrost" %}
+        webhook:
+          groupName: acme.gateway.redhat.com
+          solverName: gateway-passthrough
+          config:
+            gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
+            region: {{ ocp4_workload_cert_manager_ec2_region }}
+            zoneIDSecretRef:
+              name: cert-manager-aws-creds
+              key: aws_hosted_zone_id
+            accessKeyIDSecretRef:
+              name: cert-manager-aws-creds
+              key: aws_access_key_id
+            secretAccessKeySecretRef:
+              name: cert-manager-aws-creds
+              key: aws_secret_access_key
+{% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
@@ -60,9 +60,7 @@ spec:
           config:
             gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
             region: {{ ocp4_workload_cert_manager_ec2_region }}
-            zoneIDSecretRef:
-              name: cert-manager-aws-creds
-              key: aws_hosted_zone_id
+            zoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
             accessKeyIDSecretRef:
               name: cert-manager-aws-creds
               key: aws_access_key_id

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
@@ -59,6 +59,7 @@ spec:
           solverName: gateway-passthrough
           config:
             gatewayURL: {{ ocp4_workload_cert_manager_acme_bifrost_gateway_url }}
+            caProvider: {{ ocp4_workload_cert_manager_acme_bifrost_ca_provider | default("letsencrypt") }}
             region: {{ ocp4_workload_cert_manager_ec2_region }}
             zoneID: {{ _ocp4_workload_cert_manager_hostedzoneid }}
             accessKeyIDSecretRef:

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
@@ -67,4 +67,6 @@ spec:
             secretAccessKeySecretRef:
               name: cert-manager-aws-creds
               key: aws_secret_access_key
+            webhookKID: "{{ ocp4_workload_cert_manager_acme_bifrost_webhook_kid }}"
+            webhookSecret: "{{ ocp4_workload_cert_manager_acme_bifrost_webhook_secret }}"        
 {% endif %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/clusterissuer_fallback.yaml.j2
@@ -53,7 +53,7 @@ spec:
           subscriptionID: {{ ocp4_workload_cert_manager_azure_subscription_id }}
           tenantID: {{ ocp4_workload_cert_manager_azure_tenant_id }}
 {% endif %}
-{% if ocp4_workload_cert_manager_cloud_provider == "acme-bifrost" %}
+{% if ocp4_workload_cert_manager_provider_fallback == "acme-bifrost" %}
         webhook:
           groupName: acme.gateway.redhat.com
           solverName: gateway-passthrough

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/webhook_acme_bifrost.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/webhook_acme_bifrost.yaml.j2
@@ -33,6 +33,38 @@ subjects:
   name: acme-bifrost-webhook
   namespace: cert-manager
 ---
+# ClusterRole for cert-manager to create webhook solver resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: acme-bifrost-webhook:flowcontrol-solver
+  labels:
+    app: acme-bifrost-webhook
+rules:
+- apiGroups:
+  - acme.gateway.redhat.com
+  resources:
+  - '*'
+  verbs:
+  - 'create'
+---
+# ClusterRoleBinding for cert-manager to use the webhook
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: acme-bifrost-webhook:flowcontrol-solver
+  labels:
+    app: acme-bifrost-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: acme-bifrost-webhook:flowcontrol-solver
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cert-manager
+  namespace: cert-manager
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/webhook_acme_bifrost.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/webhook_acme_bifrost.yaml.j2
@@ -65,6 +65,38 @@ subjects:
   name: cert-manager
   namespace: cert-manager
 ---
+# ClusterRole for webhook to create subjectaccessreviews (required for API aggregation)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: acme-bifrost-webhook:subjectaccessreviews
+  labels:
+    app: acme-bifrost-webhook
+rules:
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+# ClusterRoleBinding for webhook subjectaccessreviews
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: acme-bifrost-webhook:subjectaccessreviews
+  labels:
+    app: acme-bifrost-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: acme-bifrost-webhook:subjectaccessreviews
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/webhook_acme_bifrost.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/templates/webhook_acme_bifrost.yaml.j2
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "get"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: acme-bifrost-webhook
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+spec:
+  type: ClusterIP
+  ports:
+  - port: 443
+    targetPort: 8443
+    protocol: TCP
+    name: https
+  selector:
+    app: acme-bifrost-webhook
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: acme-bifrost-webhook
+  namespace: cert-manager
+  labels:
+    app: acme-bifrost-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: acme-bifrost-webhook
+  template:
+    metadata:
+      labels:
+        app: acme-bifrost-webhook
+    spec:
+      serviceAccountName: acme-bifrost-webhook
+      containers:
+      - name: webhook
+        image: {{ ocp4_workload_cert_manager_acme_bifrost_webhook_image }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - --tls-cert-file=/tls/tls.crt
+        - --tls-private-key-file=/tls/tls.key
+        - --secure-port=8443
+        env:
+        - name: GROUP_NAME
+          value: "acme.gateway.redhat.com"
+        ports:
+        - name: https
+          containerPort: 8443
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: https
+        readinessProbe:
+          httpGet:
+            scheme: HTTPS
+            path: /healthz
+            port: https
+        volumeMounts:
+        - name: certs
+          mountPath: /tls
+          readOnly: true
+      volumes:
+      - name: certs
+        secret:
+          secretName: acme-bifrost-webhook-webhook-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: acme-bifrost-webhook-webhook-tls
+  namespace: cert-manager
+spec:
+  secretName: acme-bifrost-webhook-webhook-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+  dnsNames:
+  - acme-bifrost-webhook
+  - acme-bifrost-webhook.cert-manager
+  - acme-bifrost-webhook.cert-manager.svc
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.acme.gateway.redhat.com
+  labels:
+    app: acme-bifrost-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: "cert-manager/acme-bifrost-webhook-webhook-tls"
+spec:
+  group: acme.gateway.redhat.com
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: acme-bifrost-webhook
+    namespace: cert-manager
+  version: v1alpha1
+


### PR DESCRIPTION
##### SUMMARY

ACME Bifrost is an internal RHDP project acting as a gateway to generate SSL certificates from different providers (zerossl, zerossl rest api, google ssl and letsencrypt)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ocp4_workload_cert_manager role