### PR TITLE
Update deploy_automationcontroller role, add redis_mode option for AP 2.6

### DIFF
--- a/ansible/roles/deploy_automationcontroller/templates/automationcontroller_inventory.j2
+++ b/ansible/roles/deploy_automationcontroller/templates/automationcontroller_inventory.j2
@@ -33,7 +33,7 @@ admin_password='{{ deploy_automationcontroller_admin_password }}'
 automationhub_admin_password='{{ deploy_automationcontroller_admin_password }}'
 ansible_become=true
 ansible_become_method=sudo
-{% if groups['deploy_automationcontroller_redis_mode'] is defined %}
+{% if deploy_automationcontroller_redis_mode is defined %}
 redis_mode='{{ deploy_automationcontroller_redis_mode }}'
 {% endif %}
 {% if groups['automationcontroller_database'] is defined %}

--- a/ansible/roles/deploy_automationcontroller/templates/automationcontroller_inventory.j2
+++ b/ansible/roles/deploy_automationcontroller/templates/automationcontroller_inventory.j2
@@ -33,7 +33,9 @@ admin_password='{{ deploy_automationcontroller_admin_password }}'
 automationhub_admin_password='{{ deploy_automationcontroller_admin_password }}'
 ansible_become=true
 ansible_become_method=sudo
-
+{% if groups['deploy_automationcontroller_redis_mode'] is defined %}
+redis_mode='{{ deploy_automationcontroller_redis_mode }}'
+{% endif %}
 {% if groups['automationcontroller_database'] is defined %}
 pg_host={{ groups['automationcontroller_database'][0] }}
 pg_port='5432'


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Updating roole to allow for AAP 2.6 deployments. Specifically adding the `redis_mode` variable to the inventory template.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ansible/roles/deploy_automationcontroller/tempaltes/automationcontroller_inventory.j2
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
