### PR TITLE
Change role ocp4_workload_microshift to update vm-microshift template to expand storage

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
@@ -62,13 +62,25 @@ spec:
             ssh_pwauth: false
             ssh_authorized_keys:
             - {{ r_microshift_public_key.content | b64decode | trim }}
+              
+            growpart:
+              mode: auto
+              devices: ['/']
+              
             bootcmd:
-            - "pvcreate /dev/vdb"
-            - "vgcreate rhel /dev/vdb"
-            - "mkdir /mnt/secretdisk"
-            - "mount /dev/$(lsblk --nodeps -no name,serial | grep D23YZ9W6WA5DJ487 | cut -f1 -d' ') /mnt/secretdisk"
-            - "cp /mnt/secretdisk/openshift-pull-secret /etc/crio/openshift-pull-secret"
-            - "chmod 600 /etc/crio/openshift-pull-secret"
+              - "mkdir -p /mnt/secretdisk"
+              - "mount /dev/$(lsblk --nodeps -no name,serial | grep D23YZ9W6WA5DJ487 | cut -f1 -d' ') /mnt/secretdisk"
+              - "cp /mnt/secretdisk/openshift-pull-secret /etc/crio/openshift-pull-secret"
+              - "chmod 600 /etc/crio/openshift-pull-secret"
+
+            runcmd:
+              - [ growpart, /dev/vda, "2" ]
+              - [ pvresize, /dev/vda2 ]
+              - [ udevadm, settle ]
+              - [ pvcreate, /dev/vdb ]
+              - [ vgextend, rhel, /dev/vdb ]
+              - [ lvextend, -l, "+100%FREE", /dev/mapper/rhel-root ]
+              - [ xfs_growfs, / ]
   dataVolumeTemplates:
   - metadata:
       name: microshift-rootdisk


### PR DESCRIPTION
##### SUMMARY
Configures cloud-init in the `vm-microshift.yaml.j2` template for automatic disk expansion, enabling automatic partition growth on the root device, resizes the physical volume and extends the volume group and logical volume. Previously this had to be manually done by the user once the environment was provisioned.  

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4_workload_microshift

##### ADDITIONAL INFORMATION

```
File modified: /templates/kubevirt/vm-microshift.yaml.j2
```