### PR TITLE
Removing bookbag reference

### DIFF
--- a/ansible/configs/test-empty-config/destroy_env.yml
+++ b/ansible/configs/test-empty-config/destroy_env.yml
@@ -11,14 +11,6 @@
       msg:
       - Entering the test-empty-config destroy.yml
 
-  - name: Remove Bookbag
-    when:
-    - bookbag_git_repo is defined
-    include_role:
-      name: bookbag
-    vars:
-      ACTION: destroy
-
   - name: Remove Showroom
     when: showroom_deploy_shared_cluster_enable | default(false) | bool
     vars:


### PR DESCRIPTION
##### SUMMARY
We get rid of bookbag from empty test now.
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/configs/test-empty-config/destroy_env.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
