### PR TITLE
add coco workshop

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# ocp_username can be set by the provisioner if the workload is applied to a
+# shared cluster to set up for the requesting user.
+# The default, "system:admin", is not used for roles that are deployed as part of a whole
+# OpenShift cluster provision run.
+ocp_username: "system:admin"
+
+# OSC version tag
+ocp4_workload_coco_on_aro_osc_version: "latest"
+
+# Verity image base name
+ocp4_workload_coco_on_aro_verity_image: "registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image"
+
+# Image to pull to podvm (will be determined dynamically if not set)
+# Format: registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image@sha256:...
+ocp4_workload_coco_on_aro_image: ""
+
+# Path to cluster pull secret file (relative to working directory or absolute path)
+ocp4_workload_coco_on_aro_authfile: "cluster-pull-secret.json"

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/remove_workload.yml
@@ -1,0 +1,10 @@
+---
+# ------------------------------------------
+# Workload removal tasks
+# ------------------------------------------
+# Note: No cleanup needed - bash completion files and pulled images
+# are left in place as they may be useful for the system.
+
+- name: Deprovision complete
+  ansible.builtin.debug:
+    msg: "Workload removal completed. No cleanup needed."

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -32,7 +32,9 @@
 
 - name: Get image digest using skopeo
   ansible.builtin.shell: |
-    skopeo inspect --authfile ./{{ ocp4_workload_coco_on_aro_authfile }} docker://{{ ocp4_workload_coco_on_aro_verity_image }}:{{ ocp4_workload_coco_on_aro_osc_version }} | jq -r .Digest
+    skopeo inspect --authfile ./{{ ocp4_workload_coco_on_aro_authfile }} \
+    docker://{{ ocp4_workload_coco_on_aro_verity_image }}:{{ ocp4_workload_coco_on_aro_osc_version }} \
+    | jq -r .Digest
   args:
     chdir: "{{ ansible_env.HOME | default('/root') }}"
   register: image_digest_result

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -1,0 +1,104 @@
+---
+# -------------------------------------------------------------------------
+# Workload tasks: Pull image to podvm and setup oc bash completion
+# -------------------------------------------------------------------------
+
+- name: Ensure podvm root directory exists
+  ansible.builtin.file:
+    path: /podvm
+    state: directory
+    mode: '0755'
+  become: true
+
+- name: Change ownership of /podvm to azure:azure
+  ansible.builtin.file:
+    path: /podvm
+    owner: azure
+    group: azure
+  become: true
+
+- name: Generate cluster pull secret file from OpenShift
+  ansible.builtin.shell: |
+    oc get -n openshift-config secret/pull-secret -o json \
+    | jq -r '.data.".dockerconfigjson"' \
+    | base64 -d \
+    | jq '.' > {{ ocp4_workload_coco_on_aro_authfile }}
+  args:
+    chdir: "{{ ansible_env.HOME | default('/root') }}"
+  register: pull_secret_result
+  changed_when: pull_secret_result.rc == 0
+  retries: 3
+  delay: 5
+
+- name: Get image digest using skopeo
+  ansible.builtin.shell: |
+    skopeo inspect --authfile ./{{ ocp4_workload_coco_on_aro_authfile }} docker://{{ ocp4_workload_coco_on_aro_verity_image }}:{{ ocp4_workload_coco_on_aro_osc_version }} | jq -r .Digest
+  args:
+    chdir: "{{ ansible_env.HOME | default('/root') }}"
+  register: image_digest_result
+  when: ocp4_workload_coco_on_aro_image == ""
+  changed_when: false
+  retries: 3
+  delay: 5
+
+- name: Set image variable from digest
+  ansible.builtin.set_fact:
+    ocp4_workload_coco_on_aro_image: "{{ ocp4_workload_coco_on_aro_verity_image }}@{{ image_digest_result.stdout }}"
+  when: ocp4_workload_coco_on_aro_image == ""
+
+- name: Validate image variable is set
+  ansible.builtin.assert:
+    that:
+      - ocp4_workload_coco_on_aro_image != ""
+    fail_msg: "Image variable is not set. Either provide ocp4_workload_coco_on_aro_image or ensure skopeo can retrieve the digest."
+    success_msg: "Image variable is set: {{ ocp4_workload_coco_on_aro_image }}"
+
+- name: Pull image to podvm using cluster pull secret
+  containers.podman.podman_image:
+    name: "{{ ocp4_workload_coco_on_aro_image }}"
+    pull: true
+    pull_extra_args: "--root /podvm --authfile {{ ansible_env.HOME | default('/root') }}/{{ ocp4_workload_coco_on_aro_authfile }}"
+  retries: 3
+  delay: 10
+
+- name: Pull coco-tools image to default podman location
+  containers.podman.podman_image:
+    name: quay.io/confidential-devhub/coco-tools:0.3.0
+    pull: true
+  retries: 3
+  delay: 10
+
+- name: Generate oc bash completion script
+  ansible.builtin.command:
+    cmd: oc completion bash
+    chdir: "{{ ansible_env.HOME | default('/root') }}"
+  register: oc_completion_result
+  changed_when: oc_completion_result.rc == 0
+  retries: 3
+  delay: 5
+
+- name: Write oc bash completion to file
+  ansible.builtin.copy:
+    content: "{{ oc_completion_result.stdout }}"
+    dest: "{{ ansible_env.HOME | default('/root') }}/oc_bash_completion"
+    mode: '0644'
+
+- name: Copy oc bash completion to system directory
+  ansible.builtin.copy:
+    src: "{{ ansible_env.HOME | default('/root') }}/oc_bash_completion"
+    dest: /etc/bash_completion.d/oc_bash_completion
+    mode: '0644'
+    remote_src: true
+  become: true
+
+- name: Add oc bash completion source to bashrc
+  ansible.builtin.lineinfile:
+    path: "{{ ansible_env.HOME | default('/root') }}/.bashrc"
+    line: "source /etc/bash_completion.d/oc_bash_completion"
+    create: true
+    state: present
+    regexp: '^source /etc/bash_completion.d/oc_bash_completion'
+
+- name: Workload tasks complete
+  ansible.builtin.debug:
+    msg: "PodVM image pull and oc completion setup completed successfully"


### PR DESCRIPTION


##### SUMMARY

Pre-pull and install the necessary images and configs for the "Confidential Containers workshop on ARO" catalog.


##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_coco_on_aro: the role to pre-populate the bastion VM of the Confidential Containers on ARO workshop.

##### ADDITIONAL INFORMATION
Basically the steps I am automating are:
```
oc completion bash > oc_bash_completion
sudo cp oc_bash_completion /etc/bash_completion.d/
echo "source /etc/bash_completion.d/oc_bash_completion" > ~/.bashrc
```

```
oc get -n openshift-config secret/pull-secret -o json \
| jq -r '.data.".dockerconfigjson"' \
| base64 -d \
| jq '.' > cluster-pull-secret.json

OSC_VERSION=latest
VERITY_IMAGE=registry.redhat.io/openshift-sandboxed-containers/osc-dm-verity-image
TAG=$(skopeo inspect --authfile ./cluster-pull-secret.json docker://${VERITY_IMAGE}:${OSC_VERSION} | jq -r .Digest)
IMAGE=${VERITY_IMAGE}@${TAG}

sudo mkdir -p /podvm
sudo chown azure:azure /podvm

podman pull --root /podvm --authfile cluster-pull-secret.json $IMAGE
```

```
podman pull quay.io/confidential-devhub/coco-tools:0.3.0
```
