### PR TITLE
fix home variable

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -17,14 +17,16 @@
     group: azure
   become: true
 
+- name: Get user home directory
+  ansible.builtin.set_fact:
+    user_home: "{{ ansible_env.HOME | default(ansible_user_dir | default('/tmp')) }}"
+
 - name: Generate cluster pull secret file from OpenShift
   ansible.builtin.shell: |
     oc get -n openshift-config secret/pull-secret -o json \
     | jq -r '.data.".dockerconfigjson"' \
     | base64 -d \
-    | jq '.' > {{ ocp4_workload_coco_on_aro_authfile }}
-  args:
-    chdir: "{{ ansible_env.HOME | default('/root') }}"
+    | jq '.' > {{ user_home }}/{{ ocp4_workload_coco_on_aro_authfile }}
   register: pull_secret_result
   changed_when: pull_secret_result.rc == 0
   retries: 3
@@ -32,11 +34,9 @@
 
 - name: Get image digest using skopeo
   ansible.builtin.shell: |
-    skopeo inspect --authfile ./{{ ocp4_workload_coco_on_aro_authfile }} \
+    skopeo inspect --authfile {{ user_home }}/{{ ocp4_workload_coco_on_aro_authfile }} \
     docker://{{ ocp4_workload_coco_on_aro_verity_image }}:{{ ocp4_workload_coco_on_aro_osc_version }} \
     | jq -r .Digest
-  args:
-    chdir: "{{ ansible_env.HOME | default('/root') }}"
   register: image_digest_result
   when: ocp4_workload_coco_on_aro_image == ""
   changed_when: false
@@ -59,7 +59,7 @@
   containers.podman.podman_image:
     name: "{{ ocp4_workload_coco_on_aro_image }}"
     pull: true
-    pull_extra_args: "--root /podvm --authfile {{ ansible_env.HOME | default('/root') }}/{{ ocp4_workload_coco_on_aro_authfile }}"
+    pull_extra_args: "--root /podvm --authfile {{ user_home }}/{{ ocp4_workload_coco_on_aro_authfile }}"
   retries: 3
   delay: 10
 
@@ -73,7 +73,6 @@
 - name: Generate oc bash completion script
   ansible.builtin.command:
     cmd: oc completion bash
-    chdir: "{{ ansible_env.HOME | default('/root') }}"
   register: oc_completion_result
   changed_when: oc_completion_result.rc == 0
   retries: 3
@@ -82,12 +81,12 @@
 - name: Write oc bash completion to file
   ansible.builtin.copy:
     content: "{{ oc_completion_result.stdout }}"
-    dest: "{{ ansible_env.HOME | default('/root') }}/oc_bash_completion"
+    dest: "{{ user_home }}/oc_bash_completion"
     mode: '0644'
 
 - name: Copy oc bash completion to system directory
   ansible.builtin.copy:
-    src: "{{ ansible_env.HOME | default('/root') }}/oc_bash_completion"
+    src: "{{ user_home }}/oc_bash_completion"
     dest: /etc/bash_completion.d/oc_bash_completion
     mode: '0644'
     remote_src: true
@@ -95,7 +94,7 @@
 
 - name: Add oc bash completion source to bashrc
   ansible.builtin.lineinfile:
-    path: "{{ ansible_env.HOME | default('/root') }}/.bashrc"
+    path: "{{ user_home }}/.bashrc"
     line: "source /etc/bash_completion.d/oc_bash_completion"
     create: true
     state: present


### PR DESCRIPTION
##### SUMMARY

Apparently /root is not a good path, CI (Confidential Containers on ARO / azure_gpte/OCP4_SANDBOX_WORKSHOP_ON_ARO) provision fails with "  "msg": "Unable to change directory before execution: [Errno 13] Permission denied: b'/root'",

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
agD: ocp4_workload_coco_on_aro
agV: azure_gpte/OCP4_SANDBOX_WORKSHOP_ON_ARO

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
