### PR TITLE
coco: move everything into /tmp

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -22,7 +22,7 @@
     oc get -n openshift-config secret/pull-secret -o json \
     | jq -r '.data.".dockerconfigjson"' \
     | base64 -d \
-    | jq '.' > /tmp/{{ ocp4_workload_coco_on_aro_authfile }}
+    | jq '.' > /home/{{ ansible_user }}/{{ ocp4_workload_coco_on_aro_authfile }}
   register: pull_secret_result
   changed_when: pull_secret_result.rc == 0
   retries: 3
@@ -30,7 +30,7 @@
 
 - name: Get image digest using skopeo
   ansible.builtin.shell: |
-    skopeo inspect --authfile /tmp/{{ ocp4_workload_coco_on_aro_authfile }} \
+    skopeo inspect --authfile /home/{{ ansible_user }}/{{ ocp4_workload_coco_on_aro_authfile }} \
     docker://{{ ocp4_workload_coco_on_aro_verity_image }}:{{ ocp4_workload_coco_on_aro_osc_version }} \
     | jq -r .Digest
   register: image_digest_result
@@ -55,7 +55,7 @@
   containers.podman.podman_image:
     name: "{{ ocp4_workload_coco_on_aro_image }}"
     pull: true
-    pull_extra_args: "--root /podvm --authfile /tmp/{{ ocp4_workload_coco_on_aro_authfile }}"
+    pull_extra_args: "--root /podvm --authfile /home/{{ ansible_user }}/{{ ocp4_workload_coco_on_aro_authfile }}"
   retries: 3
   delay: 10
 
@@ -77,16 +77,16 @@
 - name: Write oc bash completion to file
   ansible.builtin.copy:
     content: "{{ oc_completion_result.stdout }}"
-    dest: /tmp/oc_bash_completion
+    dest: /home/{{ ansible_user }}/oc_bash_completion
     mode: '0644'
 
 - name: Add oc bash completion source to bashrc
   ansible.builtin.lineinfile:
     path: /home/azure/.bashrc
-    line: "source /tmp/oc_bash_completion"
+    line: "source /home/{{ ansible_user }}/oc_bash_completion"
     create: true
     state: present
-    regexp: '^source /tmp/oc_bash_completion'
+    regexp: '^source /home/{{ ansible_user }}/oc_bash_completion'
 
 - name: Workload tasks complete
   ansible.builtin.debug:

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -17,16 +17,12 @@
     group: azure
   become: true
 
-- name: Get user home directory
-  ansible.builtin.set_fact:
-    user_home: "{{ ansible_env.HOME | default(ansible_user_dir | default('/tmp')) }}"
-
 - name: Generate cluster pull secret file from OpenShift
   ansible.builtin.shell: |
     oc get -n openshift-config secret/pull-secret -o json \
     | jq -r '.data.".dockerconfigjson"' \
     | base64 -d \
-    | jq '.' > {{ user_home }}/{{ ocp4_workload_coco_on_aro_authfile }}
+    | jq '.' > /tmp/{{ ocp4_workload_coco_on_aro_authfile }}
   register: pull_secret_result
   changed_when: pull_secret_result.rc == 0
   retries: 3
@@ -34,7 +30,7 @@
 
 - name: Get image digest using skopeo
   ansible.builtin.shell: |
-    skopeo inspect --authfile {{ user_home }}/{{ ocp4_workload_coco_on_aro_authfile }} \
+    skopeo inspect --authfile /tmp/{{ ocp4_workload_coco_on_aro_authfile }} \
     docker://{{ ocp4_workload_coco_on_aro_verity_image }}:{{ ocp4_workload_coco_on_aro_osc_version }} \
     | jq -r .Digest
   register: image_digest_result
@@ -59,7 +55,7 @@
   containers.podman.podman_image:
     name: "{{ ocp4_workload_coco_on_aro_image }}"
     pull: true
-    pull_extra_args: "--root /podvm --authfile {{ user_home }}/{{ ocp4_workload_coco_on_aro_authfile }}"
+    pull_extra_args: "--root /podvm --authfile /tmp/{{ ocp4_workload_coco_on_aro_authfile }}"
   retries: 3
   delay: 10
 
@@ -81,24 +77,16 @@
 - name: Write oc bash completion to file
   ansible.builtin.copy:
     content: "{{ oc_completion_result.stdout }}"
-    dest: "{{ user_home }}/oc_bash_completion"
+    dest: /tmp/oc_bash_completion
     mode: '0644'
-
-- name: Copy oc bash completion to system directory
-  ansible.builtin.copy:
-    src: "{{ user_home }}/oc_bash_completion"
-    dest: /etc/bash_completion.d/oc_bash_completion
-    mode: '0644'
-    remote_src: true
-  become: true
 
 - name: Add oc bash completion source to bashrc
   ansible.builtin.lineinfile:
-    path: "{{ user_home }}/.bashrc"
-    line: "source /etc/bash_completion.d/oc_bash_completion"
+    path: /home/azure/.bashrc
+    line: "source /tmp/oc_bash_completion"
     create: true
     state: present
-    regexp: '^source /etc/bash_completion.d/oc_bash_completion'
+    regexp: '^source /tmp/oc_bash_completion'
 
 - name: Workload tasks complete
   ansible.builtin.debug:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

move everything in /tmp. CI (Confidential Containers on ARO / azure_gpte/OCP4_SANDBOX_WORKSHOP_ON_ARO) provision fails with " "msg": "/bin/sh: line 1: /root/cluster-pull-secret.json: Permission denied"",
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

agD: ocp4_workload_coco_on_aro
agV: azure_gpte/OCP4_SANDBOX_WORKSHOP_ON_ARO