### PR TITLE
pull manually as podman module doesn't support --root

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -52,10 +52,12 @@
     success_msg: "Image variable is set: {{ ocp4_workload_coco_on_aro_image }}"
 
 - name: Pull image to podvm using cluster pull secret
-  containers.podman.podman_image:
-    name: "{{ ocp4_workload_coco_on_aro_image }}"
-    pull: true
-    pull_extra_args: "--root /podvm --authfile /home/{{ ansible_user }}/{{ ocp4_workload_coco_on_aro_authfile }}"
+  ansible.builtin.shell: |
+    podman pull --root /podvm \
+    --authfile /home/{{ ansible_user }}/{{ ocp4_workload_coco_on_aro_authfile }} \
+    {{ ocp4_workload_coco_on_aro_image }}
+  register: podman_pull_result
+  changed_when: podman_pull_result.rc == 0
   retries: 3
   delay: 10
 


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
`podman --root` is not supported in podman module. Replace it with ansible builtin shell
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
agD: ocp4_workload_coco_on_aro
agV: azure_gpte/OCP4_SANDBOX_WORKSHOP_ON_ARO
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
