### PR TITLE
Change role ocp4_workload_microshift to update vm-microshift template to modify lvextend size to 23G and restart microshift

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_microshift/templates/kubevirt/vm-microshift.yaml.j2
@@ -79,8 +79,9 @@ spec:
               - [ udevadm, settle ]
               - [ pvcreate, /dev/vdb ]
               - [ vgextend, rhel, /dev/vdb ]
-              - [ lvextend, -l, "+100%FREE", /dev/mapper/rhel-root ]
+              - [ lvextend, -L, "+23G", /dev/mapper/rhel-root ]
               - [ xfs_growfs, / ]
+              - [ systemctl, restart, microshift ]
   dataVolumeTemplates:
   - metadata:
       name: microshift-rootdisk


### PR DESCRIPTION
##### SUMMARY
Modifies cloud-init in the `vm-microshift.yaml.j2` template because of the need to limit the root partition expansion to leave "unallocated" space in the Volume Group so the MicroShift provisioner can dynamically create the persistent volumes required by pods.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ocp4_workload_microshift

##### ADDITIONAL INFORMATION

```
File modified: /templates/kubevirt/vm-microshift.yaml.j2
```