### PR TITLE
fix vmware ad password generation

### DIFF
--- a/ansible/configs/ocp4-upi-vmc/post_infra_vmware_ibm.yml
+++ b/ansible/configs/ocp4-upi-vmc/post_infra_vmware_ibm.yml
@@ -2,7 +2,8 @@
 - name: Set student Console password
   set_fact:
     vmware_ibm_sandbox_generated_password: >-
-      {{- lookup('password', '/dev/null length=1 chars=letters') -}}
+      {{- lookup('password', '/dev/null length=1 chars=ascii_lowercase') -}}
+      {{- lookup('password', '/dev/null length=1 chars=ascii_uppercase') -}}
       {{- lookup('password', '/dev/null length=10') -}}
       {{- lookup('password', '/dev/null length=1 chars=digits') -}}
 

--- a/ansible/configs/sandbox/post_infra_vmware_ibm.yml
+++ b/ansible/configs/sandbox/post_infra_vmware_ibm.yml
@@ -26,7 +26,8 @@
     - name: Set student Console password
       set_fact:
         vmware_ibm_sandbox_generated_password: >-
-          {{- lookup('password', '/dev/null length=1 chars=letters') -}}
+          {{- lookup('password', '/dev/null length=1 chars=ascii_lowercase') -}}
+          {{- lookup('password', '/dev/null length=1 chars=ascii_uppercase') -}}
           {{- lookup('password', '/dev/null length=10') -}}
           {{- lookup('password', '/dev/null length=1 chars=digits') -}}
 


### PR DESCRIPTION
force an uppercase and a lowercase letter

- Bugfix Pull Request

Sometimes it would only generate lowercase, and fail the install.