### PR TITLE
configure role ocp4-workload-quarkus-workshop

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/defaults/main.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/defaults/main.yml
@@ -11,6 +11,14 @@ workshop_ds_user_password: 'openshift'
 workshop_openshift_admin_password: 'r3dh4t1!'
 workshop_rhsso_admin_user_name: admin
 workshop_rhsso_admin_password: 'r3dh4t1!'
+workshop_content_git_tag: 'rhbq-3.27'
+workshop_content_git_org: 'RedHat-Middleware-Workshops'
+community_catalog_source_tag: 'v4.20_2025_12_15'
+redhat_catalog_source_tag: 'v4.20_2025_12_15'
+devspaces_images_list: >-
+  quarkus-stack-3-27=quay.io/openshiftlabs/quarkus-workshop-stack:3.27-ocp-4.20;
+  che-code-injector=registry.redhat.io/devspaces/code-rhel9@sha256:e0d94b772b364b41f419e144042766579bd2ef9c1fe5259c0defaff6b5169718;
+  project-clone=registry.redhat.io/devworkspace/devworkspace-project-clone-rhel9@sha256:63843bb17c34ee71dc801626f829190e53917455564e5a20b4a48ca2d95a8959;
 
 module_type: m1
 

--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/stack.Dockerfile
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/stack.Dockerfile
@@ -1,24 +1,22 @@
 # To build this stack:
-# docker build -t quay.io/openshiftlabs/quarkus-workshop-stack:3.27-ocp-4.20 -f stack.Dockerfile .
-# docker push quay.io/openshiftlabs/quarkus-workshop-stack:3.27-ocp-4.20
+# docker build -t quay.io/openshiftlabs/quarkus-workshop-stack:3.27.1 -f stack.Dockerfile .
+# docker push quay.io/openshiftlabs/quarkus-workshop-stack:3.27.1
 # macOS M1: --platform linux/x86_64
 
-FROM registry.redhat.io/devspaces/udi-rhel9:latest
+FROM quay.io/devfile/base-developer-image:ubi9-9b60f86
 
 ENV MANDREL_VERSION=23.1.9.0-Final
 ENV MVN_VERSION=3.9.9
 ENV GRAALVM_HOME="/usr/local/mandrel-java21-${MANDREL_VERSION}"
-ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk"
+ENV JAVA_HOME="/usr/local/mandrel-java21-${MANDREL_VERSION}"
 ENV PATH="/usr/local/maven/apache-maven-${MVN_VERSION}/bin:$JAVA_HOME/bin:${PATH}"
-ENV RHBQ_VERSION=3.27.1.redhat-00003
+ENV QUARKUS_VERSION=3.27.1.redhat-00003
 ENV QUARKUS_CLI_VERSION=3.27.1
 ENV JBANG_DIR="/usr/local/jbang"
 ENV OC_VERSION=4.20.8
 
 USER root
 
-# WARNING: devspaces/udi-rhel9 also provides an oc binary!
-# Run the following oc installation ONLY in cases when a custom oc version is needed:
 RUN curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VERSION/openshift-client-linux-$OC_VERSION.tar.gz -o /tmp/openshift-client-linux-$OC_VERSION.tar.gz \
   && tar -xvf /tmp/openshift-client-linux-$OC_VERSION.tar.gz -C /usr/bin/ \
   && chmod +x /usr/bin/oc \
@@ -26,9 +24,9 @@ RUN curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OC_VERSIO
   && rm /tmp/openshift-client-linux-$OC_VERSION.tar.gz /usr/bin/README.md
 # RUN wget -O /tmp/openjdk-21.0.7.tar.gz https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.7%2B6/OpenJDK21U-jdk_x64_linux_hotspot_21.0.7_6.tar.gz && tar -xvzf /tmp/openjdk-21.0.7.tar.gz && rm -rf /tmp/openjdk-21.0.7.tar.gz && mv jdk-21.0.7+6 /tmp/java-21-openjdk && sudo mv /tmp/java-21-openjdk /usr/lib/jvm/ && sudo alternatives --install /usr/bin/java java /usr/lib/jvm/java-21-openjdk/bin/java 1
 RUN wget -O /tmp/mvn.tar.gz https://archive.apache.org/dist/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz && sudo tar -xvzf /tmp/mvn.tar.gz && rm -rf /tmp/mvn.tar.gz && mkdir /usr/local/maven && mv apache-maven-${MVN_VERSION}/ /usr/local/maven/ && alternatives --install /usr/bin/mvn mvn /usr/local/maven/apache-maven-${MVN_VERSION}/bin/mvn 1
-RUN sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && sudo microdnf install -y zlib-devel gcc siege gcc-c++ && sudo curl -Lo /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.8.1/jq-linux-amd64 && sudo chmod a+x /usr/bin/jq
+RUN sudo dnf install -y zlib-devel gcc siege gcc-c++
 RUN wget -O /tmp/mandrel.tar.gz https://github.com/graalvm/mandrel/releases/download/mandrel-${MANDREL_VERSION}/mandrel-java21-linux-amd64-${MANDREL_VERSION}.tar.gz && cd /usr/local && sudo tar -xvzf /tmp/mandrel.tar.gz && rm -rf /tmp/mandrel.tar.gz
-RUN ln -f -s /usr/lib/jvm/java-21-openjdk/* ${HOME}/.java/current
+RUN mkdir -p /user/home/.java/current && ln -f -s $JAVA_HOME/* /user/home/.java/current
 
 RUN mkdir -p /usr/local/quarkus-cli/lib && mkdir /usr/local/quarkus-cli/bin
 RUN wget -O /tmp/quarkus-cli.tgz https://github.com/quarkusio/quarkus/releases/download/${QUARKUS_CLI_VERSION}/quarkus-cli-${QUARKUS_CLI_VERSION}.tar.gz && tar -xzf /tmp/quarkus-cli.tgz -C /tmp
@@ -36,13 +34,13 @@ RUN cp /tmp/quarkus-cli-${QUARKUS_CLI_VERSION}/bin/quarkus /usr/local/bin && cp 
 RUN chmod +x /usr/local/bin/quarkus && cd /usr/local/bin
 RUN mkdir -p ${JBANG_DIR} && curl -Ls https://sh.jbang.dev | bash -s - app setup
 RUN ln -s ${JBANG_DIR}/bin/jbang /usr/local/bin/jbang
-
+RUN chmod 777 ${JAVA_HOME}/lib/security/cacerts
 USER user
 
 RUN mkdir -p /home/user/.m2
 COPY settings.xml /home/user/.m2
-RUN cd /tmp && mkdir project && cd project && mvn com.redhat.quarkus.platform:quarkus-maven-plugin:${RHBQ_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -DplatformGroupId=com.redhat.quarkus.platform -DplatformVersion=${RHBQ_VERSION} -Dextensions="quarkus-rest,quarkus-rest-jackson,quarkus-agroal,quarkus-jdbc-h2,quarkus-jdbc-postgresql,quarkus-kubernetes,quarkus-scheduler,quarkus-smallrye-fault-tolerance,quarkus-smallrye-health" && mvn -f footest clean compile package -DskipTests && cd / && rm -rf /tmp/project
-RUN cd /tmp && mkdir project && cd project && mvn com.redhat.quarkus.platform:quarkus-maven-plugin:${RHBQ_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -DplatformGroupId=com.redhat.quarkus.platform -DplatformVersion=${RHBQ_VERSION} -Dextensions="quarkus-messaging-kafka,quarkus-vertx,quarkus-kafka-client,quarkus-micrometer-registry-prometheus,quarkus-smallrye-openapi,quarkus-rest-qute,quarkus-opentelemetry" && mvn -f footest clean compile package -Pnative -DskipTests && cd / && rm -rf /tmp/project
+RUN cd /tmp && mkdir project && cd project && mvn com.redhat.quarkus.platform:quarkus-maven-plugin:${QUARKUS_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -DplatformGroupId=com.redhat.quarkus.platform -DplatformVersion=${QUARKUS_VERSION} -Dextensions="quarkus-rest,quarkus-rest-jackson,quarkus-agroal,quarkus-jdbc-h2,quarkus-jdbc-postgresql,quarkus-kubernetes,quarkus-scheduler,quarkus-smallrye-fault-tolerance,quarkus-smallrye-health" && mvn -f footest clean compile package -DskipTests && cd / && rm -rf /tmp/project
+RUN cd /tmp && mkdir project && cd project && mvn com.redhat.quarkus.platform:quarkus-maven-plugin:${QUARKUS_VERSION}:create -DprojectGroupId=org.acme -DprojectArtifactId=footest -DplatformGroupId=com.redhat.quarkus.platform -DplatformVersion=${QUARKUS_VERSION} -Dextensions="quarkus-messaging-kafka,quarkus-vertx,quarkus-kafka-client,quarkus-micrometer-registry-prometheus,quarkus-smallrye-openapi,quarkus-rest-qute,quarkus-opentelemetry" && mvn -f footest clean compile package -Pnative -DskipTests && cd / && rm -rf /tmp/project
 RUN cd /tmp && git clone https://github.com/RedHat-Middleware-Workshops/quarkus-workshop-m3-labs && cd quarkus-workshop-m3-labs && git checkout rhbq-3.27 && for proj in *-petclinic* ; do mvn -fn -f ./$proj dependency:resolve-plugins dependency:resolve dependency:go-offline clean compile -DskipTests ; done && cd /tmp && rm -rf /tmp/quarkus-workshop-m3-labs
 RUN siege && sed -i 's/^connection = close/connection = keep-alive/' $HOME/.siege/siege.conf && sed -i 's/^benchmark = false/benchmark = true/' $HOME/.siege/siege.conf
 RUN echo '-w "\n"' > $HOME/.curlrc

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-devspaces.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-devspaces.yaml
@@ -34,7 +34,7 @@
   kubernetes.core.k8s:
     merge_type:
     - merge
-    definition: "{{ lookup('file', 'devspaces_cr.yaml' ) }}"
+    definition: "{{ lookup('template', 'devspaces_cr.yaml.j2' ) }}"
   register: r_create_crd
   until: r_create_crd is successful
   retries: 30

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-guides.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-guides.yaml
@@ -26,8 +26,8 @@
     -e DS_URL=https://devspaces.{{ route_subdomain }}
     -e KEYCLOAK_URL=https://rhbk.{{ route_subdomain }}
     -e ROUTE_SUBDOMAIN={{ route_subdomain }}
-    -e CONTENT_URL_PREFIX='https://raw.githubusercontent.com/RedHat-Middleware-Workshops/quarkus-workshop-{{ prefix_url }}/rhbq-3.27/docs/'
-    -e WORKSHOPS_URLS="https://raw.githubusercontent.com/RedHat-Middleware-Workshops/quarkus-workshop-{{ prefix_url }}/rhbq-3.27/docs/_workshop_{{ guide }}.yml"
+    -e CONTENT_URL_PREFIX='https://raw.githubusercontent.com/{{ workshop_content_git_org }}/quarkus-workshop-{{ prefix_url }}/{{ workshop_content_git_tag }}/docs/'
+    -e WORKSHOPS_URLS="https://raw.githubusercontent.com/{{ workshop_content_git_org }}/quarkus-workshop-{{ prefix_url }}/{{ workshop_content_git_tag }}/docs/_workshop_{{ guide }}.yml"
     -e LOG_TO_STDOUT=true
 
 - name: create the Route for {{ guide }}

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
@@ -15,16 +15,16 @@
   debug:
     msg: "selected modules list: {{ modules }}"
 
-- name: Create CatalogSource Index 4.15
+- name: Create CatalogSource Index {{ community_catalog_source_tag }}
   k8s:
     state: present
     merge_type:
     - strategic-merge
     - merge
-    definition: "{{ lookup('file', item ) | from_yaml }}"
+    definition: "{{ lookup('template', item ) | from_yaml }}"
   loop:
-  - redhat-operators-index.yaml
-  - community-operators-index.yaml
+  - redhat-operators-index.yaml.j2
+  - community-operators-index.yaml.j2
 
 - name: Import custome project request to increase the limits
   k8s:

--- a/ansible/roles/ocp4-workload-quarkus-workshop/templates/community-operators-index.yaml.j2
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/templates/community-operators-index.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   name: community-operators-index
   namespace: openshift-marketplace
 spec:
-  displayName: Community Operators Index 4.20
-  image: 'quay.io/gpte-devops-automation/olm_snapshot_community_catalog:v4.20_2025_12_15'
+  displayName: Community Operators Index {{ community_catalog_source_tag }}
+  image: 'quay.io/gpte-devops-automation/olm_snapshot_community_catalog:{{ community_catalog_source_tag }}'
   publisher: Daniel Oh
   sourceType: grpc

--- a/ansible/roles/ocp4-workload-quarkus-workshop/templates/devspaces_cr.yaml.j2
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/templates/devspaces_cr.yaml.j2
@@ -13,11 +13,12 @@ spec:
       logLevel: INFO
     metrics:
       enable: true
-    pluginRegistry: {openVSXURL: 'https://open-vsx.org'}
+    pluginRegistry:
+      openVSXURL: 'https://open-vsx.org'
     imagePuller:
       enable: true
       spec:
-        images: quarkus-stack-3-27=quay.io/openshiftlabs/quarkus-workshop-stack:3.27-ocp-4.20;che-code-injector=registry.redhat.io/devspaces/code-rhel9@sha256:e0d94b772b364b41f419e144042766579bd2ef9c1fe5259c0defaff6b5169718;project-clone=registry.redhat.io/devworkspace/devworkspace-project-clone-rhel9@sha256:63843bb17c34ee71dc801626f829190e53917455564e5a20b4a48ca2d95a8959
+        images: {{ devspaces_images_list }}
   containerRegistry: {}
   devEnvironments:
     secondsOfRunBeforeIdling: -1

--- a/ansible/roles/ocp4-workload-quarkus-workshop/templates/redhat-operators-index.yaml.j2
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/templates/redhat-operators-index.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   name: redhat-operators-index
   namespace: openshift-marketplace
 spec:
-  displayName: Red Hat Operators Index 4.20
-  image: 'quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:v4.20_2025_12_15'
+  displayName: Red Hat Operators Index {{ redhat_catalog_source_tag }}
+  image: 'quay.io/gpte-devops-automation/olm_snapshot_redhat_catalog:{{ redhat_catalog_source_tag }}'
   publisher: Daniel Oh
   sourceType: grpc


### PR DESCRIPTION
* This update moves a few configurable strings to `defaults/main.yml` reducing the need to make frequent changes to agnosticd
  * no change to the existing values (without configuration via agnosticv)
* updated `files/stack.Dockerfile` with a smaller base image

Please cut new tags for these two test CIs:
* [`git_tag_prefix: ocp4-workload-quarkus-workshop`](https://github.com/rhpds/agnosticv/blob/master/sandboxes-gpte/OCP4_WORKSHOP_QUARKUS/test.yaml)
* [`git_tag_prefix: cnv-ocp4-workload-quarkus-workshop`](https://github.com/rhpds/agnosticv/blob/master/openshift_cnv/OCP4_WORKSHOP_QUARKUS_CNV/test.yaml)

##### SUMMARY

* This update provides the following configuration options for this workload in agnosticv:
  * `workshop_content_git_tag`
  * `community_catalog_source_tag`
  * `redhat_catalog_source_tag`
  * `devspaces_images_list`
  * `workshop_content_git_org`
* update to a smaller devspaces base image: `FROM quay.io/devfile/base-developer-image:ubi9`

##### ISSUE TYPE
- New config Pull Request

##### COMPONENT NAME
roles/ocp4-workload-quarkus-workshop

##### ADDITIONAL INFORMATION

tested here:
* https://catalog.demo.redhat.com/catalog/babylon-catalog-dev/order/sandboxes-gpte.ocp4-workshop-quarkus.dev
* https://catalog.demo.redhat.com/catalog/babylon-catalog-dev/order/openshift-cnv.ocp4-workshop-quarkus-cnv.dev