### PR TITLE
Update environment variable for Java options

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4-workload-camel-workshop/templates/camel-docserver.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-camel-workshop/templates/camel-docserver.yaml.j2
@@ -82,9 +82,7 @@ spec:
           
           echo "Job complete!"
         env:
-        - name: HOME
-          value: /home/user
-        - name: JBANG_JAVA_OPTIONS
+        - name: JDK_JAVA_OPTIONS
           value: "-Duser.home=/home/user"
         resources:
           limits:


### PR DESCRIPTION
##### SUMMARY
Latest UBI update breaks Camel build and deploy process due to inability to resolve the user.home system property.
Fixed by replacing JBANG_JAVA_OPTIONS with JDK_JAVA_OPTIONS in environment variables.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Job process 'camel-jbang-job'

##### ADDITIONAL INFORMATION
I'm not certain how the UBI updated affected this job.
What is clear is that the JVM is not able to resolve the system property `user.home` as it did in previous versions, so we're fixing the problem by setting the system property in an environment variable JDK loads.
