### PR TITLE
Fix workload ocp4_workload_openshift_data_foundation - add support for 4.19, 4.20

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -75,8 +75,7 @@
     definition: "{{ lookup('template', 'subscription.yaml.j2') | from_yaml }}"
 
 - name: "Config for channel {{ ocp4_workload_openshift_data_foundation_channel }}"
-  when:
-    - ocp4_workload_openshift_data_foundation_channel not in ["stable-4.19", "stable-4.20"]
+  when: ocp4_workload_openshift_data_foundation_channel not in ["stable-4.19", "stable-4.20"]
   ansible.builtin.set_fact:
     _console_plugin_api_version: "console.openshift.io/v1alpha1"
     _storage_systems_enabled: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -74,6 +74,13 @@
     state: present
     definition: "{{ lookup('template', 'subscription.yaml.j2') | from_yaml }}"
 
+- name: "Config for channel {{ ocp4_workload_openshift_data_foundation_channel }}"
+  when:
+    - ocp4_workload_openshift_data_foundation_channel not in ["stable-4.19", "stable-4.20"]
+  ansible.builtin.set_fact:
+    _console_plugin_api_version: "console.openshift.io/v1alpha1"
+    _storage_systems_enabled: true
+
 - name: Wait for the CRD storagesystems to become available
   kubernetes.core.k8s_info:
     api_version: apiextensions.k8s.io/v1
@@ -85,6 +92,9 @@
   until:
   - r_crd_storagesystems.resources is defined
   - r_crd_storagesystems.resources | list | length == 1
+  when:
+    - _storage_systems_enabled is defined
+    - _storage_systems_enabled == true
 
 - name: Wait for the CRD storagecluster to become available
   kubernetes.core.k8s_info:
@@ -100,7 +110,7 @@
 
 - name: Wait for the console plugin to become available
   kubernetes.core.k8s_info:
-    api_version: console.openshift.io/v1alpha1
+    api_version: "{{ _console_plugin_api_version | default('console.openshift.io/v1') }}"
     kind: ConsolePlugin
     name: odf-console
   register: r_console_plugin
@@ -132,6 +142,9 @@
   until: r_k8s_run is not failed
   delay: 10
   retries: 3
+  when:
+    - _storage_systems_enabled is defined
+    - _storage_systems_enabled == true
 
 - name: Wait for ODF Storage System to finish deploying
   kubernetes.core.k8s_info:
@@ -146,6 +159,9 @@
       type: Available
     wait_sleep: 10
     wait_timeout: "{{ ocp4_workload_openshift_data_foundation_ceph_storage_system_deploy_timeout }}"
+  when:
+    - _storage_systems_enabled is defined
+    - _storage_systems_enabled == true
 
 - name: Wait for ODF Storage Cluster to finish deploying
   kubernetes.core.k8s_info:

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -92,9 +92,7 @@
   until:
   - r_crd_storagesystems.resources is defined
   - r_crd_storagesystems.resources | list | length == 1
-  when:
-    - _storage_systems_enabled is defined
-    - _storage_systems_enabled == true
+  when: _storage_systems_enabled | default(false) | bool
 
 - name: Wait for the CRD storagecluster to become available
   kubernetes.core.k8s_info:
@@ -142,9 +140,7 @@
   until: r_k8s_run is not failed
   delay: 10
   retries: 3
-  when:
-    - _storage_systems_enabled is defined
-    - _storage_systems_enabled == true
+  when: _storage_systems_enabled | default(false) | bool
 
 - name: Wait for ODF Storage System to finish deploying
   kubernetes.core.k8s_info:
@@ -159,9 +155,7 @@
       type: Available
     wait_sleep: 10
     wait_timeout: "{{ ocp4_workload_openshift_data_foundation_ceph_storage_system_deploy_timeout }}"
-  when:
-    - _storage_systems_enabled is defined
-    - _storage_systems_enabled == true
+  when: _storage_systems_enabled | default(false) | bool
 
 - name: Wait for ODF Storage Cluster to finish deploying
   kubernetes.core.k8s_info:


### PR DESCRIPTION
Add support for ODF channels: `stable-4.19`, `stable-4.20`

##### SUMMARY
⚠️ ODF is currently unavailable on ocp-4.20

This change adds support for two new ODF channels while maintaining backward compatibility with previous releases

I considered these follow-up tasks (instead of configuring based on the odf channel info), but they were not easy to solve:
* Check the subscription CSV to determine support for StorageSystems CRD (deprecated in stable-4.19 and later releases)
* Find the ConsolePlugin api_version by fetching the related CRD

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation`

##### ADDITIONAL INFORMATION
This change has been tested with the following ODF channels: `stable-4.18`, `stable-4.19`, `stable-4.20`
via: https://catalog.demo.redhat.com/catalog?item=babylon-catalog-dev/rhdp.ocp4-rad-ea-rs-wksp.dev