### PR TITLE
Bugfix: CI sap-hana-rhel9 - old collection in requirements.yaml file

### DIFF
--- a/ansible/configs/sap-hana-rhel9/requirements.yml
+++ b/ansible/configs/sap-hana-rhel9/requirements.yml
@@ -3,8 +3,8 @@ roles:
 - src: https://github.com/redhat-cop/infra-ansible.git
   name: infra-ansible
   version: v2.0.9
-- name: redhat_sap.sap_rhsm
-  version: v1.1.2
+# name: redhat_sap.sap_rhsm
+# version: v1.1.2
 
 collections:
 - name: community.general
@@ -12,10 +12,10 @@ collections:
 - name: ansible.posix
   version: 1.3.0
 - name: openstack.cloud
-  version: 1.7.2
+  # version: 1.7.2
 - name: ansible.utils
-  version: 2.11.0
+  # version: 2.11.0
 - name: kubevirt.core
-  version: 1.1.0
+  # version: 1.1.0
 - name: infra.aap_utilities
   version: 2.7.0

--- a/ansible/configs/sap-hana-rhel9/requirements.yml
+++ b/ansible/configs/sap-hana-rhel9/requirements.yml
@@ -3,8 +3,6 @@ roles:
 - src: https://github.com/redhat-cop/infra-ansible.git
   name: infra-ansible
   version: v2.0.9
-# name: redhat_sap.sap_rhsm
-# version: v1.1.2
 
 collections:
 - name: community.general
@@ -12,10 +10,7 @@ collections:
 - name: ansible.posix
   version: 1.3.0
 - name: openstack.cloud
-  # version: 1.7.2
 - name: ansible.utils
-  # version: 2.11.0
 - name: kubevirt.core
-  # version: 1.1.0
 - name: infra.aap_utilities
   version: 2.7.0

--- a/ansible/configs/sap-hana-rhel9/requirements.yml
+++ b/ansible/configs/sap-hana-rhel9/requirements.yml
@@ -8,9 +8,12 @@ collections:
 - name: community.general
   version: ">=6.6.0"
 - name: ansible.posix
-  version: 1.3.0
+  version: ">=1.3.0"
 - name: openstack.cloud
+  version: 1.7.2
 - name: ansible.utils
+  version: 2.11.0
 - name: kubevirt.core
+  version: ">=1.1.0"
 - name: infra.aap_utilities
   version: 2.7.0


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Urgent bugfix, that prohbits the released version from being rolled out. There was a no longer existing collection listed in the requirements.yml file.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
sap-hana-rhel9

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

There were some historical leftovers in the requirements.yaml file. I removed the dependency on certain collection versions that are no longer available at Galaxy.

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
