### PR TITLE
[ocp4_workload_validated_pattern_deploy] add omnicloud as a service

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_validated_pattern_deploy/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_validated_pattern_deploy/defaults/main.yml
@@ -29,6 +29,11 @@ ocp4_workload_validated_pattern_deploy_available_patterns:
     repo: https://github.com/validatedpatterns-sandbox/travelops
     revision: rhdp-deploy
     doc_url: https://validatedpatterns.io/patterns/travelops/
+  - display_name: "Omnicloud as a Service"
+    pattern_name: omnicloud-as-a-service
+    repo: https://github.com/validatedpatterns-sandbox/omnicloud-as-a-service
+    revision: rhdp
+    doc_url: https://validatedpatterns.io/patterns/omnicloud/
 
 ocp4_workload_validated_pattern_deploy_default_pattern:
   display_name: "Operator only"

--- a/ansible/roles_ocp_workloads/ocp4_workload_validated_pattern_deploy/templates/values-secret-omnicloud-as-a-service.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_validated_pattern_deploy/templates/values-secret-omnicloud-as-a-service.yaml.j2
@@ -1,0 +1,3 @@
+---
+version: "2.0"
+secrets: {}


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

This PR makes [omnicloud as a service](https://validatedpatterns.io/patterns/omnicloud/) a deployable pattern

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

- ocp4_workload_validated_pattern_deploy

##### ADDITIONAL INFORMATION

This is currently testable with the dev catalog entry for validated patterns. I have already confirmed it is working
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
