### PR TITLE
Add failed hosts check on completion callback

### DIFF
--- a/ansible/completion_callback.yml
+++ b/ansible/completion_callback.yml
@@ -9,6 +9,7 @@
       when:
       - agnosticd_callback_url != ''
       - agnosticd_callback_token != ''
+      - ansible_failed_hosts | length == 0
       vars:
         user_body_yaml: "{{ [ output_dir, ACTION ~ '-user-body.yaml' ] | path_join }}"
         user_data_yaml: "{{ [ output_dir, ACTION ~ '-user-data.yaml' ] | path_join }}"


### PR DESCRIPTION
##### SUMMARY

Add check of `ansible_failed_hosts` to completion callback to prevent reporting successful completion when hosts failed.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

completion callback playbook