### PR TITLE
Fix infra-ec2-create-inventory failure when no instances exist

### DIFF
--- a/ansible/roles-infra/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-create-inventory/tasks/main.yml
@@ -44,6 +44,7 @@
        | map(attribute='tags.internaldns')
        | sort | first
       }}
+  when: ec2_info.instances | default([]) | length > 0
 
 - name: Add hosts to the current inventory
   add_host:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

Add guard condition to the bastion lookup task to handle empty instance lists. Commit 19f9d023 (#9354) refactored the bastion lookup but removed the when condition that previously skipped the task when no instances matched, causing '| first' to fail with 'No first item, sequence was empty' on environments without EC2 instances (e.g., sandbox open-environment configs).

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles-infra/infra-ec2-create-inventory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
