### PR TITLE
Treat robot RH users as external. (for now)

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -4,6 +4,7 @@
     internal_user: True
   when:
     - '"@redhat.com" in requester_email'
+    - '"+" not in requester_email.split("@")[0]'
     - agnosticd_open_environment | default(false) | bool
 
 - name: Check if email is not a Red Hat associate


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Treat robot RH users as external. (for now)
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
roles/open-env-azure-add-user-to-subscription

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
