### PR TITLE
Add common_password and satellite_script to showroom helm release values

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -28,10 +28,12 @@
         zero_touch_ui_enabled: "{{ ocp4_workload_showroom_zero_touch_ui_enabled | string | lower }}"
 
       guid: "{{ guid }}"
+      common_password: "{{ common_password | default('') }}"
       satellite:
         url: "{{ satellite_url | default('') }}"
         org: "{{ satellite_org | default('') }}"
         activationkey: "{{ satellite_activationkey | default('') }}"
+        script: "{{ satellite_script | default('') }}"
       deployer:
         domain: "{{ _deployer_domain }}"
         registry_pull_token: "{{ registry_pull_token | default('') }}"


### PR DESCRIPTION
Pass common_password and satellite_script through to the ansible-runner container so setup-automation/main.yml can use them.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
