### PR TITLE
Add remove_workloads support to zero-touch destroy playbooks

### DIFF
--- a/ansible/configs/zero-touch-ansible-bu/destroy_env.yml
+++ b/ansible/configs/zero-touch-ansible-bu/destroy_env.yml
@@ -1,4 +1,20 @@
 ---
+- name: Remove workloads
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  run_once: true
+  become: false
+  tasks:
+    - name: Remove workloads
+      when: remove_workloads | default([]) | length > 0
+      ansible.builtin.include_role:
+        name: "{{ workload_loop_var }}"
+      vars:
+        ACTION: "remove"
+      loop: "{{ remove_workloads | default([], true) }}"
+      loop_control:
+        loop_var: workload_loop_var
 
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{ cloud_provider }}_destroy_env.yml

--- a/ansible/configs/zero-touch-base-rhel/destroy_env.yml
+++ b/ansible/configs/zero-touch-base-rhel/destroy_env.yml
@@ -1,4 +1,20 @@
 ---
+- name: Remove workloads
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  run_once: true
+  become: false
+  tasks:
+    - name: Remove workloads
+      when: remove_workloads | default([]) | length > 0
+      ansible.builtin.include_role:
+        name: "{{ workload_loop_var }}"
+      vars:
+        ACTION: "remove"
+      loop: "{{ remove_workloads | default([], true) }}"
+      loop_control:
+        loop_var: workload_loop_var
 
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{ cloud_provider }}_destroy_env.yml


### PR DESCRIPTION
## Summary
- Adds `remove_workloads` processing to `zero-touch-base-rhel` and `zero-touch-ansible-bu` destroy playbooks
- Runs removal workloads (with `ACTION: remove`) before the cloud provider destroy
- Follows the same pattern used in `ocp4-cluster/destroy_env_ec2.yml`
- Enables cleanup of resources like LiteMaaS virtual keys on environment destroy

## Changes
- `ansible/configs/zero-touch-base-rhel/destroy_env.yml`
- `ansible/configs/zero-touch-ansible-bu/destroy_env.yml`

## Test plan
- [ ] Deploy with `remove_workloads` set, destroy environment, confirm workload roles run with `ACTION: remove`
- [ ] Deploy without `remove_workloads`, destroy environment, confirm no change in behavior