### PR TITLE
Add RHELv9.7 image to infra-images

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -32,6 +32,13 @@ infra_images_predefined:
     aws_filters:
       is-public: false
 
+  RHEL97GOLD-latest:
+    owner: "{{ infra_images_redhat_owner_id }}"
+    name: RHEL-9.7.*_HVM_*Access*
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
   RHEL96GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-9.6.*_HVM_*Access*


### PR DESCRIPTION
##### SUMMARY

- Add the RHEL v9.7 image to infra-images

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
infra-images

##### ADDITIONAL INFORMATION

