### PR TITLE
Fixing two bugs: Containerlab-podman issue + SSH agent issue

### DIFF
--- a/ansible/roles/containerlab/tasks/main.yml
+++ b/ansible/roles/containerlab/tasks/main.yml
@@ -13,9 +13,16 @@
         state: started
         enabled: true
 
-    - name: Install containerlab
-      ansible.builtin.shell:
-        cmd: bash -c "$(curl -sL https://get.containerlab.dev)"
+    - name: Fetch stable containerlab RPM
+      ansible.builtin.get_url:
+        url: wget https://github.com/srl-labs/containerlab/releases/download/v0.71.0/containerlab_0.71.0_linux_amd64.rpm"
+        dest: /tmp/containerlab_0.71.0_linux_amd64.rpm
+        mode: '0644'
+
+    - name: Install containerlab from local RPM file
+      ansible.builtin.dnf:
+        name: /tmp/containerlab_0.71.0_linux_amd64.rpm
+        state: present
 
     - name: Containerlab relabling
       ansible.builtin.command:
@@ -42,14 +49,24 @@
         owner: "{{ containerlab_lab_username }}"
         group: "{{ containerlab_lab_username }}"
         mode: "u=rw,g=r,o=r"
-
+        
     - name: Put in-place the SSH key file for the student user
       ansible.builtin.copy:
         src: files/advanced-networking-workshop_id_rsa
         dest: /home/{{ containerlab_lab_username }}/.ssh/advanced-networking-workshop_id_rsa
         owner: "{{ containerlab_lab_username }}"
         group: "{{ containerlab_lab_username }}"
-        mode: "u=r,g-rwx,o-rwx"
+        mode: "0600"
+
+    - name: Ensure student bashrc contains ssh-agent start
+      ansible.builtin.lineinfile:
+        path: /home/{{ containerlab_lab_username }}/.bashrc
+        line: "eval $(ssh-agent -s)"
+
+    - name: Ensure student bashrc contains ssh-add of containerlab key
+      ansible.builtin.lineinfile:
+        path: /home/{{ containerlab_lab_username }}/.bashrc
+        line: "ssh-add ~/.ssh/advanced-networking-workshop_id_rsa"
 
     - name: Download and Install ansible collections
       when: containerlab_ansible_collections_tar_url is defined


### PR DESCRIPTION
##### SUMMARY

Hi, maintainer of related workshop: Advanced Ansible Network Automation here.

Lastest version of containerlab is broken, we have to revert to an older version.

ssh-agent was not started properly and the containerlab ssh key used to automate against containerized switches was not added. Fixed that by adding ssh-agent, ssh-add into .bashrc of student user.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/containerlab for "Advanced Ansible Network Automation"

##### ADDITIONAL INFORMATION
End users have hit these issues.