### PR TITLE
Update locations of cert & key…

### DIFF
--- a/ansible/roles/ansible_bu_satellite/tasks/main.yml
+++ b/ansible/roles/ansible_bu_satellite/tasks/main.yml
@@ -121,8 +121,8 @@
 - name: Update satellite with LetsEncrypt cert and enable registration and template modules
   shell: >-
     satellite-installer --scenario satellite
-    --certs-server-cert "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/fullchain.pem"
-    --certs-server-key "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/privkey.pem"
+    --certs-server-cert "/etc/letsencrypt/archive/{{ ansible_bu_satellite_external_fqdn }}/fullchain1.pem"
+    --certs-server-key "/etc/letsencrypt/archive/{{ ansible_bu_satellite_external_fqdn }}/privkey1.pem"
     --certs-server-ca-cert "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/letsencrypt-ca-bundle.pem"
     --certs-update-server --certs-update-server-ca
     --foreman-proxy-registration true


### PR DESCRIPTION
…due to "feature" of Satellite 6.18 installer.

##### SUMMARY
Update satellite-installer to point to actual files, rather than symlinks utilized by letsencrypt tooling.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles/ansible_bu_satellite
