### PR TITLE
Fix URL format for fetching containerlab RPM

### DIFF
--- a/ansible/roles/containerlab/tasks/main.yml
+++ b/ansible/roles/containerlab/tasks/main.yml
@@ -15,7 +15,7 @@
 
     - name: Fetch stable containerlab RPM
       ansible.builtin.get_url:
-        url: wget https://github.com/srl-labs/containerlab/releases/download/v0.71.0/containerlab_0.71.0_linux_amd64.rpm"
+        url: https://github.com/srl-labs/containerlab/releases/download/v0.71.0/containerlab_0.71.0_linux_amd64.rpm"
         dest: /tmp/containerlab_0.71.0_linux_amd64.rpm
         mode: '0644'
 


### PR DESCRIPTION

##### SUMMARY

Hi maintainer of "Advanced Ansible Network Automation" which this component relates to. 

This is a fix for a copy and paste error (url stated 'wget the-url' instead of 'the-url') in get_url url argument caught during development deployment.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
roles/containerlab for "Advanced Ansible Network Automation"

##### ADDITIONAL INFORMATION
N/A
