### PR TITLE
Add environment variable for installation command

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,7 +32,7 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
-  environment:                                                                                             
+  environment:                                                                                        
     PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2"
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,8 +32,8 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
-  environment:                                                                                                
-    PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2" 
+  environment:                                                                                             
+    PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2"
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,6 +32,8 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
+  environment:                                                                                                
+    PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2" 
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,7 +32,7 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
-  environment:                                                                                   
+  environment:                                                                                
     PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2"
 
 # Leave this as the last task in the playbook.

--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,7 +32,7 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
-  environment:                                                                                        
+  environment:                                                                                   
     PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2"
 
 # Leave this as the last task in the playbook.


### PR DESCRIPTION
Set environment variable for utility container version.


##### SUMMARY
  Pin utility-container to v1.0.2 to fix validation error                                                               
   
  The deployment started failing on Feb 25, 2026 with error:                                                            
  "Secret has onMissingValue set to 'generate' but has a value set"

  Root cause:
  - Container image quay.io/validatedpatterns/utility-container:latest
    was rebuilt on Feb 16, 2026 (now points to v1.0.3)
  - v1.0.3 includes stricter validation from rhvp.cluster_utils that
    requires fields with onMissingValue: generate to have explicit
    vaultPolicy defined
  - Upstream values-secret.yaml.template in rag-llm-gitops repo
    is missing required vaultPolicy fields for mssql and azuresql secrets

  Fix:
  Pin PATTERN_UTILITY_CONTAINER to v1.0.2 (last working version from
  Dec 15, 2025) via environment variable in workload.yml

  This is a temporary workaround. Can be removed once upstream fixes
  the template by adding vaultPolicy fields to generated secrets.

  Ref: https://github.com/validatedpatterns-sandbox/rag-llm-gitops

```
