### PR TITLE
fix: pin utility-container to v1.0.2 to bypass validation error

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,6 +32,8 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
+  environment:
+    PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2"
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------


### PR DESCRIPTION
Container v1.0.3 has stricter secret validation that fails on upstream template missing vaultPolicy fields. Pinning to v1.0.2 (last working version) until upstream fixes the template.

Deployments were working on Dec 15, 2025 but started failing Feb 25, 2026 due to :latest tag now pointing to v1.0.3.

Root cause:
- Container image quay.io/validatedpatterns/utility-container:latest was rebuilt on Feb 16, 2026 (now points to v1.0.3)
- v1.0.3 includes stricter validation from rhvp.cluster_utils that requires fields with onMissingValue: generate to have explicit vaultPolicy defined
- Upstream values-secret.yaml.template in rag-llm-gitops repo is missing required vaultPolicy fields for mssql and azuresql secrets

This is a temporary workaround. Can be removed once upstream fixes the template by adding vaultPolicy fields to generated secrets.

Ref: https://github.com/validatedpatterns-sandbox/rag-llm-gitops



```
