### PR TITLE
ec2_infrastructure_deployment.yml - Fix new ansible bool logic for "C…

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -43,7 +43,7 @@
       include_role:
         name: create_ssh_provision_key
       when:
-        - instances | default([]) | length
+        - instances | default([]) | length > 0
         - ssh_provision_key_name is undefined
 
     - name: Locate environment SSH key


### PR DESCRIPTION
Task: `create_ssh_provision_key`

Ansible changed how the condition is evaluated and now it needs an actual bool. Other tasks were changed already e.g.

```
- name: Locate environment SSH key
      include_role:
        name: locate_env_authorized_key
      when: instances | default([]) | length > 0

    - name: Create keypair in ec2
      include_role:
        name: infra-ec2-ssh-key
      when: instances | default([]) | length > 0
```

but this one was left behind