### PR TITLE
fix boolean type instead of string

### DIFF
--- a/ansible/configs/controller-migration-casc/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/controller-migration-casc/files/cloud_providers/ec2_cloud_template.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True"
+#jinja2: lstrip_blocks: True
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Currently, the deployments encounters the following error:

```
Task failed.
Origin: /runner/project/ansible/roles-infra/infra-ec2-template-generate/tasks/main.yml:21:3
19     var: cloudformation_template
20
21 - name: AWS Generate CloudFormation Template
     ^ column 3
<<< caused by >>>
Syntax error in template: TemplateOverrides.lstrip_blocks must be <class 'bool'> instead of <class 'str'>
Origin: /runner/project/ansible/configs/controller-migration-casc/files/cloud_providers/ec2_cloud_template.j2
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Syntax error in template: TemplateOverrides.lstrip_blocks must be <class 'bool'> instead of <class 'str'>"}
```

This is fixing the data type for the `lstrip_block` option

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
see https://redhat-internal.slack.com/archives/C04MLMA15MX/p1772509532625449