### PR TITLE
ee-multicloud-public: Add community.mysql collection

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -15,6 +15,7 @@ openstacksdk==1.3.1
 packet-python>=1.43.1
 passlib
 paramiko
+PyMySQL
 pexpect>=4.5
 petname
 pyOpenSSL

--- a/tools/execution_environments/ee-multicloud-public/requirements.yml
+++ b/tools/execution_environments/ee-multicloud-public/requirements.yml
@@ -23,6 +23,9 @@ collections:
 - name: community.crypto
 - name: community.general
 
+# PyMySQL
+- name: community.mysql
+
 # kubernetes>=12.0.0
 # requests-oauthlib
 - name: community.okd


### PR DESCRIPTION
Add community.mysql Ansible collection and PyMySQL Python dependency to this EE.

Required for configs like controller-migration-casc that use community.mysql.mysql_user and related modules.
