### PR TITLE
Delete ansible/roles_ocp_workloads/ocp4_workload_cert_manager/cert_manager_ddns.yml

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/cert_manager_ddns.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_cert_manager/cert_manager_ddns.yml
@@ -1,4 +1,0 @@
----
-- name: Nothing to do
-  ansible.builtin.debug:
-    msg: "Using DDNS"


### PR DESCRIPTION
##### SUMMARY

Wrong location / not used

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_cert_manager role
