### PR TITLE
Update to gitea version to fix breaking deployments

### DIFF
--- a/ansible/roles/ocp4-workload-eap8-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-eap8-workshop/tasks/workload.yml
@@ -50,7 +50,8 @@
     ocp4_workload_gitea_operator_create_admin: True
     ocp4_workload_gitea_operator_create_users: True
     ocp4_workload_gitea_operator_migrate_repositories: true
-    ocp4_workload_gitea_operator_gitea_image_tag: v2.0.1
+    ocp4_workload_gitea_operator_catalog_image_tag: v2.1.0
+    ocp4_workload_gitea_operator_starting_csv: gitea-operator.v2.1.0
     ocp4_workload_gitea_operator_repositories_list:
     - repo: "{{ gitea_git_url }}"
       name: "workshop"

--- a/ansible/roles/ocp4-workload-eap8-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-eap8-workshop/tasks/workload.yml
@@ -50,7 +50,7 @@
     ocp4_workload_gitea_operator_create_admin: True
     ocp4_workload_gitea_operator_create_users: True
     ocp4_workload_gitea_operator_migrate_repositories: true
-    ocp4_workload_gitea_operator_gitea_image_tag: 1.20.0
+    ocp4_workload_gitea_operator_gitea_image_tag: v2.0.1
     ocp4_workload_gitea_operator_repositories_list:
     - repo: "{{ gitea_git_url }}"
       name: "workshop"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Fixes breaking deployment from incorrect gitea version.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ansible/roles/ocp4-workload-eap8-workshop 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
