### PR TITLE
add clusterrolebinding kubevirt.io:migrate to all users

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/tasks/workload.yml
@@ -4,9 +4,9 @@
     state: present
     definition: "{{ lookup('file', resource | from_yaml) }}"
   loop:
-  - clusterrole-operator-viewer.yaml
-  - clusterrolebinding-operator-view.yaml
-  - clusterrolebinding-template-view.yaml
+    - clusterrole-operator-viewer.yaml
+    - clusterrolebinding-operator-view.yaml
+    - clusterrolebinding-template-view.yaml
   loop_control:
     loop_var: resource
 
@@ -15,8 +15,8 @@
     state: present
     definition: "{{ lookup('file', resource | from_yaml) }}"
   loop:
-  - rolebinding-openshift-view.yaml
-  - rolebinding-openshift-images-os-view.yaml
+    - rolebinding-openshift-view.yaml
+    - rolebinding-openshift-images-os-view.yaml
   loop_control:
     loop_var: resource
 
@@ -25,12 +25,13 @@
     state: present
     definition: "{{ lookup('template', resource | from_yaml) }}"
   loop:
-  - configmap-ui-settings.yaml.j2
-  - configmap-user-settings.yaml.j2
-  - role-kubevirt-ui-features-reader.yaml.j2
-  - role-kubevirt-user-settings-reader.yaml.j2
-  - rolebinding-kubevirt-ui-features-reader.yaml.j2
-  - rolebinding-kubevirt-user-settings-reader.yaml.j2
+    - configmap-ui-settings.yaml.j2
+    - configmap-user-settings.yaml.j2
+    - role-kubevirt-ui-features-reader.yaml.j2
+    - role-kubevirt-user-settings-reader.yaml.j2
+    - rolebinding-kubevirt-ui-features-reader.yaml.j2
+    - rolebinding-kubevirt-user-settings-reader.yaml.j2
+    - rolebinding-kubevirt-user-migrate.yaml.j2
   loop_control:
     loop_var: resource
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/templates/rolebinding-kubevirt-user-migrate.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_virt_roadshow_multi_user/templates/rolebinding-kubevirt-user-migrate.yaml.j2
@@ -1,0 +1,15 @@
+---
+# new in 4.20, users need ClusterRole kubevirt.io:migrate to do Live VM migrations
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubevirt-user-migrate
+  namespace: {{ ocp4_workload_virt_roadshow_multi_user_configmap_namespace }}
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: 'kubevirt.io:migrate'


### PR DESCRIPTION
New in 4.20.  Needs CRB kubevirt.io:migrate to do live VM migrations

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
