### PR TITLE
Add infra.controller_configuration dependency

### DIFF
--- a/ansible/configs/controller-migration-casc/requirements.yml
+++ b/ansible/configs/controller-migration-casc/requirements.yml
@@ -22,3 +22,5 @@ collections:
   version: '1.1.0'
 - name: community.mysql
   version: '3.9.0'
+- name: infra.controller_configuration
+  version: '>=3.2.4'


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
Add infra.controller_configuration dependency for version >=3.2.4
<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://catalog.demo.redhat.com/catalog?item=babylon-catalog-dev/sandboxes-gpte.aap2-migrate-awx-with-casc.dev is failing with the older versions of the `infra.controller_configuration` collection.
<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
<!-- ```paste below

``` -->
