### PR TITLE
TL500: Detect the gitlab chart version to use

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_tl500/tasks/workload.yml
@@ -152,6 +152,12 @@
   retries: 3
   delay: 10
 
+- name: Determine the installed Gitlab operator version
+  ansible.builtin.command: >-
+    oc get subscription -n gitlab-system gitlab-operator-kubernetes \
+    -o jsonpath={.status.currentCSV}
+  register: gitlab_operator_version_cmd
+
 - name: Install tl500-course-content chart
   command: "{{ item }}"
   args:
@@ -160,8 +166,13 @@
     - "helm dep up"
     - "helm upgrade --install tl500-course-content . \
         --set app_domain={{ ocp4_workload_tl500_apps_domain }} \
+        --set gitlab.chart_version={{ gitlab_chart_version }} \
         --namespace tl500 --create-namespace --timeout=20m"
   register: tl500_course_content
+  vars:
+    gitlab_chart_version: "{{ lookup('ansible.builtin.url', gitlab_url, wantlist=true) | first }}"
+    gitlab_url: "https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/raw/{{ gitlab_op_ver }}/CHART_VERSIONS"
+    gitlab_op_ver: "{{ gitlab_operator_version_cmd.stdout | split('.v') | last }}"
   until: tl500_course_content.rc == 0
   ignore_errors: true
   retries: 3


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
Detect the gitlab chart version to used based on [this listing](https://gitlab.com/gitlab-org/cloud-native/gitlab-operator/-/blob/2.9.2/CHART_VERSIONS). To do this, we can detect the operator version, then visit that page with the correct operator version tag. From that, we can detect the latest acceptable chart version to use, and apply that to the tl500-course-content helm chart.

This fixes an issue where the helm chart will fail on deploy if the supported version in Gitlab has updated (which is fairly frequent)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_tl500

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Related to https://github.com/rht-labs/enablement-framework/pull/189 which needs to be merged in conjunction for this to take any effect

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
Tested with `ansible [core 2.18.7]`
