### PR TITLE
fix(bookbag): skip cleanup when kubeconfig is unavailable during destroy

### DIFF
--- a/ansible/roles/bookbag/tasks/remove_workload.yaml
+++ b/ansible/roles/bookbag/tasks/remove_workload.yaml
@@ -1,22 +1,33 @@
 ---
 # Implement your Workload removal tasks here
-- name: List project namespaces
-  k8s_info:
-    kubeconfig: "{{ _bookbag_kubeconfig | default(omit) }}"
-    api_version: project.openshift.io/v1
-    kind: Project
-  register: r_list_projects
 
-- name: Remove bookbag namespace
-  k8s:
-    kubeconfig: "{{ _bookbag_kubeconfig | default(omit) }}"
-    state: absent
-    api_version: project.openshift.io/v1
-    kind: Project
-    name: "{{ bookbag_namespace }}"
-  vars:
-    _project_names: "{{ r_list_projects.resources | default([]) | json_query('[].metadata.name') }}"
-  when: bookbag_namespace in _project_names
+- name: Remove bookbag resources
+  when: _bookbag_kubeconfig is defined
+  block:
+    - name: List project namespaces
+      k8s_info:
+        kubeconfig: "{{ _bookbag_kubeconfig }}"
+        api_version: project.openshift.io/v1
+        kind: Project
+      register: r_list_projects
+
+    - name: Remove bookbag namespace
+      k8s:
+        kubeconfig: "{{ _bookbag_kubeconfig }}"
+        state: absent
+        api_version: project.openshift.io/v1
+        kind: Project
+        name: "{{ bookbag_namespace }}"
+      vars:
+        _project_names: "{{ r_list_projects.resources | default([]) | json_query('[].metadata.name') }}"
+      when: bookbag_namespace in _project_names
+
+- name: Skipping bookbag cleanup
+  debug:
+    msg: >-
+      Skipping bookbag namespace removal - no kubeconfig available.
+      Resources will be cleaned up when the environment is destroyed.
+  when: _bookbag_kubeconfig is not defined
 
 # Leave this as the last task in the playbook.
 - name: remove_workload tasks complete


### PR DESCRIPTION
## Summary

- Wraps bookbag `remove_workload.yaml` cleanup tasks in a block gated on `_bookbag_kubeconfig is defined`
- Skips namespace removal gracefully when no kubeconfig is available during destroy
- Removes `default(omit)` fallback that silently fell back to a nonexistent default kubeconfig

## Problem

During the destroy phase, the bookbag role's `remove_workload.yaml` fails with:

```
Could not create API client: Invalid kube-config file. No configuration found
```

`_bookbag_kubeconfig` is only set in `pre_workload.yaml` when all three variables are defined:
- `bookbag_openshift_api_ca_cert`
- `bookbag_openshift_api_token`
- `bookbag_openshift_api_url`

During destroy, these variables are often unavailable and the temporary kubeconfig file no longer exists. The `default(omit)` fallback causes `k8s_info` to look for a default kubeconfig that doesn't exist in the execution environment.

## Fix

Gate the entire cleanup block on `_bookbag_kubeconfig is defined`, matching the symmetry with `pre_workload.yaml`. When undefined, a debug message explains that cleanup was skipped and resources will be removed when the environment is destroyed.

## Test plan

- [ ] Verify destroy succeeds when kubeconfig is unavailable (the failing scenario)
- [ ] Verify destroy still cleans up bookbag namespace when kubeconfig is available
- [ ] Verify `test-empty-config` destroy action no longer fails on bookbag removal