### PR TITLE
infra-aws-open-environment: treat CFN stack delete failure as non-fatal

### DIFF
--- a/ansible/roles-infra/infra-aws-open-environment/tasks/destroy_resources.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/destroy_resources.yaml
@@ -6,5 +6,15 @@
     stack_name: "{{ project_tag }}-open-environment"
     state: absent
     region: "{{ aws_region_loop | d(aws_region) | d(region) | d('us-east-1')}}"
+  register: r_cfn_destroy
+  ignore_errors: true
   tags:
     - open_environment
+
+- name: Warn if Cloudformation stack deletion failed
+  when: r_cfn_destroy is failed
+  debug:
+    msg: >-
+      WARNING: Cloudformation stack {{ project_tag }}-open-environment deletion failed.
+      This is non-fatal - AWS Nuke will clean up remaining resources when the sandbox is released.
+      Error: {{ r_cfn_destroy.msg | default('unknown') }}

--- a/ansible/roles-infra/infra-aws-open-environment/tasks/destroy_resources.yaml
+++ b/ansible/roles-infra/infra-aws-open-environment/tasks/destroy_resources.yaml
@@ -13,7 +13,7 @@
 
 - name: Warn if Cloudformation stack deletion failed
   when: r_cfn_destroy is failed
-  debug:
+  ansible.builtin.debug:
     msg: >-
       WARNING: Cloudformation stack {{ project_tag }}-open-environment deletion failed.
       This is non-fatal - AWS Nuke will clean up remaining resources when the sandbox is released.


### PR DESCRIPTION
## Summary
- Makes CloudFormation stack deletion non-fatal in `infra-aws-open-environment` destroy
- Logs a warning instead of failing the entire destroy operation
- AWS Nuke handles cleanup when the sandbox is released

## Problem
When destroying ROSA environments, the CloudFormation stack deletion can fail due to dependent resources (e.g. ENIs left behind after ROSA cluster deletion). This causes the entire destroy to fail and the AnarchySubject gets stuck in `destroy-failed`, retrying indefinitely.

By the time `destroy_resources.yaml` runs, the ROSA cluster has already been confirmed deleted by `uninstall_rosa.yml`. The CFN stack contains supporting infrastructure (VPC, subnets, etc.) that AWS Nuke will clean up when the sandbox is released.

**Observed:** 4 ROSA subjects stuck in `destroy-failed` for up to 17 days, with 25 retry attempts each, all failing at the same `Stack DELETE failed` error.

## Test plan
- [ ] Verify destroy completes successfully when CFN stack delete fails
- [ ] Verify warning message is logged with the CFN error details
- [ ] Verify destroy still works normally when CFN stack delete succeeds