### PR TITLE
agnosticd_restore_output_dir: fix tar ownership error in EE containers

### DIFF
--- a/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
@@ -31,6 +31,7 @@
     dest: "{{ output_dir }}"
     extra_opts:
     - --strip-components=1
+    - --no-same-owner
 
 - name: Remove archive file from output_dir
   ansible.builtin.file:


### PR DESCRIPTION
## Summary
- Add `--no-same-owner` to `unarchive` extra_opts when restoring output_dir archives from S3

## Problem
When the output_dir archive is created on a bastion VM running inside OpenShift (KubeVirt/CNV), the files in the archive are owned by OCP's random high UID (e.g. `1001430000`). When the destroy job later restores this archive in an EE container running as root, `gtar` tries to `chown` files to that UID and fails:

```
gtar: ssh_provision_pp2v5: Cannot change ownership to uid 1001430000, gid 0: Invalid argument
gtar: Exiting with failure status due to previous errors
```

This causes the **entire destroy to fail before any cleanup logic runs**, leaving AnarchySubjects stuck in `destroy-failed` with live cloud resources (OCP namespaces, DNS records, etc.). The destroy retries indefinitely and never succeeds.

### Why this only affects CNV-based configs

Most configs run bastions on EC2/cloud VMs with normal UIDs (0, 1000, etc.), so the archive UIDs are valid everywhere. The issue only hits configs where:
1. The bastion runs inside OCP as a KubeVirt VM (assigned a random high UID like `1001430000`)
2. The output_dir archive is created on that bastion (capturing the high UID)
3. The destroy restores the archive in the EE container (which cannot `chown` to that UID)

## Fix
`--no-same-owner` tells `gtar` to use the current user's ownership instead of restoring the original ownership from the archive. This is safe for all configs - it is a no-op when UIDs are normal, and fixes the failure for CNV-based configs.

## Affected catalog items
- `openshift-cnv.ocp-virt-roadshow-multi-user.prod` (SCM ref: `cnv-virt-roadshow-multi-2.0.4`)
- Potentially any CNV-based config that saves output_dir from a bastion running inside OCP

## Test plan
- [ ] Verify destroy completes past the archive restore step for CNV-based configs
- [ ] Verify archive contents are extracted correctly (file permissions, contents intact)
- [ ] Verify no behavior change for EC2/cloud-based configs (normal UIDs)