### PR TITLE
feat(ocp4_workload_showroom): pass environment_variables to zerotouch, add inputs for usb to openshift_cnv

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
@@ -181,6 +181,12 @@
         devices:
           disks: {{ _instance_disks | replace('INSTANCENAME', _instance_name) }}
           interfaces: {{ _instance_interfaces }}
+      {% if _instance.inputs | default([]) | length > 0 %}
+          inputs: {{ _instance.inputs | to_json }}
+      {% endif %}
+      {% if _instance.host_devices | default([]) | length > 0 %}
+          hostDevices: {{ _instance.host_devices | to_json }}
+      {% endif %}
       networks: {{ _instance_networks }}
       volumes: {{ _instance_volumes | replace('INSTANCENAME', _instance_name) }}
   kubernetes.core.k8s:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -115,3 +115,12 @@ _showroom_user_data:
   bastion_public_hostname: 'test_hostname'
   bastion_ssh_password: 'test_password'
   bastion_ssh_user_name: 'test_user_name'
+
+# Public overrides merged into _showroom_vars after _showroom_user_data.
+showroom_vars: {}
+
+# Environment variables passed to zerotouch automation pods.
+# Set one dict for both pods, or override runtime vs setup independently.
+showroom_environment_variables: {}
+showroom_runtime_automation_environment_variables: "{{ showroom_environment_variables }}"
+showroom_setup_automation_environment_variables: "{{ showroom_environment_variables }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -121,6 +121,6 @@ showroom_vars: {}
 
 # Environment variables passed to zerotouch automation pods.
 # Set one dict for both pods, or override runtime vs setup independently.
-showroom_environment_variables: {}
-showroom_runtime_automation_environment_variables: "{{ showroom_environment_variables }}"
-showroom_setup_automation_environment_variables: "{{ showroom_environment_variables }}"
+showroom_automation_environment_variables: {}
+showroom_runtime_automation_environment_variables: "{{ showroom_automation_environment_variables }}"
+showroom_setup_automation_environment_variables: "{{ showroom_automation_environment_variables }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -133,11 +133,11 @@
         tokengenserver: "localhost:8081"
       runtime_automation:
         setup: "{{ ('false' if ocp4_workload_showroom_automation_disable | bool  else 'true') | string | lower }}"
-        environment_variables: "{{ _showroom_vars.environment_variables | default({}) }}"
+        environment_variables: "{{ showroom_runtime_automation_environment_variables }}"
       setup_automation:
         setup: "{{ ('false' if ocp4_workload_showroom_automation_disable | bool  else 'true') | string | lower }}"
         vault_password: "{{ _showroom_user_data.vault_password | default('') }}"
-        environment_variables: "{{ _showroom_vars.environment_variables | default({}) }}"
+        environment_variables: "{{ showroom_setup_automation_environment_variables }}"
   register: r_helm_templates
 
 - name: Deploy rendered manifests to OpenShift

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -133,9 +133,11 @@
         tokengenserver: "localhost:8081"
       runtime_automation:
         setup: "{{ ('false' if ocp4_workload_showroom_automation_disable | bool  else 'true') | string | lower }}"
+        environment_variables: "{{ _showroom_vars.environment_variables | default({}) }}"
       setup_automation:
         setup: "{{ ('false' if ocp4_workload_showroom_automation_disable | bool  else 'true') | string | lower }}"
         vault_password: "{{ _showroom_user_data.vault_password | default('') }}"
+        environment_variables: "{{ _showroom_vars.environment_variables | default({}) }}"
   register: r_helm_templates
 
 - name: Deploy rendered manifests to OpenShift

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/workload.yml
@@ -30,7 +30,7 @@
     - ocp4_workload_showroom_deployer_chart_name | default("") != "zerotouch"
     vars:
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
-      _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
+      _showroom_vars: "{{ _showroom_user_data | combine(showroom_vars) | combine({'guid': guid}) }}"
     ansible.builtin.include_tasks:
       file: deploy-showroom-helm.yaml
 
@@ -41,7 +41,7 @@
     vars:
       _showroom_user: "{{ _showroom_users_item.key }}"
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"
-      _showroom_vars: "{{ _showroom_users_item.value | combine({'guid': guid, 'user': _showroom_user}) }}"
+      _showroom_vars: "{{ _showroom_users_item.value | combine(showroom_vars) | combine({'guid': guid, 'user': _showroom_user}) }}"
     ansible.builtin.include_tasks:
       file: deploy-showroom-helm.yaml
     loop: "{{ _showroom_user_data.users | dict2items }}"
@@ -55,7 +55,7 @@
     - ocp4_workload_showroom_deployer_chart_name | default("") == "zerotouch"
     vars:
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
-      _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
+      _showroom_vars: "{{ _showroom_user_data | combine(showroom_vars) | combine({'guid': guid}) }}"
     ansible.builtin.include_tasks:
       file: deploy-showroom-helm-zerotouch.yaml
 
@@ -66,7 +66,7 @@
     vars:
       _showroom_user: "{{ _showroom_users_item.key }}"
       _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"
-      _showroom_vars: "{{ _showroom_users_item.value | combine({'guid': guid, 'user': _showroom_user}) }}"
+      _showroom_vars: "{{ _showroom_users_item.value | combine(showroom_vars) | combine({'guid': guid, 'user': _showroom_user}) }}"
     ansible.builtin.include_tasks:
       file: deploy-showroom-helm-zerotouch.yaml
     loop: "{{ _showroom_user_data.users | dict2items }}"
@@ -78,7 +78,7 @@
 - name: Report Variables to user_data (single user)
   when: not _showroom_user_data.users is defined
   vars:
-    _showroom_vars: "{{ _showroom_user_data | combine({'guid': guid}) }}"
+    _showroom_vars: "{{ _showroom_user_data | combine(showroom_vars) | combine({'guid': guid}) }}"
     _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}"
   ansible.builtin.include_tasks:
     file: report-variables.yaml
@@ -88,7 +88,7 @@
   vars:
     _showroom_user: "{{ _showroom_users_item.key }}"
     _showroom_namespace: "{{ ocp4_workload_showroom_namespace }}-{{ _showroom_user }}"
-    _showroom_vars: "{{ _showroom_users_item.value | combine({'guid': guid, 'user': _showroom_user}) }}"
+    _showroom_vars: "{{ _showroom_users_item.value | combine(showroom_vars) | combine({'guid': guid, 'user': _showroom_user}) }}"
   ansible.builtin.include_tasks:
     file: report-variables.yaml
   loop: "{{ _showroom_user_data.users | dict2items }}"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

Forward _showroom_vars.environment_variables into both runtime_automation and setup_automation sections of the zerotouch Helm release values so that AgnosticV catalog entries can inject arbitrary environment variables into the Showroom automation containers.

Add Jinja2-conditional blocks for inputs (e.g., USB tablet) and hostDevices (PCI/USB passthrough) in the VirtualMachine spec devices section. Both are gated behind default([]) checks so existing deployments are unaffected.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_instance.yaml
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

- Deploy a zero-touch Showroom lab with `environment_variables` defined in the catalog entry (Done)
- Verify the env vars appear in both setup and runtime automation containers (Done)
- Verify labs without `environment_variables` defined continue to work (default `{}`) (Done)

- Deploy a CNV VM with `inputs: [{type: tablet, bus: usb, name: usb-tablet}]` (Done)
- Verify `lsusb` inside the guest shows the USB tablet device (Done)
- Deploy a CNV VM without `inputs` or `host_devices` and verify no regression (Done)

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
