### PR TITLE
Make finding bastion in infra-ec2-create-inventory safer

### DIFF
--- a/ansible/roles-infra/infra-ec2-create-inventory/tasks/main.yml
+++ b/ansible/roles-infra/infra-ec2-create-inventory/tasks/main.yml
@@ -35,16 +35,20 @@
     - must
 
 - name: Find the bastion in this batch of hosts
-  set_fact:
-    local_bastion: >-
+  vars:
+    _bastions: >-
       {{ ec2_info.instances
        | rejectattr('state.name', 'equalto', 'terminated')
        | selectattr('tags.internaldns', 'defined')
        | selectattr('tags.AnsibleGroup', 'ansible.builtin.regex', '(^|,)bastions(,|$)')
        | map(attribute='tags.internaldns')
-       | sort | first
+       | sort
       }}
-  when: ec2_info.instances | default([]) | length > 0
+  set_fact:
+    local_bastion: "{{ _bastions | first }}"
+  when:
+    - ec2_info.instances | default([]) | length > 0
+    - _bastions | length > 0
 
 - name: Add hosts to the current inventory
   add_host:


### PR DESCRIPTION
##### SUMMARY

Fix error in finding bastion in `infra-ec2-create-inventory` to make it safer in the case instances are available but none are bastion.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Role `infra-ec2-create-inventory`