### PR TITLE
feat(showroom): add antora UI bundle URL override for custom themes

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -96,6 +96,10 @@ ocp4_workload_showroom_test_self_provisioner: false
 ocp4_workload_showroom_zero_touch_bundle: ""
 ocp4_workload_showroom_zero_touch_ui_enabled: false
 
+# Override the Antora UI bundle URL to use a custom theme
+# When empty, the default theme from the content repo's site.yml is used
+ocp4_workload_showroom_antora_ui_bundle_url: ""
+
 ocp4_workload_showroom_use_sandbox_domain: false
 
 ocp4_workload_showroom_terminal_enable: false

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -27,6 +27,9 @@
         zero_touch_bundle: "{{ ocp4_workload_showroom_zero_touch_bundle }}"
         zero_touch_ui_enabled: "{{ ocp4_workload_showroom_zero_touch_ui_enabled | string | lower }}"
 
+      antora:
+        uiBundleUrl: "{{ ocp4_workload_showroom_antora_ui_bundle_url }}"
+
       guid: "{{ guid }}"
       common_password: "{{ common_password | default('') }}"
       satellite:


### PR DESCRIPTION
##### SUMMARY

Adds a new variable `ocp4_workload_showroom_antora_ui_bundle_url` that allows overriding the Antora UI bundle URL at deploy time, enabling custom themes without modifying the content repo's `site.yml`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- showroom

##### ADDITIONAL INFORMATION
- Add `ocp4_workload_showroom_antora_ui_bundle_url` default variable (defaults to empty string, preserving existing behavior)
- Pass the new variable through to the Helm chart as `antora.uiBundleUrl` in the zerotouch deployment task