### PR TITLE
[ocp4_workload_coco_on_aro] fix again user creation

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workshop_users.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workshop_users.yml
@@ -47,20 +47,18 @@
   args:
     executable: /bin/bash
 
-- name: Wait for authentication cluster operator (retry until both oc wait succeed)
+- name: Wait until htpasswd authentication accepts oc login (devel and uadmin)
   ansible.builtin.shell: |
     set -euo pipefail
-    sleep 5
-    for ((attempt=1; attempt<=5; attempt++)); do
-      if oc wait clusteroperator/authentication --for=condition=Progressing=False --timeout=300s \
-        && oc wait clusteroperator/authentication --for=condition=Available=True --timeout=300s; then
-        exit 0
-      fi
-      echo "authentication clusteroperator wait attempt ${attempt} failed, retrying after 30s..." >&2
-      sleep 30
+    MY_SERVER=$(oc whoami --show-server)
+    until KUBECONFIG={{ ocp4_workload_coco_on_aro_home }}/.kube/devel.kubeconfig oc login -u devel -p devel --server="$MY_SERVER"; do
+      echo "Waiting for devel user to authenticate..."
+      sleep 20
     done
-    echo "authentication clusteroperator did not become ready after 5 attempt(s)" >&2
-    exit 1
+    until KUBECONFIG={{ ocp4_workload_coco_on_aro_home }}/.kube/uadmin.kubeconfig oc login -u uadmin -p uadmin --server="$MY_SERVER"; do
+      echo "Waiting for uadmin user to authenticate..."
+      sleep 20
+    done
   environment:
     KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
   args:
@@ -172,17 +170,6 @@
         oc adm policy add-role-to-user sandboxed-admin-namespace-role uadmin -n "$ns"
       fi
     done
-  environment:
-    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
-  args:
-    executable: /bin/bash
-
-- name: Create devel and uadmin kubeconfig files
-  ansible.builtin.shell: |
-    set -euo pipefail
-    MY_SERVER=$(oc whoami --show-server)
-    KUBECONFIG={{ ocp4_workload_coco_on_aro_home }}/.kube/devel.kubeconfig oc login -u devel -p devel --server="$MY_SERVER"
-    KUBECONFIG={{ ocp4_workload_coco_on_aro_home }}/.kube/uadmin.kubeconfig oc login -u uadmin -p uadmin --server="$MY_SERVER"
   environment:
     KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
   args:


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix once again waiting for users creation that was failing or exiting too early. With this we should be sure that the user is actually created before trying to log in.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_coco_on_aro

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
