### PR TITLE
add: coco: fix cluster roles added too early

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workshop_users.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workshop_users.yml
@@ -64,30 +64,6 @@
   args:
     executable: /bin/bash
 
-- name: Grant cluster-admin to kube:admin user
-  ansible.builtin.command: oc adm policy add-cluster-role-to-user cluster-admin kube:admin
-  environment:
-    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
-
-- name: Grant devel edit role in default namespace
-  ansible.builtin.command: oc adm policy add-role-to-user edit devel -n default
-  environment:
-    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
-
-- name: Create fraud-detection namespace
-  ansible.builtin.command: oc create namespace fraud-detection
-  environment:
-    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
-  register: r_fraud_ns
-  failed_when:
-    - r_fraud_ns.rc != 0
-    - '"AlreadyExists" not in (r_fraud_ns.stderr | default(""))'
-
-- name: Grant devel edit role in fraud-detection namespace
-  ansible.builtin.command: oc adm policy add-role-to-user edit devel -n fraud-detection
-  environment:
-    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
-
 - name: Apply sandboxed-admin cluster-scoped ClusterRole (Kata, nodes, MC, namespace list)
   ansible.builtin.shell: |
     set -euo pipefail
@@ -99,7 +75,7 @@
     rules:
       - apiGroups: [""]
         resources: ["namespaces"]
-        verbs: ["get", "list", "watch"]
+        verbs: ["get", "list", "watch", "create", "patch", "update"]
       - apiGroups: ["config.openshift.io"]
         resources: ["infrastructures"]
         verbs: ["get", "list", "watch"]
@@ -111,7 +87,7 @@
         verbs: ["get", "list", "watch"]
       - apiGroups: ["datasciencecluster.opendatahub.io"]
         resources: ["datascienceclusters"]
-        verbs: ["get", "list", "watch"]
+        verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
       - apiGroups: ["kataconfiguration.openshift.io"]
         resources: ["kataconfigs"]
         verbs: ["*"]
@@ -162,10 +138,13 @@
   environment:
     KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
 
-- name: Bind workload sandboxed-admin ClusterRole to uadmin in allowed namespaces that exist
+- name: Bind workload sandboxed-admin ClusterRole to uadmin in allowed namespaces
   ansible.builtin.shell: |
     set -euo pipefail
     for ns in {{ ocp4_workload_coco_on_aro_uadmin_namespaces | join(' ') }}; do
+      if ! oc get namespace "$ns" &>/dev/null; then
+        oc create namespace "$ns"
+      fi
       if oc get namespace "$ns" &>/dev/null; then
         oc adm policy add-role-to-user sandboxed-admin-namespace-role uadmin -n "$ns"
       fi
@@ -174,6 +153,21 @@
     KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
   args:
     executable: /bin/bash
+
+- name: Grant cluster-admin to kube:admin user
+  ansible.builtin.command: oc adm policy add-cluster-role-to-user cluster-admin kube:admin
+  environment:
+    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
+
+- name: Grant devel edit role in default namespace
+  ansible.builtin.command: oc adm policy add-role-to-user edit devel -n default
+  environment:
+    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
+
+- name: Grant devel edit role in fraud-detection namespace
+  ansible.builtin.command: oc adm policy add-role-to-user edit devel -n fraud-detection
+  environment:
+    KUBECONFIG: "{{ ocp4_workload_coco_on_aro_admin_kubeconfig }}"
 
 - name: Create detached tmux session for workshop layout (no attach)
   environment:

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workshop_users.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workshop_users.yml
@@ -1,5 +1,12 @@
 ---
 # Workshop user setup (htpasswd OAuth, namespaces, RBAC, kubeconfigs, tmux).
+# The idea here is to create two new users: devel and uadmin.
+# The devel user will have the edit role in the default and fraud-detection namespaces.
+# The uadmin user will have the sandboxed-admin ClusterRoles: cluster-scoped
+# APIs per sandboxed-admin-cluster-role, plus workload rules in ocp4_workload_coco_on_aro_uadmin_namespaces.
+# The devel and uadmin users will have the kubeconfig files created in the ocp4_workload_coco_on_aro_home directory.
+# There will be a tmux session created in the ocp4_workload_coco_on_aro_tmux_session variable.
+# The bashrc file will be updated to automatically attach to the tmux session on interactive login.
 
 - name: Build htpasswd file for devel and uadmin
   ansible.builtin.shell: |


### PR DESCRIPTION


<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
Other fixes in the clusterrole added to the namespace too early when they don't exist yet
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_coco_on_aro
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
