### PR TITLE
fix: add retry logic to vscode extension downloads for rate limiting

### DIFF
--- a/ansible/roles/vscode-server/tasks/vscode-server.yml
+++ b/ansible/roles/vscode-server/tasks/vscode-server.yml
@@ -57,9 +57,14 @@
     dest: "{{ vscode_server_user_dir }}/extensions/"
     validate_certs: no
     owner: "{{ vscode_user_name }}"
+  register: __extension_download
+  until: __extension_download is not failed
+  retries: 3
+  delay: 5
   loop: "{{ [__vscode_server_extensions_base_url] | product(vscode_server_default_extensions) | map('join') | list | union(vscode_server_extension_urls) }}"
   loop_control:
     loop_var: __vscode_server_extension
+    pause: 2
 
 - name: vscode | install extensions in given order
   become_user: "{{ vscode_user_name }}"


### PR DESCRIPTION
## Summary
- Add `retries: 3` / `delay: 5` / `until` to the `vscode | download necessary extensions` task so transient HTTP errors (e.g. 429 from open-vsx.org) are retried automatically.
- Add `loop_control.pause: 2` to space out sequential downloads and reduce the likelihood of triggering rate limits in the first place.

## Problem
When multiple VS Code extensions are downloaded from open-vsx.org in rapid succession, the registry returns HTTP 429 (Too Many Requests), causing the entire provisioning job to fail.

## Test plan
- [x] Verified the task YAML is syntactically valid
- [ ] Deploy a lab environment with 4+ open-vsx.org extensions to confirm downloads succeed with the pause/retry logic
