### PR TITLE
Fix test-empty-config range with list filter

### DIFF
--- a/ansible/configs/test-empty-config/infra.yml
+++ b/ansible/configs/test-empty-config/infra.yml
@@ -38,7 +38,7 @@
 
     - name: Add testhosts
       loop: >-
-        {{ range(0, test_empty_config_host_count|int) }}
+        {{ range(0, test_empty_config_host_count|int) | list }}
       loop_control:
         loop_var: testhost_num
         label: "{{ testhost_name }}"


### PR DESCRIPTION
##### SUMMARY

Fix test-empty-config range for `test_empty_config_host_count` by applying list filter.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Config test-empty-config