### PR TITLE
fix(azure): delete locks at all scopes during subscription cleanup

### DIFF
--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -109,33 +109,29 @@
         az_resource_group: "{{ item.name }}"
       loop: "{{ allresourcegroups.resourcegroups }}"
 
-    - name: Get list of locks in the subscription
-      environment:
-        AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
-      azure.azcollection.azure_rm_lock_info:
-        auth_source: env
-        managed_resource_id: "/subscriptions/{{ pool_subscription_id }}"
-      register: r_subscription_locks
-
-    - name: Delete all locks in the subscription
-      when: r_subscription_locks.locks|length>0
+    - name: Get list of all locks in the subscription (all scopes)
       environment:
         AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
       ansible.builtin.command: >
-        az lock delete --name {{ item.name }} --ids {{ item.id }}
-      loop: "{{ r_subscription_locks.locks }}"
+        az lock list --subscription {{ pool_subscription_id }}
+        --query "[].{name:name, id:id, resourceGroup:resourceGroup}"
+        -o json
+      register: r_subscription_locks_raw
+      changed_when: false
 
-    # Leave here until azure fixes the collection
-    #- name: Delete all locks in the subscription
-    #  when: r_subscription_locks.locks|length>0
-    #  environment:
-    #    AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
-    #  azure.azcollection.azure_rm_lock:
-    #    auth_source: env
-    #    name: "{{ item.name }}"
-    #    managed_resource_id: "{{ item.id }}"
-    #    state: absent
-    #  loop: "{{ r_subscription_locks.locks }}"
+    - name: Set lock list fact
+      ansible.builtin.set_fact:
+        r_subscription_locks_list: "{{ r_subscription_locks_raw.stdout | from_json }}"
+
+    - name: Delete all locks in the subscription (all scopes)
+      when: r_subscription_locks_list | length > 0
+      environment:
+        AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
+      ansible.builtin.command: >
+        az lock delete --ids {{ item.id }}
+      loop: "{{ r_subscription_locks_list }}"
+      loop_control:
+        label: "{{ item.name }}"
 
     - name: Delete all resource groups owned by the subscription (RG's created by the lab user)
       when: allresourcegroups.resourcegroups|length>0


### PR DESCRIPTION
## Summary
- Fix lock deletion in `open-env-azure-remove-user-from-subscription` role to cover all scopes (subscription, resource group, and resource level)
- Previous implementation used `azure_rm_lock_info` with `managed_resource_id` scoped to the subscription only, which missed resource group-level locks
- Attacker-created `CanNotDelete` locks on resource groups caused Zerotouch destroy to fail with `ScopeLocked` errors, allowing unauthorized VMs to persist for up to 10 days

## What changed
- Replaced `azure_rm_lock_info` (subscription-scope only) with `az lock list` (all scopes)
- Delete locks by full resource ID instead of by name
- Added `loop_control` label for cleaner output
- Removed commented-out code for broken azure collection lock module

## Test plan
- [ ] Verify `az lock list` returns locks at subscription, resource group, and resource levels
- [ ] Verify lock deletion succeeds for resource group-scoped locks
- [ ] Verify resource group deletion succeeds after locks are removed
- [ ] Test with a subscription that has no locks (should skip gracefully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)