### PR TITLE
Fix RHOAI DataScienceCluster provision failure

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ai_llm_rag_demo/tasks/workload.yml
@@ -32,6 +32,8 @@
   ansible.builtin.command: ./pattern.sh make install
   args:
     chdir: ~/ai-llm-rag-demo-repo
+  environment:
+    PATTERN_UTILITY_CONTAINER: "quay.io/validatedpatterns/utility-container:v1.0.2"
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
@@ -22,6 +22,8 @@ spec:
       registriesNamespace: {{ ocp4_workload_openshift_ai_modelregistries_namespace }}
     ray:
       managementState: {{ ocp4_workload_openshift_ai_ray }}
+    trainer:
+      managementState: Removed
     trustyai:
       managementState: {{ ocp4_workload_openshift_ai_trustyai }}
     workbenches:


### PR DESCRIPTION
## Summary
Fixes Red Hat OpenShift AI 3.4.0 DataScienceCluster provisioning failures by explicitly disabling the trainer component.

## Problem
The trainer component requires the JobSet operator, which is not available in the default redhat-operators catalog. When the component is not explicitly set in the DataScienceCluster spec, it defaults to Managed state, causing the entire cluster to fail provisioning with:
- `Message: JobSet operator not installed, please install it first`
- Dashboard component stuck at 0/1 deployments
- Overall cluster status: Not Ready

## Solution
Added explicit `trainer: managementState: Removed` to the DataScienceCluster template to prevent the cluster from trying to provision a component that depends on unavailable dependencies.

## Testing
- Verified on sandbox with g6.4xlarge GPU instance in us-east-2
- DataScienceCluster now reaches Ready status
- All other components (Dashboard, KServe, Ray, TrustyAI, Model Registry, Workbenches) provision successfully

Fixes Ying's provision failure (Job ID 2452317, sandbox5198)