### PR TITLE
Fix ocp4_workload_openshift_ai DataScienceCluster provision failure

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2
@@ -22,6 +22,8 @@ spec:
       registriesNamespace: {{ ocp4_workload_openshift_ai_modelregistries_namespace }}
     ray:
       managementState: {{ ocp4_workload_openshift_ai_ray }}
+    trainer:
+      managementState: Removed
     trustyai:
       managementState: {{ ocp4_workload_openshift_ai_trustyai }}
     workbenches:


### PR DESCRIPTION
## Summary
Fixes Red Hat OpenShift AI 3.4.0 DataScienceCluster provisioning failures by explicitly disabling the trainer component that requires an unavailable JobSet operator.

## Problem
The trainer component requires the JobSet operator, which is not available in the default redhat-operators catalog. When the component is not explicitly set in the DataScienceCluster spec, it defaults to Managed state, causing the entire cluster to fail provisioning.

**Error message:**
```
Message: JobSet operator not installed, please install it first
```

**Impact:**
- DataScienceCluster stuck in "Not Ready" phase
- Dashboard component unable to reach Ready state (0/1 deployments)
- All RHOAI provisioning failures reported in Job ID 2452317, sandbox5198

## Solution
Added explicit `trainer: managementState: Removed` to the DataScienceCluster template to prevent the cluster from attempting to provision a component dependent on unavailable infrastructure.

## Files Changed
- `ansible/roles_ocp_workloads/ocp4_workload_openshift_ai/templates/redhat-datasciencecluster.yaml.j2`

## Testing
Verified on sandbox cluster (g6.4xlarge GPU, us-east-2):
- ✅ DataScienceCluster now reaches Ready status
- ✅ All other components provision successfully (Dashboard, KServe, Ray, TrustyAI, Model Registry, Workbenches)
- ✅ No impact to other RHOAI functionality