### PR TITLE
fix(azure): add retry loops for Entra ID eventual consistency retirement

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -159,6 +159,10 @@
         app_id: "{{ azapp.applications[0].app_id }}"
         subscription_id: "{{ subscription_id }}"
       register: azsp
+      retries: 30
+      delay: 10
+      until:
+        - azsp.service_principals | length > 0
 
     - name: Add SP to group
       azure.azcollection.azure_rm_adgroup:
@@ -211,6 +215,10 @@
         app_id: "{{ azaroapp.applications[0].app_id }}"
         tenant: "{{ azure_tenant }}"
       register: azaroappsp
+      retries: 30
+      delay: 10
+      until:
+        - azaroappsp.service_principals | length > 0
 
     - name: Save ARO SP password
       ansible.builtin.set_fact: az_aro_pass="{{ azaroappcreate.stdout | from_json | json_query('password') }}"

--- a/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
+++ b/ansible/roles/open-env-azure-create-open-env/tasks/main.yml
@@ -100,6 +100,10 @@
     app_id: "{{ azapp.applications[0].app_id }}"
     tenant: "{{ azure_tenant }}"
   register: azappsp
+  retries: 30
+  delay: 10
+  until:
+    - azappsp.service_principals | length > 0
 
 - name: Build payload for service principal role assignment
   ansible.builtin.set_fact:
@@ -118,6 +122,11 @@
     -u https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments
     -b "{{ payload }}"
   register: rest_post
+  retries: 6
+  delay: 10
+  until:
+    - rest_post.rc == 0
+      or "A conflicting object with one or more of the specified property values is present in the directory" in rest_post.stderr
   failed_when:
     - rest_post.rc != 0
     - '"A conflicting object with one or more of the specified property values is present in the directory" not in rest_post.stderr'
@@ -148,6 +157,10 @@
     app_id: "{{ azaroapp.applications[0].app_id }}"
     tenant: "{{ azure_tenant }}"
   register: azaroappsp
+  retries: 30
+  delay: 10
+  until:
+    - azaroappsp.service_principals | length > 0
 
 - name: Build payload for role assignment
   ansible.builtin.set_fact:
@@ -166,6 +179,11 @@
     -u https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignments
     -b "{{ payload }}"
   register: rest_post
+  retries: 6
+  delay: 10
+  until:
+    - rest_post.rc == 0
+      or "A conflicting object with one or more of the specified property values is present in the directory" in rest_post.stderr
   failed_when:
     - rest_post.rc != 0
     - '"A conflicting object with one or more of the specified property values is present in the directory" not in rest_post.stderr'

--- a/ansible/roles/open-env-azure-invite-user/tasks/main.yml
+++ b/ansible/roles/open-env-azure-invite-user/tasks/main.yml
@@ -92,6 +92,18 @@
       loop:
         - "An invitation has been sent to your redhat.com inbox."
         - "You will need to accept the invitation."
-    - name: Wait 60 seconds for Azure to create user
+    - name: Wait 30 seconds for invitation to propagate
       ansible.builtin.wait_for:
-        timeout: 60
+        timeout: 30
+
+    - name: Verify invited user is visible in Entra ID
+      azure.azcollection.azure_rm_aduser_info:
+        auth_source: cli
+        user_principal_name: "{{ upn }}"
+        tenant: "{{ azure_tenant }}"
+      register: invited_user_check
+      retries: 12
+      delay: 10
+      until:
+        - invited_user_check is succeeded
+        - invited_user_check.ad_users | length > 0

--- a/ansible/roles_ocp_workloads/ocp4_workload_ols/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_ols/tasks/workload.yml
@@ -63,10 +63,20 @@
             _child_app_id: "{{ child_app_response.json.appId }}"
             _child_client_secret: "{{ child_app_response.json.passwordCredentials[0].secretText }}"
 
-        # Introduce a 30-second delay before the next tasks
-        - name: Pause for 30 seconds
-          pause:
-            seconds: 30
+        - name: Verify child app registration is visible in Entra ID
+          ansible.builtin.uri:
+            url: "https://graph.microsoft.com/v1.0/applications(appId='{{ _child_app_id }}')"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ master_access_token }}"
+              Content-Type: "application/json"
+            status_code: [200, 404]
+            return_content: true
+          register: child_app_verify
+          retries: 12
+          delay: 10
+          until:
+            - child_app_verify.status == 200
 
         - name: Create Service Principal for Child App
           uri:
@@ -82,14 +92,24 @@
             status_code: 201  # Expect 201 Created
           register: service_principal_response
 
-        # Introduce a 30-second delay before the next tasks
-        - name: Pause for 30 seconds
-          pause:
-            seconds: 30
-
         - name: Set Child Service Principal Object ID
           set_fact:
             _child_service_principal_object_id: "{{ service_principal_response.json.id }}"
+
+        - name: Verify child service principal is visible in Entra ID
+          ansible.builtin.uri:
+            url: "https://graph.microsoft.com/v1.0/servicePrincipals/{{ _child_service_principal_object_id }}"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ master_access_token }}"
+              Content-Type: "application/json"
+            status_code: [200, 404]
+            return_content: true
+          register: sp_verify
+          retries: 12
+          delay: 10
+          until:
+            - sp_verify.status == 200
 
         - name: Add Child App to Azure AD Group
           uri:
@@ -104,10 +124,20 @@
             return_content: true
             status_code: [201, 204]  # Expect 201 Created or 204 No Content
 
-        # Introduce a 30-second delay before the next tasks
-        - name: Pause for 30 seconds
-          pause:
-            seconds: 30
+        - name: Verify child app is member of Azure AD group
+          ansible.builtin.uri:
+            url: "https://graph.microsoft.com/v1.0/groups/{{ ocp4_workload_ols_azure_group_id }}/members/{{ _child_service_principal_object_id }}"
+            method: GET
+            headers:
+              Authorization: "Bearer {{ master_access_token }}"
+              Content-Type: "application/json"
+            status_code: [200, 404]
+            return_content: true
+          register: group_member_check
+          retries: 12
+          delay: 10
+          until:
+            - group_member_check.status == 200
 
         - name: Get Token for Child App using REST API call
           uri:
@@ -121,16 +151,16 @@
               client_id: "{{ _child_app_id }}"
               client_secret: "{{ _child_client_secret }}"
               scope: https://cognitiveservices.azure.com/.default
+            status_code: 200
           register: child_token_response
+          retries: 12
+          delay: 10
+          until:
+            - child_token_response.status == 200
 
         - name: Set Child Access Token
           set_fact:
             _child_access_token: "{{ child_token_response.json.access_token }}"
-
-        # Introduce a 30-second delay before the next tasks
-        - name: Pause for 30 seconds
-          pause:
-            seconds: 30
 
         - name: Ask AI Service Using Child App
           uri:


### PR DESCRIPTION
## Summary

Microsoft Entra is retiring default app-only read-after-write consistency for Graph APIs on **June 30, 2026** ([MC1268930](https://docs.google.com/document/d/12qyQwROlAe1yDgwbgYwT3jAiUDkhZAstGiyNKyN6fF4/edit?tab=t.0)). After this change, app-only token flows become eventually consistent — reads immediately after writes may return stale/empty results.

Two RHDP app registrations are flagged by Microsoft as affected:
- `rhpds-open-env` (`ac9029cc`) — used by `open-env-azure-*` roles
- `RHDP-llm-gpt4-lightspeed-User` (`0837ad92`) — used by `ocp4_workload_ols`

### Changes

- **open-env-azure-create-open-env**: Add `retries: 30, delay: 10` to SP info lookups and `retries: 6, delay: 10` to role assignment POSTs
- **open-env-azure-add-user-to-subscription**: Add `retries: 30, delay: 10` to SP info lookups (same pattern)
- **open-env-azure-invite-user**: Replace flat 60s `wait_for` with 30s settle + `azure_rm_aduser_info` verification polling loop
- **ocp4_workload_ols**: Replace all four `pause: seconds: 30` blocks with Graph API verification retry loops (app visibility, SP visibility, group membership, token acquisition)

### Why this is safe to deploy now

While default consistency is still active (before June 30), every retry loop succeeds on the first attempt — the resource is already visible. The retries only activate once eventual consistency kicks in.

### Microsoft scream test schedule

- **First week of July 2026**: ~6 hour controlled test
- **Second week of July 2026**: ~24 hour controlled test

Watch Ansible logs for `RETRYING` messages on the affected tasks during these windows.

## Reference

- [Internal tracking doc](https://docs.google.com/document/d/12qyQwROlAe1yDgwbgYwT3jAiUDkhZAstGiyNKyN6fF4/edit?tab=t.0)
- [Microsoft guidance: Designing for Eventual Consistency](https://learn.microsoft.com/en-us/entra/architecture/data-consistency)

## Test plan

- [ ] Verify open-env Azure provisioning completes successfully (retry loops pass on first attempt)
- [ ] Verify OLS workload deploys with `ocp4_workload_ols_token: true`
- [ ] Monitor during Microsoft's July 2026 scream test windows for retry activity