### PR TITLE
[CNV/assisted installer] Update machine type to pc-q35-rhel9.2.0

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_masters_etcd.yaml
@@ -152,7 +152,7 @@
           interfaces: {{ _instance_interfaces }}
           networkInterfaceMultiqueue: true
         machine:
-          type: pc-q35-rhel8.6.0
+          type: pc-q35-rhel9.2.0
         resources:
           requests:
             memory: "{{ ai_control_plane_memory }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -133,7 +133,7 @@
           interfaces: {{ _instance_interfaces }}
           networkInterfaceMultiqueue: true
         machine:
-          type: pc-q35-rhel8.6.0
+          type: pc-q35-rhel9.2.0
         memory:
           guest: "{{ ai_workers_memory }}"
       readinessProbe:

--- a/ansible/roles/host-ocp4-assisted-scale/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-scale/tasks/kubevirt/create_workers.yaml
@@ -133,7 +133,7 @@
           interfaces: {{ _instance_interfaces }}
           networkInterfaceMultiqueue: true
         machine:
-          type: pc-q35-rhel8.6.0
+          type: pc-q35-rhel9.2.0
         resources:
           requests:
             memory: "{{ ai_workers_memory }}"


### PR DESCRIPTION
##### SUMMARY

Avoid warnings related to cpu type on kubevirt, such as:
```
Virtual Machine 'worker-cluster-jtbsc-4' in namespace 'Namespace
NS
[sandbox-jtbsc-ocp4-cluster]
' is using machine type 'pc-q35-rhel8.6.0', which is deprecated. Current status: 'running'.

```
##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
host-ocp4-assisted-installer role
host-ocp4-assisted-scale role
