### PR TITLE
fix(ansible_bu_satellite): use certbot chain.pem instead of hardcoded LE intermediates

### DIFF
--- a/ansible/roles/ansible_bu_satellite/tasks/main.yml
+++ b/ansible/roles/ansible_bu_satellite/tasks/main.yml
@@ -59,44 +59,31 @@
           - "{{ dns_information }}"
           - "The Lets Encrypt certbot failed for the satellite node, please check https://letsencrypt.status.io/ to make sure the service is running"
 
-- name: Download LetsEncrypt CA certs
+- name: Download ISRG Root X1 certificate
   get_url:
-    url: "{{ item.url }}"
-    dest: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}"
+    url: https://letsencrypt.org/certs/isrgrootx1.pem
+    dest: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/isrgrootx1.pem"
     mode: 0644
-    checksum: "{{ item.checksum }}"
+    checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
     group: root
     owner: root
-  loop:
-    - url: https://letsencrypt.org/certs/2024/r12.pem
-      checksum: sha256:c6afa726f611cd87bb3c7b743567221782655db4c4f47e7c64993d1bbdaae8f3
-    - url: https://letsencrypt.org/certs/2024/r13.pem
-      checksum: sha256:6c595b12bcc415caa5ac38c60ad01414131a8b1944c21c7a0c5b1c97631968c9
-    - url: https://letsencrypt.org/certs/isrgrootx1.pem
-      checksum: sha256:22b557a27055b33606b6559f37703928d3e4ad79f110b407d04986e1843543d1
 
-- name: Retrieve LetsEncrypt R12 cert
+- name: Retrieve certbot chain (intermediate certificates)
   slurp:
-    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r12.pem"
-  register: intermediate_cert_r12
+    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/chain.pem"
+  register: certbot_chain
 
-- name: Retrieve LetsEncrypt R13 cert
-  slurp:
-    src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/r13.pem"
-  register: intermediate_cert_r13
-
-- name: Retrieve LetsEncrypt root X1 cert
+- name: Retrieve ISRG Root X1 certificate
   slurp:
     src: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/isrgrootx1.pem"
   register: root_cert
 
-- name: Combine R12, R13 and root X1 certs to create Letsencrypt CA bundle
+- name: Build LetsEncrypt CA bundle from certbot chain and ISRG Root X1
   copy:
     content: |
-      {{ root_cert.content|b64decode }}
-      {{ intermediate_cert_r12.content | b64decode }}
-      {{ intermediate_cert_r13.content | b64decode }}
-    dest: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/letsencrypt-ca-bundle.pem" 
+      {{ certbot_chain.content | b64decode }}
+      {{ root_cert.content | b64decode }}
+    dest: "/etc/letsencrypt/live/{{ ansible_bu_satellite_external_fqdn }}/letsencrypt-ca-bundle.pem"
 
 - name: Start httpd
   service:


### PR DESCRIPTION
## Summary

The `ansible_bu_satellite` role fails during provisioning because the hardcoded Let's Encrypt intermediate certificates (R12/R13) no longer match the intermediates used to sign new certificates.

**Root cause:** On May 27, 2026, Let's Encrypt switched the default `classic` ACME profile to [Generation Y intermediates](https://letsencrypt.org/2025/11/24/gen-y-hierarchy.html) (YR1-YR3 for RSA, YE1-YE3 for ECDSA). The role hardcodes downloads of R12 and R13 to build the CA bundle, but `certbot:latest` now issues certs signed by YR-series intermediates. The `satellite-installer` then fails CA bundle verification:

```
Checking CA bundle against the certificate file:
[FAIL]
error 20 at 0 depth lookup: unable to get local issuer certificate
```

This is the same class of bug that previously required updating from R3 to R12+R13 — hardcoding intermediates creates recurring breakage on every LE rotation.

**Fix:** Replace the hardcoded intermediate downloads with certbot's own `chain.pem` output, which always contains the correct intermediate(s) for the issued certificate. The CA bundle is now built from:
1. `chain.pem` (certbot-provided intermediate chain)
2. `isrgrootx1.pem` (ISRG Root X1, the trust anchor)

This makes the role resilient to future Let's Encrypt hierarchy changes.

## What changed

- **Removed:** Download tasks for `r12.pem` and `r13.pem`
- **Removed:** Slurp tasks for R12 and R13 certificates
- **Removed:** Static "Combine R12, R13 and root X1" bundle task
- **Added:** Slurp of certbot's `chain.pem` (contains the signing intermediate)
- **Changed:** CA bundle now built from `chain.pem` + `isrgrootx1.pem`
- **Kept:** ISRG Root X1 download (stable 20-year root cert)
- **Kept:** All other tasks unchanged

## Affected catalog items

- `sandboxes-gpte/ANS_BU_WKSP_AUTO_SATELLITE` (prod `scm_ref: auto-satellite-2.1.0`) — confirmed failing in job 2493548
- Any other catalog item using the `ansible_bu_satellite` role

## Test plan

- [ ] Provision `ANS_BU_WKSP_AUTO_SATELLITE` in dev/test and verify `satellite-installer` completes with `Success!`
- [ ] Verify the CA bundle contains the correct intermediate chain by running `openssl verify -CAfile letsencrypt-ca-bundle.pem fullchain1.pem` on the satellite host
- [ ] Confirm Satellite web UI is accessible over HTTPS with a valid certificate

cc @msavage (maintainer per agnosticv)