### PR TITLE
feat: add workload ocp4_workload_open_ssh_from_bastion

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+ocp4_workload_open_ssh_from_bastion_enable: false
+
+ocp4_workload_open_ssh_from_bastion_silent: true
+
+ocp4_workload_open_ssh_from_bastion_region: ''
+ocp4_workload_open_ssh_from_bastion_access_key_id: ''
+ocp4_workload_open_ssh_from_bastion_secret_access_key: ''
+
+ocp4_workload_open_ssh_from_bastion_cluster_cidr: "10.0.0.0/16"
+ocp4_workload_open_ssh_from_bastion_bastion_cidr: "192.168.0.0/16"

--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_open_ssh_from_bastion
+  author: Red Hat, Cluster Platform (ITCP) (itcp-team@redhat.com)
+  description: |
+    Open/allow SSH communication from the Bastion host to the nodes of the OCP4 cluster
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+  - ocp
+  - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/readme.adoc
@@ -1,0 +1,64 @@
+= ocp4_workload_open_ssh_from_bastion - Configure the cloud to allow the Bastion host in OCP4 cluster to SSH to the control plane and worker nodes of the cluster
+
+== Role overview
+
+* This role creates a VPC peering connection between the Bastion and the associated OCP4 cluster VPCs.  It then modifies the associated routes and security groups to allow the Bastion host to SSH directly to the control plane and worker nodes of the cluster.  This access is essential for Red Hat Support teams to troubleshoot and recover OCP4 clusters where the recommended process ie. `oc debug node/<nodename>` is unavailable due to an outage/failure of the OpenShift API which is a common recovery scenario.
+
+** Tasks: link:./tasks/pre_workload.yml[pre_workload.yml] - Sets up an
+ environment for the workload deployment.
+*** Debug task will print out: `pre_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to open the SSH communication between Bastion and OpenShift hosts
+*** Debug task will print out: `workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/post_workload.yml[post_workload.yml] - Used to
+ configure the workload after deployment
+*** This role doesn't do anything here
+*** Debug task will print out: `post_workload Tasks completed successfully.`
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to
+ delete the workload
+*** This role doesn't do anything here
+*** Debug task will print out: `remove_workload Tasks completed successfully.`
+
+== Review the defaults variable file
+
+* This file link:./defaults/main.yml[./defaults/main.yml] contains all the variables you need to define to control the deployment of your workload.
+* The variable *ocp4_workload_open_ssh_from_bastion_enable=true* is mandatory to enable this role, by default, the role will not run.
+* A variable *ocp4_workload_open_ssh_from_bastion_silent=false* can be passed to increase debug messages.
+* The variables *ocp4_workload_open_ssh_from_bastion_region*, *ocp4_workload_open_ssh_from_bastion_access_key_id* and *ocp44_workload_open_ssh_from_bastion_secret_access_key* are required to be passed with the appropriate AWS sandbox values for this role to function.
+* You can modify any of these default values by adding `-e "variable_name=variable_value"` to the command line
+
+=== Deploy a Workload with the `ocp-workload` playbook [Mostly for testing]
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+WORKLOAD="ocp4_workload_open_ssh_from_bastion"
+GUID=1001
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"ocp4_workload_open_ssh_from_bastion_silent=False" \
+    -e"guid=${GUID}" \
+    -e"ACTION=create"
+----
+
+=== To Delete an environment
+
+----
+TARGET_HOST="bastion.na4.openshift.opentlc.com"
+OCP_USERNAME="wkulhane-redhat.com"
+WORKLOAD="ocp4_workload_cert_manager"
+GUID=1002
+
+# a TARGET_HOST is specified in the command line, without using an inventory file
+ansible-playbook -i ${TARGET_HOST}, ./configs/ocp-workloads/ocp-workload.yml \
+    -e"ansible_ssh_private_key_file=~/.ssh/keytoyourhost.pem" \
+    -e"ansible_user=ec2-user" \
+    -e"ocp_workload=${WORKLOAD}" \
+    -e"guid=${GUID}" \
+    -e"ACTION=remove"
+----

--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+# --------------------------------------------------
+# Do not modify this file
+# --------------------------------------------------
+- name: Running workload provision tasks
+  when: ACTION == "provision"
+  ansible.builtin.include_tasks:
+    file: workload.yml
+
+- name: Running workload removal tasks
+  when: ACTION == "destroy"
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml

--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/open_ssh_comms_in_aws.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/open_ssh_comms_in_aws.yml
@@ -1,0 +1,183 @@
+---
+- name: Execute the SSH ACCESS workload
+  when:
+    - ocp4_workload_open_ssh_from_bastion_enable | bool
+  module_defaults:
+    group/aws:
+      region: "{{ ocp4_workload_open_ssh_from_bastion_region }}"
+      access_key: "{{ ocp4_workload_open_ssh_from_bastion_access_key_id }}"
+      secret_key: "{{ ocp4_workload_open_ssh_from_bastion_secret_access_key }}"
+  block:
+    ###########################################################################
+    #
+    # Step 1: Create a VPC Peering Connection between the Bastion and
+    # Cluster VPCs
+    #
+    ###########################################################################
+
+    - name: Get Bastion VPC
+      amazon.aws.ec2_vpc_net_info:
+        filters:
+          "cidr": "{{ ocp4_workload_open_ssh_from_bastion_bastion_cidr }}"
+      register: r_bastion_vpc
+
+    - name: Display the Bastion VPC
+      ansible.builtin.debug:
+        var: r_bastion_vpc.vpcs[0].vpc_id
+
+    - name: Get Cluster VPC
+      amazon.aws.ec2_vpc_net_info:
+        filters:
+          "cidr": "{{ ocp4_workload_open_ssh_from_bastion_cluster_cidr }}"
+      register: r_cluster_vpc
+
+    - name: Display the Cluster VPC
+      ansible.builtin.debug:
+        var: r_cluster_vpc.vpcs[0].vpc_id
+
+    - name: Create VPC Peering Connection between VPCs
+      amazon.aws.ec2_vpc_peering:
+        vpc_id: "{{ r_bastion_vpc.vpcs[0].vpc_id }}"
+        peer_vpc_id: "{{ r_cluster_vpc.vpcs[0].vpc_id }}"
+      register: r_vpc_peering
+
+    - name: Accept VPC Peering request
+      amazon.aws.ec2_vpc_peering:
+        peering_id: "{{ r_vpc_peering.peering_id }}"
+        state: "accept"
+
+    ###########################################################################
+    #
+    # Step 2: Add route from Bastion to Cluster as well as from Cluster to
+    #         Bastion subnet via the Peering connection
+    #
+    ###########################################################################
+
+    - name: Debug - Get all Route Tables
+      when:
+        - not ocp4_workload_open_ssh_from_bastion_silent | bool
+      block:
+        - name: Get all Route Tables
+          amazon.aws.ec2_vpc_route_table_info:
+          register: r_all_route_tables
+
+        - name: Display all Route Tables
+          ansible.builtin.debug:
+            var: r_all_route_tables
+
+    - name: Get filtered list of Bastion route tables
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          "tag:env_type": ocp4-cluster
+          association.main: false
+          vpc-id: "{{ r_bastion_vpc.vpcs[0].vpc_id }}"
+      register: r_bastion_filtered_routes
+
+    - name: Display the filtered list of Bastion route tables
+      ansible.builtin.debug:
+        var: r_bastion_filtered_routes
+      when:
+        - not ocp4_workload_open_ssh_from_bastion_silent | bool
+
+    - name: Get filtered list of Cluster route tables
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          "tag:env_type": ocp4-cluster
+          "tag:Name": "*private*"
+          association.main: false
+          vpc-id: "{{ r_cluster_vpc.vpcs[0].vpc_id }}"
+      register: r_cluster_filtered_routes
+
+    - name: Display the filtered list of Cluster route tables
+      ansible.builtin.debug:
+        var: r_cluster_filtered_routes
+      when:
+        - not ocp4_workload_open_ssh_from_bastion_silent | bool
+
+    - name: Add route from Bastion to Cluster via VPC Peering Connection
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ r_bastion_vpc.vpcs[0].vpc_id }}"
+        route_table_id: "{{ item }}"
+        lookup: id
+        purge_routes: false
+        routes:
+          - dest: "{{ ocp4_workload_open_ssh_from_bastion_cluster_cidr }}"
+            vpc_peering_connection_id: "{{ r_vpc_peering.peering_id }}"
+      loop: "{{ r_bastion_filtered_routes.route_tables | map(attribute='route_table_id') | list }}"
+
+    - name: Add route from Cluster to Bastion via VPC Peering Connection
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ r_cluster_vpc.vpcs[0].vpc_id }}"
+        route_table_id: "{{ item }}"
+        lookup: id
+        purge_routes: false
+        routes:
+          - dest: "{{ ocp4_workload_open_ssh_from_bastion_bastion_cidr }}"
+            vpc_peering_connection_id: "{{ r_vpc_peering.peering_id }}"
+      loop: "{{ r_cluster_filtered_routes.route_tables | map(attribute='route_table_id') | list }}"
+
+    ###########################################################################
+    #
+    # Step 3: Add security group rules in Cluster 'controlplane' and 'node'
+    #         security groups allowing SSH (22/tcp) from the Bastion cidr
+    #
+    ###########################################################################
+
+    - name: Debug - Get all Security Groups
+      when:
+        - not ocp4_workload_open_ssh_from_bastion_silent | bool
+      block:
+        - name: Get all Security Group Info
+          amazon.aws.ec2_security_group_info:
+          register: r_all_sg_info
+
+        - name: Display all Security Groups
+          ansible.builtin.debug:
+            var: r_all_sg_info
+
+    # NOTE: Newer versions of OpenShift (v4.16+) have 'controlplane' and 'node' in the
+    #       security group names while older have 'master' and 'worker'.
+
+    - name: Get Security Groups info for the cluster controlplane and nodes
+      amazon.aws.ec2_security_group_info:
+        filters:
+          vpc-id: "{{ r_cluster_vpc.vpcs[0].vpc_id }}"
+          "tag:Name": "{{ item }}"
+      loop:
+        - "*controlplane*"
+        - "*node*"
+        - "*master*"
+        - "*worker*"
+      register: r_filtered_cluster_sg_info
+
+    - name: Display filtered list of Security Groups for the cluster controlplane and nodes
+      ansible.builtin.debug:
+        var: >-
+          r_filtered_cluster_sg_info.results
+          | map(attribute='security_groups')
+          | flatten
+          | map(attribute='group_name')
+          | list
+      when:
+        - not ocp4_workload_open_ssh_from_bastion_silent | bool
+
+    - name: Add rule to Security Groups allowing SSH from the Bastion to the Cluster
+      amazon.aws.ec2_security_group:
+        name: "{{ item }}"
+        purge_rules: false
+        purge_rules_egress: false
+        description: Allow SSH from Bastion to Cluster
+        vpc_id: "{{ r_cluster_vpc.vpcs[0].vpc_id }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: "{{ ocp4_workload_open_ssh_from_bastion_bastion_cidr }}"
+      loop: >-
+        {{
+          r_filtered_cluster_sg_info.results
+          | map(attribute='security_groups')
+          | flatten
+          | map(attribute='group_name')
+          | list
+        }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/remove_workload.yml
@@ -1,0 +1,8 @@
+---
+# ------------------------------------------
+# Implement your workload removal tasks here
+# ------------------------------------------
+
+- name: Remove_workload tasks complete
+  ansible.builtin.debug:
+    msg: "Remove Workload tasks completed successfully."

--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/workload.yml
@@ -1,0 +1,5 @@
+---
+- name: Open SSH communication from Bastion to OCP4 cluster hosts in AWS
+  ansible.builtin.include_tasks: open_ssh_comms_in_aws.yml
+  when:
+    - cloud_provider == 'ec2'


### PR DESCRIPTION
##### SUMMARY
This new role was created by the Cluster Platform dev team on behalf of the Red Hat OpenShift support team.  This role configures the AWS sandbox such that the Bastion host can be the jump point to SSH to any of the OpenShift hosts within its associated OpenShift cluster.  This capability is required by the support team to reproduce customer cases where the standard access to the OpenShift hosts via API is not available.

closes:  #15579

##### ISSUE TYPE
- New role Pull Request

##### COMPONENT NAME
ocp4_workload_open_ssh_from_bastion

##### ADDITIONAL INFORMATION
There are three main steps to this workload:
1. Create an AWS VPC Peering Connection between the Bastion and Cluster VPCs
2. Configure a route from the Bastion to the Cluster network(s) via the VPC Peering Connection as well as the inverse route(s) from the Cluster back to the Bastion also via the VPC Peering Connection
3. Configure Security Group rules allowing SSH from the Bastion
