### PR TITLE
fix(open-env-azure): prevent CannotDeleteLastRbacAdminAssignment on destroy retry

### DIFF
--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -159,6 +159,17 @@
         id: "{{ azure_subscription_id }}"
       register: management_subscription
 
+    - name: Ensure pool manager SP has direct Owner on subscription
+      environment:
+        AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
+      azure.azcollection.azure_rm_roleassignment:
+        auth_source: env
+        scope: "{{ subscriptionfqid }}"
+        assignee_object_id: "{{ azure_open_env_app_id }}"
+        role_definition_id:
+          "/subscriptions/{{ pool_subscription_id }}/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+        state: present
+
     - name: Get all direct role assignments for the subscription
       environment:
         AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
@@ -168,10 +179,10 @@
         strict_scope_match: True
       register: role_assignments
 
-    - name: Remove all direct role assignments from the subscription
+    - name: Remove non-pool-manager role assignments from the subscription
       environment:
         AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
-      when: 'item.assignee_object_id != azure_open_env_app_id'
+      when: item.assignee_object_id != azure_open_env_app_id
       azure.azcollection.azure_rm_roleassignment:
         auth_source: env
         id: "{{ item.id }}"


### PR DESCRIPTION
## Summary
- Ensures pool manager SP's direct Owner assignment exists on the subscription before removing other role assignments during destroy
- Prevents `CannotDeleteLastRbacAdminAssignment` error on destroy retries when the pool manager's Owner was removed by a previous failed run

## Problem
When a destroy job fails mid-run and retries:
1. Previous run successfully removed the pool manager SP's direct Owner assignment
2. Only the per-environment SP's Owner remains
3. The per-environment SP's app registration gets deleted (orphaning the assignment)
4. Azure blocks removing this orphaned Owner because it's the last RBAC admin
5. Destroy fails permanently with `CannotDeleteLastRbacAdminAssignment`

## Fix
Add a task before role assignment removal that ensures the pool manager SP (`azure_open_env_app_id`) has a direct Owner assignment on the subscription. This is:
- **No-op on first run**: assignment already exists
- **Recovery on retry**: recreates the pool manager's Owner so the orphaned per-env SP assignment can be safely removed

## Test plan
- [ ] Verify on a clean subscription that the new task is a no-op (Owner already exists)
- [ ] Verify on a broken subscription (missing pool manager Owner) that the fix restores it
- [ ] Manually tested: restored pool manager Owner on pool-01-377 and pool-00-30, then successfully deleted orphaned assignments