### PR TITLE
fix(infra_vmware_ibm): detach FCD disks before VM deletion

### DIFF
--- a/ansible/roles-infra/infra_vmware_ibm_resources/defaults/main.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/defaults/main.yaml
@@ -2,4 +2,7 @@
 # Naming of instances
 vmc_instance_numeration: '%d'
 
+# Disable SSL certificate validation for vCenter connections
+vmw_validate_certs: false
+
 publicips: []

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_instance.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_instance.yaml
@@ -29,7 +29,7 @@
         value: "{{ _instance_userdata | b64encode }}"
       - key: "guestinfo.userdata.encoding"
         value: "base64"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
@@ -46,7 +46,7 @@
     network_name: "segment-{{ env_type }}-{{ guid }}"
     start_connected: true
     connected: true
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: present
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
@@ -61,7 +61,7 @@
   community.vmware.vmware_guest_custom_attributes:
     folder: "/Workloads/{{env_type}}-{{ guid }}"
     name: "{{ _instance_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: present
     attributes: "{{ _instance.attributes + [{'name':'public_dns', 'value': _instance.public_dns|default(False)}]  }}"
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
@@ -81,7 +81,7 @@
     state: poweredon
     wait_for_ip_address: true
     name: "{{ _instance_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index
@@ -96,7 +96,7 @@
   community.vmware.vmware_guest_info:
     folder: "/Workloads/{{env_type}}-{{ guid }}"
     name: "{{ _instance_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
   loop: "{{ range(1, _instance.count|default(1)|int+1) | list }}"
   loop_control:
     index_var: _index

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_instances.yaml
@@ -8,7 +8,7 @@
     folder_name: "{{ env_type }}-{{ guid }}"
     parent_folder: "Workloads"
     folder_type: vm
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: present
   register: r_vcenter_folder
   until: r_vcenter_folder is success

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_instances.yaml
@@ -6,6 +6,47 @@
 - name: Stop instances
   include_tasks: stop_instances.yaml
 
+- name: Get disk info for each VM
+  community.vmware.vmware_guest_disk_info:
+    datacenter: "{{ vcenter_datacenter }}"
+    name: "{{ item.guest_name }}"
+    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+  loop: "{{ r_vmc_vms.virtual_machines | default([]) }}"
+  loop_control:
+    label: "{{ item.guest_name }}"
+  register: r_disk_info
+
+- name: Build list of FCD disks to detach
+  ansible.builtin.set_fact:
+    _fcd_disks_to_remove: >-
+      {{
+        _fcd_disks_to_remove | default([]) + (
+          item.guest_disk_info | dict2items
+          | selectattr('value.backing_filename', 'search', 'fcd/')
+          | map('combine', {'_vm_name': item.item.guest_name})
+          | list
+        )
+      }}
+  loop: "{{ r_disk_info.results }}"
+  loop_control:
+    label: "{{ item.item.guest_name }}"
+
+- name: Detach FCD disks before VM deletion
+  when: _fcd_disks_to_remove | default([]) | length > 0
+  community.vmware.vmware_guest_disk:
+    datacenter: "{{ vcenter_datacenter }}"
+    name: "{{ item._vm_name }}"
+    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    disk:
+      - state: absent
+        destroy: true
+        controller_type: "{{ item.value.controller_type }}"
+        controller_number: "{{ item.value.controller_bus_number }}"
+        unit_number: "{{ item.value.unit_number }}"
+  loop: "{{ _fcd_disks_to_remove | default([]) }}"
+  loop_control:
+    label: "{{ item._vm_name }} - {{ item.value.backing_filename }}"
+
 - name: Remove the VMs
   register: r_vmc_instances
   community.vmware.vmware_guest:

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_instances.yaml
@@ -10,7 +10,7 @@
   community.vmware.vmware_guest_disk_info:
     datacenter: "{{ vcenter_datacenter }}"
     name: "{{ item.guest_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
   loop: "{{ r_vmc_vms.virtual_machines | default([]) }}"
   loop_control:
     label: "{{ item.guest_name }}"
@@ -36,7 +36,7 @@
   community.vmware.vmware_guest_disk:
     datacenter: "{{ vcenter_datacenter }}"
     name: "{{ item._vm_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     disk:
       - state: absent
         destroy: true
@@ -52,7 +52,7 @@
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"
     name: "{{ item.guest_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: "absent"
   loop: "{{ r_vmc_vms.virtual_machines|default([]) }}"
 
@@ -68,7 +68,7 @@
     folder_name: "{{ env_type }}-{{ guid }}"
     parent_folder: "Workloads"
     folder_type: vm
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: absent
 
 - name: Delete additional public ips

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/start_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/start_instances.yaml
@@ -4,13 +4,13 @@
   community.vmware.vmware_vm_info:
     folder: "/{{ vcenter_datacenter }}/vm/Workloads/{{ env_type }}-{{ guid }}"
     show_attribute: true
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
 
 - name: Start the VMs
   register: r_vmc_instances
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"
     name: "{{ item.guest_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: "poweredon"
   loop: "{{ r_vmc_vms.virtual_machines }}"

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/stop_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/stop_instances.yaml
@@ -4,7 +4,7 @@
   community.vmware.vmware_vm_info:
     folder: "/{{ vcenter_datacenter }}/vm/Workloads/{{ env_type }}-{{ guid }}"
     show_attribute: true
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
   ignore_errors: True
 
 - name: Stop the VMs
@@ -12,7 +12,7 @@
   community.vmware.vmware_guest:
     folder: "/Workloads/{{env_type}}-{{ guid }}"
     name: "{{ item.guest_name }}"
-    validate_certs: "{{ vmw_validate_certs | default(false) | bool }}"
+    validate_certs: "{{ vmw_validate_certs }}"
     state: "poweredoff"
   loop: "{{ r_vmc_vms.virtual_machines|default([]) }}"
 


### PR DESCRIPTION
## Summary
- Detaches and deletes First Class Disk (FCD) attachments from VMs before attempting VM deletion
- Fixes "Invalid virtual machine state - incomplete disk information" errors during destroy

## Problem
OCP clusters deployed on VMware IBM create persistent volumes as FCDs via the vSphere CSI driver. During destroy:
1. The OCP cluster is torn down, which may delete the FCD objects but leave the backing VMDKs
2. The VM config still references the `fcd/` backed disks
3. `community.vmware.vmware_guest` with `state: absent` fails with "Invalid virtual machine state" because it can't resolve the FCD metadata for these disks

## Fix
Before the "Remove the VMs" step, the role now:
1. Queries disk info for each VM (`vmware_guest_disk_info`)
2. Identifies disks with `fcd/` in the backing filename
3. Detaches and deletes those disks (`vmware_guest_disk` with `state: absent, destroy: true`)

Handles both cases:
- **FCD still registered + attached**: detach removes attachment, destroy deletes the VMDK
- **FCD deleted, orphaned VM reference**: detach cleans up stale config, destroy removes leftover VMDK

No-op for VMs without FCD disks.

## Test plan
- [x] Tested locally against vcsnsx-vc with sandbox-48v2l (2 VMs, 4 FCD disks)
- [x] Detach succeeded on all 4 disks, VM deletion succeeded on both VMs
- [ ] Verify no regression on VMs without FCD disks (standard sandbox deployments)