### PR TITLE
[GPTEINFRA-16844] ocp4-workload-app-connect-ai: per-user LiteMaaS virtual keys

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/defaults/main.yml
@@ -59,6 +59,8 @@ helpdesk_db_name: "helpdesk"
 helpdesk_admin_user: "admin"
 helpdesk_admin_password: "Openshift1!"
 
-# AI / MaaS
-maas_url: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
+# AI / MaaS — defaults point to new LiteMaaS cluster
+# maas_url is overridden at provision time via lookup('agnosticd_user_data', 'litellm_api_base_url')
+# set in agnosticv common.yaml. This default is a fallback only.
+maas_url: "https://maas-rhdp.apps.maas.redhatworkshops.io/v1"
 internal_ai_gateway_url: "http://internal-ai-gateway-openshift-default.ai-gateway.svc.cluster.local"

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/defaults/main.yml
@@ -50,9 +50,6 @@ lab_deploy_assets_branch: "main"
 # Showroom / docs
 docs_namespace: "showroom"
 
-# LiteLLM virtual key used as Bearer token in user HTTPRoutes
-litellm_virtual_key: "{{ocp4_workload_app_connect_ai_apikey}}"
-
 # Helpdesk (Trudesk)
 helpdesk_namespace: "helpdesk"
 helpdesk_db_admin_password: "mongoAdmin1!"
@@ -64,5 +61,4 @@ helpdesk_admin_password: "Openshift1!"
 
 # AI / MaaS
 maas_url: "https://litellm-prod.apps.maas.redhatworkshops.io/v1"
-maas_key: "{{ocp4_workload_app_connect_ai_apikey}}"
 internal_ai_gateway_url: "http://internal-ai-gateway-openshift-default.ai-gateway.svc.cluster.local"

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_cl_api_users.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_cl_api_users.yaml
@@ -18,6 +18,7 @@
     resource_definition: "{{ lookup('template', 'kuadrant-silver-user.yaml.j2') }}"
   vars:
     __api_key: "{{ api_keys[__user]['silver'] }}"
+    __litellm_key: "{{ _litellm_user_data['litellm_' ~ __user ~ '_virtual_key'] | default('') }}"
   loop: "{{ users }}"
   loop_control:
     loop_var: __user
@@ -28,6 +29,7 @@
     resource_definition: "{{ lookup('template', 'kuadrant-gold-user.yaml.j2') }}"
   vars:
     __api_key: "{{ api_keys[__user]['gold'] }}"
+    __litellm_key: "{{ _litellm_user_data['litellm_' ~ __user ~ '_virtual_key'] | default('') }}"
   loop: "{{ users }}"
   loop_control:
     loop_var: __user

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
@@ -25,6 +25,10 @@
   shell: oc get route s3 -n openshift-storage -o jsonpath='https://{.spec.host}'
   register: _lc_s3_endpoint
 
+- name: Initialize api_keys if Connectivity Link stack is not deployed
+  set_fact:
+    api_keys: "{{ api_keys | default({}) }}"
+
 - name: Create lab-config Secret for each user
   kubernetes.core.k8s:
     state: present
@@ -77,8 +81,8 @@
           internal_ai_http_route_url={{ internal_ai_gateway_url }}/{{ item.name }}/v1
 
           # Kuadrant API keys (per-user)
-          kuadrant_silver_api_key={{ api_keys[item.name]['silver'] }}
-          kuadrant_gold_api_key={{ api_keys[item.name]['gold'] }}
+          kuadrant_silver_api_key={{ (api_keys[item.name] | default({}))['silver'] | default('') }}
+          kuadrant_gold_api_key={{ (api_keys[item.name] | default({}))['gold'] | default('') }}
   loop: "{{ _lc_im_users }}"
   loop_control:
     label: "{{ item.name }}"

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
@@ -74,8 +74,8 @@
           # S3 (per-user)
           s3_bucket={{ item.name }}
 
-          # AI / MaaS (per-user key, endpoint from virtual keys workload)
-          maas_url={{ (litellm_api_endpoint ~ '/v1') if litellm_api_endpoint is defined else maas_url }}
+          # AI / MaaS (per-user key, endpoint from virtual keys workload via agnosticd_user_data)
+          maas_url={{ lookup('agnosticd_user_data', 'litellm_api_base_url') | default(maas_url) }}
           maas_key={{ _litellm_user_data['litellm_' ~ item.name ~ '_virtual_key'] | default('') }}
           internal_ai_gateway_url={{ internal_ai_gateway_url }}
           internal_ai_http_route_url={{ internal_ai_gateway_url }}/{{ item.name }}/v1

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
@@ -74,8 +74,8 @@
           # S3 (per-user)
           s3_bucket={{ item.name }}
 
-          # AI / MaaS (per-user key, shared endpoint from virtual keys workload)
-          maas_url={{ litellm_api_base_url | default(maas_url) }}
+          # AI / MaaS (per-user key, endpoint from virtual keys workload)
+          maas_url={{ (litellm_api_endpoint ~ '/v1') if litellm_api_endpoint is defined else maas_url }}
           maas_key={{ _litellm_user_data['litellm_' ~ item.name ~ '_virtual_key'] | default('') }}
           internal_ai_gateway_url={{ internal_ai_gateway_url }}
           internal_ai_http_route_url={{ internal_ai_gateway_url }}/{{ item.name }}/v1

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
@@ -74,8 +74,8 @@
           # S3 (per-user)
           s3_bucket={{ item.name }}
 
-          # AI / MaaS (shared)
-          maas_url={{ maas_url }}
+          # AI / MaaS (per-user key, shared endpoint from virtual keys workload)
+          maas_url={{ litellm_api_base_url | default(maas_url) }}
           maas_key={{ _litellm_user_data['litellm_' ~ item.name ~ '_virtual_key'] | default('') }}
           internal_ai_gateway_url={{ internal_ai_gateway_url }}
           internal_ai_http_route_url={{ internal_ai_gateway_url }}/{{ item.name }}/v1

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_lab_config.yaml
@@ -72,7 +72,7 @@
 
           # AI / MaaS (shared)
           maas_url={{ maas_url }}
-          maas_key={{ maas_key }}
+          maas_key={{ _litellm_user_data['litellm_' ~ item.name ~ '_virtual_key'] | default('') }}
           internal_ai_gateway_url={{ internal_ai_gateway_url }}
           internal_ai_http_route_url={{ internal_ai_gateway_url }}/{{ item.name }}/v1
 

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/workload_main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/workload_main.yaml
@@ -79,8 +79,8 @@
   include_tasks: provision_im_credentials.yaml
 
 # Needs to run before provisioning lab config secrets
-# - name: Provision Connectivity Link Stack
-#   include_tasks: provision_cl_main.yaml
+- name: Provision Connectivity Link Stack
+  include_tasks: provision_cl_main.yaml
 
 - name: Provision per-user lab config Secrets
   include_tasks: provision_lab_config.yaml

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/http-route-internal.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/http-route-internal.yaml.j2
@@ -25,7 +25,7 @@ spec:
           requestHeaderModifier:
             set:
               - name: Host
-                value: litellm-prod.apps.maas.redhatworkshops.io
+                value: "{{ litellm_api_endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"
       backendRefs:
         - name: ai-api-external
           namespace: llm-api

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/kuadrant-gold-user.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/kuadrant-gold-user.yaml.j2
@@ -10,7 +10,7 @@ metadata:
   annotations:
     kuadrant.io/groups: gold
     secret.kuadrant.io/user-id: "{{ __user }}"
-    secret.kuadrant.io/upstream-token: "Bearer {{ litellm_virtual_key }}"
+    secret.kuadrant.io/upstream-token: "Bearer {{ __litellm_key }}"
 stringData:
   api_key: "{{ __api_key }}"
 type: Opaque

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/kuadrant-silver-user.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/kuadrant-silver-user.yaml.j2
@@ -10,7 +10,7 @@ metadata:
   annotations:
     kuadrant.io/groups: silver
     secret.kuadrant.io/user-id: "{{ __user }}"
-    secret.kuadrant.io/upstream-token: "Bearer {{ litellm_virtual_key }}"
+    secret.kuadrant.io/upstream-token: "Bearer {{ __litellm_key }}"
 stringData:
   api_key: "{{ __api_key }}"
 type: Opaque

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/llm-api-destination-rule.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/llm-api-destination-rule.yaml.j2
@@ -5,9 +5,9 @@ metadata:
   name: ai-origination
   namespace: llm-api
 spec:
-  host: litellm-prod.apps.maas.redhatworkshops.io
+  host: "{{ litellm_api_endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"
   exportTo: ["*"]
   trafficPolicy:
     tls:
       mode: SIMPLE
-      sni: litellm-prod.apps.maas.redhatworkshops.io
+      sni: "{{ litellm_api_endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/llm-api-service-entry.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/llm-api-service-entry.yaml.j2
@@ -6,7 +6,7 @@ metadata:
   namespace: llm-api
 spec:
   hosts:
-  - litellm-prod.apps.maas.redhatworkshops.io
+  - "{{ litellm_api_endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"
   exportTo: ["*"]
   location: MESH_EXTERNAL
   ports:

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/llm-api-shadow-service.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/llm-api-shadow-service.yaml.j2
@@ -6,4 +6,4 @@ metadata:
   namespace: llm-api
 spec:
   type: ExternalName
-  externalName: litellm-prod.apps.maas.redhatworkshops.io
+  externalName: "{{ litellm_api_endpoint | regex_replace('https?://', '') | regex_replace('/.*', '') }}"


### PR DESCRIPTION
## Summary

Migrates LB2131 (AI data flows) from a single shared long-running LiteMaaS API key to per-user scoped virtual keys, as required by new infosec policy and LiteMaaS infrastructure migration.

### Changes

- **`defaults/main.yml`** — removed `litellm_virtual_key` and `maas_key` static defaults that were derived from `ocp4_workload_app_connect_ai_apikey`. These are now supplied per-user by the `ocp4_workload_litellm_virtual_keys` workload (configured in agnosticv).
- **`tasks/provision_lab_config.yaml`** — changed `maas_key` in the per-user `lab-config` Secret from the shared static variable to `_litellm_user_data['litellm_' ~ item.name ~ '_virtual_key']`, which reads the per-user key set by the virtual keys workload earlier in the same Ansible play.

### How it works

The `ocp4_workload_litellm_virtual_keys` collection (added to agnosticv `infra_workloads` before this role) calls the LiteMaaS API once per user and stores results in the `_litellm_user_data` Ansible fact dict (keys: `litellm_user1_virtual_key`, `litellm_user2_virtual_key`, etc.). Since all workloads run in the same Ansible play, those facts are available when this role's `provision_lab_config.yaml` runs.

### Jira

GPTEINFRA-16844

### Reviewers

CC: @bmeseguer (Bruno Meseguer) — Juliano Mohr on PTO
