### PR TITLE
Fix vmware destroy: add missing module_defaults for disk info/disk modules

### DIFF
--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/main.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/main.yaml
@@ -60,6 +60,16 @@
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
+    community.vmware.vmware_guest_disk_info:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter: "{{ vcenter_datacenter }}"
+    community.vmware.vmware_guest_disk:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter: "{{ vcenter_datacenter }}"
 
 - when: ACTION in ['status', 'start', 'stop']
   block:


### PR DESCRIPTION
## Problem

All VMware IBM sandbox destroy jobs are failing at the **"Get disk info for each VM"** task in `infra_vmware_ibm_resources/tasks/delete_instances.yaml` with:

```
"Hostname parameter is missing. Please specify this parameter in task or
export environment variable like 'export VMWARE_HOST=ESXI_HOSTNAME'"
```

This causes stuck Anarchy destroy actions and orphaned VMware environments.

**Example failed job**: `aap2-prod-us-east-2` job 2541862 — sandbox `5pjvc` destroy for `andharri@redhat.com`

## Root Cause

The `delete_instances.yaml` tasks for FCD disk handling use `community.vmware.vmware_guest_disk_info` and `community.vmware.vmware_guest_disk`, but these modules are **not listed** in the DESTROY block's `module_defaults` in `tasks/main.yaml`. All other vmware modules (`vmware_guest`, `vcenter_folder`, `vmware_guest_info`, `vmware_vm_info`) are listed and work fine.

## Fix

Add `community.vmware.vmware_guest_disk_info` and `community.vmware.vmware_guest_disk` to the DESTROY `module_defaults` block in `tasks/main.yaml`, following the same credential pattern as the existing entries.

## Testing

- Verified that the failing task (`vmware_guest_disk_info`) matches a module missing from `module_defaults`
- Confirmed that other modules in the same role (`vmware_guest` in "Stop the VMs") succeed because they ARE in `module_defaults`
- The fix follows the identical pattern used for all other modules in the block