### PR TITLE
Fix vmware destroy: add folder param and error resilience to FCD disk tasks

### DIFF
--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_instances.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_instances.yaml
@@ -9,12 +9,14 @@
 - name: Get disk info for each VM
   community.vmware.vmware_guest_disk_info:
     datacenter: "{{ vcenter_datacenter }}"
+    folder: "/Workloads/{{ env_type }}-{{ guid }}"
     name: "{{ item.guest_name }}"
     validate_certs: "{{ vmw_validate_certs }}"
   loop: "{{ r_vmc_vms.virtual_machines | default([]) }}"
   loop_control:
     label: "{{ item.guest_name }}"
   register: r_disk_info
+  ignore_errors: true
 
 - name: Build list of FCD disks to detach
   ansible.builtin.set_fact:
@@ -30,11 +32,13 @@
   loop: "{{ r_disk_info.results }}"
   loop_control:
     label: "{{ item.item.guest_name }}"
+  when: not (item.failed | default(false))
 
 - name: Detach FCD disks before VM deletion
   when: _fcd_disks_to_remove | default([]) | length > 0
   community.vmware.vmware_guest_disk:
     datacenter: "{{ vcenter_datacenter }}"
+    folder: "/Workloads/{{ env_type }}-{{ guid }}"
     name: "{{ item._vm_name }}"
     validate_certs: "{{ vmw_validate_certs }}"
     disk:
@@ -46,6 +50,7 @@
   loop: "{{ _fcd_disks_to_remove | default([]) }}"
   loop_control:
     label: "{{ item._vm_name }} - {{ item.value.backing_filename }}"
+  ignore_errors: true
 
 - name: Remove the VMs
   register: r_vmc_instances
@@ -76,4 +81,3 @@
   loop: "{{ additional_publicips|default([]) }}"
   loop_control:
     loop_var: _additional
-


### PR DESCRIPTION
## Problem

VMware IBM sandbox destroy jobs fail at the FCD disk handling tasks in
`infra_vmware_ibm_resources/tasks/delete_instances.yaml`, leaving orphaned VMs
and stuck Anarchy destroy actions.

**Example**: prod-us-east-2 job 2543087 — sandbox `vpfw2` destroy fails with:
```
"Multiple virtual machines with same name [rhel9] found, Folder value is a
required parameter to find uniqueness of the virtual machine"
```

This follows the fix in #9809 (merged today) which added the missing
`module_defaults` for `vmware_guest_disk_info` and `vmware_guest_disk`. With
credentials now flowing correctly, the modules connect to vCenter but hit
additional issues.

## Root Cause (3 issues)

### 1. Missing `folder` parameter
`vmware_guest_disk_info` and `vmware_guest_disk` don't pass `folder`, so
vCenter can't disambiguate VMs with common names (e.g. `rhel9`). Every other
`vmware_guest` call in this file passes `folder: "/Workloads/{{ env_type }}-{{ guid }}"`.

### 2. No error resilience on best-effort tasks
FCD disk detachment is a pre-cleanup step before VM deletion. If disk info
or detach fails for **one** VM (name collision, transient error, partially
deleted VM), it blocks deletion of **all** VMs. Compare: `stop_instances.yaml`
uses `ignore_errors: True` on its `vmware_vm_info` call.

### 3. `set_fact` crashes on failed disk info results
If `vmware_guest_disk_info` fails for a VM (even with `ignore_errors`),
`r_disk_info.results` contains items where `guest_disk_info` is undefined.
The `set_fact` task then crashes with an undefined variable error.

## Fix

- Add `folder: "/Workloads/{{ env_type }}-{{ guid }}"` to `vmware_guest_disk_info`
  and `vmware_guest_disk` tasks
- Add `ignore_errors: true` to disk info and detach tasks
- Add `when: not (item.failed | default(false))` to the `set_fact` to skip
  VMs where disk info collection failed

## Testing

- Job 2541862: confirmed "Hostname parameter is missing" → fixed by #9809
- Job 2543087: confirmed "Multiple virtual machines with same name" → fixed by
  this PR (folder param)
- Error resilience verified by code review: matches `ignore_errors` pattern in
  `stop_instances.yaml`