### PR TITLE
fix: route deletions in ocp4_Workload_open_ssh_from_bastion

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_open_ssh_from_bastion/tasks/remove_workload.yml
@@ -106,6 +106,8 @@
             - name: Get Bastion route tables
               amazon.aws.ec2_vpc_route_table_info:
                 filters:
+                  "tag:env_type": ocp4-cluster
+                  association.main: false
                   vpc-id: "{{ r_bastion_vpc.vpcs[0].vpc_id }}"
               register: r_bastion_route_tables
               failed_when: false
@@ -113,35 +115,44 @@
             - name: Get Cluster route tables
               amazon.aws.ec2_vpc_route_table_info:
                 filters:
+                  "tag:env_type": ocp4-cluster
+                  "tag:Name": "*private*"
+                  association.main: false
                   vpc-id: "{{ r_cluster_vpc.vpcs[0].vpc_id }}"
               register: r_cluster_route_tables
               failed_when: false
 
+            # Use AWS CLI to surgically remove the specific routes that were
+            # added rather than using the Ansible module with the added
+            # complexity which requires purging / recreating the entire table
+            # minus the route(s) that need to be removed.
             - name: Remove routes from Bastion route tables pointing to Cluster
-              amazon.aws.ec2_vpc_route_table:
-                route_table_id: "{{ item.route_table_id }}"
-                lookup: id
-                purge_routes: false
-                routes:
-                  - dest: "{{ ocp4_workload_open_ssh_from_bastion_cluster_cidr }}"
-                    vpc_peering_connection_id: "{{ _peering_id }}"
-                state: absent
+              ansible.builtin.command:
+                cmd: >-
+                  aws ec2 delete-route
+                  --region {{ ocp4_workload_open_ssh_from_bastion_region }}
+                  --route-table-id {{ item.route_table_id }}
+                  --destination-cidr-block {{ ocp4_workload_open_ssh_from_bastion_cluster_cidr }}
+              environment:
+                AWS_ACCESS_KEY_ID: "{{ ocp4_workload_open_ssh_from_bastion_access_key_id }}"
+                AWS_SECRET_ACCESS_KEY: "{{ ocp4_workload_open_ssh_from_bastion_secret_access_key }}"
               loop: "{{ r_bastion_route_tables.route_tables | default([]) }}"
               failed_when: false
-              when: r_bastion_route_tables.route_tables | length > 0
+              changed_when: true
 
             - name: Remove routes from Cluster route tables pointing to Bastion
-              amazon.aws.ec2_vpc_route_table:
-                route_table_id: "{{ item.route_table_id }}"
-                lookup: id
-                purge_routes: false
-                routes:
-                  - dest: "{{ ocp4_workload_open_ssh_from_bastion_bastion_cidr }}"
-                    vpc_peering_connection_id: "{{ _peering_id }}"
-                state: absent
+              ansible.builtin.command:
+                cmd: >-
+                  aws ec2 delete-route
+                  --region {{ ocp4_workload_open_ssh_from_bastion_region }}
+                  --route-table-id {{ item.route_table_id }}
+                  --destination-cidr-block {{ ocp4_workload_open_ssh_from_bastion_bastion_cidr }}
+              environment:
+                AWS_ACCESS_KEY_ID: "{{ ocp4_workload_open_ssh_from_bastion_access_key_id }}"
+                AWS_SECRET_ACCESS_KEY: "{{ ocp4_workload_open_ssh_from_bastion_secret_access_key }}"
               loop: "{{ r_cluster_route_tables.route_tables | default([]) }}"
               failed_when: false
-              when: r_cluster_route_tables.route_tables | length > 0
+              changed_when: true
 
             ###########################################################################
             #


### PR DESCRIPTION
### Summary

Fix issues when deleting routes created by the ocp4_workload_open_ssh_from_bastion workload.  Routes were being clobbered by the remove_workload.yml resulting in AAP job deletion failures due to the loss of certain routes causing the  Bastion host to became unreachable.

### Problem

The workload creates VPC infrastructure to enable SSH from bastion to cluster nodes:

    VPC Peering Connections
    Custom routes in route tables
    Security group rules allowing SSH

However, the remove_workload.yml was clobbering the route tables during the destroy resulting in a failed job in AAP when the Bastion was no longer reachable.

### Changes

Modified the remove_workload.yml:

    ✅ Added filters to further restrict the route tables that need to be altered.  These additional filters match those used by the workload when selecting the route tables that need the additional routes
    ✅ Switched from the Ansible module 'amazon.aws.ec2_vpc_route_table' to the AWS CLI.  The module removes routes by purging all routes then re-creating them.  Undesirable routes must be excluded from the list.  Using the AWS CLI allows routes to be deleted explicitly.

### Testing

    Code follows same pattern as workload.yml
    Cleanup is idempotent (safe to run multiple times)
    Error handling prevents failures if resources already deleted

### Related

    Related to https://github.com/rhpds/clusterplatform-agnosticv/pull/58 which added this workload to the catalog
