### PR TITLE
Add RHEL v9.8 and v10.2 images to infra-images

### DIFF
--- a/ansible/roles-infra/infra-images/defaults/main.yaml
+++ b/ansible/roles-infra/infra-images/defaults/main.yaml
@@ -17,14 +17,21 @@ infra_images_predefined:
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false
-  
+
+  RHEL-10.2-GOLD-latest:
+    owner: "{{ infra_images_redhat_owner_id }}"
+    name: RHEL-10.2.*_HVM_*Access*
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
   RHEL-10.1-GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-10.1.*_HVM-*Access*
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false
-      
+
   RHEL-10.0-GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-10.0.*_HVM-*Access*
@@ -35,6 +42,13 @@ infra_images_predefined:
   RHEL-10-GOLD-latest:
     owner: "{{ infra_images_redhat_owner_id }}"
     name: RHEL-10.*_HVM-*Access*
+    architecture: "{{ _infra_images_arch }}"
+    aws_filters:
+      is-public: false
+
+  RHEL98GOLD-latest:
+    owner: "{{ infra_images_redhat_owner_id }}"
+    name: RHEL-9.8.*_HVM_*Access*
     architecture: "{{ _infra_images_arch }}"
     aws_filters:
       is-public: false


### PR DESCRIPTION
### Summary

Add RHEL v9.8 and RHEL v10.2 images to infra-images.

### Problem

Need to be able to install released versions of RHEL.  RHEL v9.8 and 10.2 GA'd last month.

### Changes

    ✅ Add `RHEL-10.2-GOLD-latest` image
    ✅ Add `RHEL98GOLD-latest` image

### Testing

    Successfully created RHEL v9.8 and v10.2 clusters in the 4 AWS regions:
         us-east-2
         ap-southeast-1
         eu-central-1
         eu-west-1