### PR TITLE
Add workload ocp4_workload_create_rwx_volume

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+ocp4_workload_create_rwx_volume_enable: false
+
+ocp4_workload_create_rwx_volume_silent: "{{ silent | default(false) }}"
+
+ocp4_workload_create_rwx_volume_virtualenv_path: /opt/virtualenvs/k8s
+
+ocp4_workload_create_rwx_volume_region: "{{ aws_region }}"
+ocp4_workload_create_rwx_volume_access_key_id: "{{ aws_access_key_id }}"
+ocp4_workload_create_rwx_volume_secret_access_key: "{{ aws_secret_access_key }}"
+
+ocp4_workload_create_rwx_volume_installer_root_url: https://mirror.openshift.com/pub/openshift-v4/clients
+ocp4_workload_create_rwx_volume_helm_version: 3.19.5
+
+ocp4_workload_create_rwx_volume_s3_bucket_name: "s3-bucket-{{ guid }}-for-rwx"
+
+ocp4_workload_create_rwx_volume_helm_s3_driver_repo_url: https://awslabs.github.io/mountpoint-s3-csi-driver
+
+ocp4_workload_create_rwx_volume_pv_storage: 1200Gi
+ocp4_workload_create_rwx_volume_pv_name: s3-volume-pv

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: ocp4_workload_create_rwx_volume
+  author: Red Hat, Cluster Platform (ITCP) (itcp-team@redhat.com)
+  description: |
+    Creates a S3 bucket and the PersistentVolume for it, accessing it as ReadWriteMany
+  license: MIT
+  min_ansible_version: "2.9"
+  platforms: []
+  galaxy_tags:
+    - ocp
+    - openshift
+dependencies: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/readme.adoc
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/readme.adoc
@@ -1,0 +1,25 @@
+= ocp4_workload_create_rwx_volume - Workload Role for Creating an RWX volume
+
+== Role Overview
+
+This role creates a S3 bucket and the PersistentVolume for it, accessing it as ReadWriteMany.
+
+=== Task Files
+
+** Tasks: link:./tasks/workload.yml[workload.yml] - Used to creates a S3 bucket and the PersistentVolume for it
+
+** Tasks: link:./tasks/remove_workload.yml[remove_workload.yml] - Used to delete the workload
+
+=== The defaults variable file
+
+* This file ./defaults/main.yml contains all the variables you need to define to control the deployment of your workload.
+
+* The following variables are mandatory:
+** ocp4_workload_create_rwx_volume_region: AWS region for deployment
+** ocp4_workload_create_rwx_volume_access_key_id: AWS access key id
+** ocp4_workload_create_rwx_volume_secret_access_key: AWS access key
+** guid: a global UID to be used on S3 bucket naming
+
+* A variable silent=True can be passed to suppress debug messages.
+
+* You can override any of these default values by adding -e "variable_name=variable_value" to the command line

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# Do not modify this file
+
+- name: Running Workload Tasks
+  ansible.builtin.include_tasks:
+    file: workload.yml
+  when: ACTION == "create" or ACTION == "provision"
+
+- name: Running Workload removal Tasks
+  ansible.builtin.include_tasks:
+    file: remove_workload.yml
+  when: ACTION == "destroy" or ACTION == "remove"

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/remove_workload.yml
@@ -1,0 +1,24 @@
+---
+- name: Execute the workload
+  when:
+    - cloud_provider == 'ec2'
+    - ocp4_workload_create_rwx_volume_enable | bool
+  block:
+    #############################################################################
+    # Clean up S3 bucket
+    #############################################################################
+    - name: Remove AWS S3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ ocp4_workload_create_rwx_volume_s3_bucket_name }}"
+        region: "{{ ocp4_workload_create_rwx_volume_region }}"
+        state: absent
+        force: true
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: remove_workload tasks complete
+  debug:
+    msg: "Remove Workload tasks completed successfully."
+  when: not ocp4_workload_create_rwx_volume_silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/workload.yml
@@ -1,0 +1,110 @@
+---
+- name: Execute the workload
+  when:
+    - cloud_provider == 'ec2'
+    - ocp4_workload_create_rwx_volume_enable | bool
+  block:
+    #############################################################################
+    # Setup dependencies
+    #############################################################################
+
+    - name: Install dependencies
+      become: true
+      ansible.builtin.pip:
+        name:
+          - boto3
+          - openshift
+          - pyyaml
+          - kubernetes
+        state: present
+
+    - name: Ensure kubernetes.core collection is installed on bastion
+      become: true
+      command: "{{ ocp4_workload_create_rwx_volume_virtualenv_path }}/bin/ansible-galaxy collection install kubernetes.core"
+
+    #############################################################################
+    # Setup Helm
+    #############################################################################
+
+    - name: Check if Helm is already installed
+      ansible.builtin.stat:
+        path: /usr/bin/helm
+      register: r_helm
+
+    - name: Setup Helm
+      when: not r_helm.stat.exists
+      become: true
+      block:
+        - name: Set URL for helm
+          ansible.builtin.set_fact:
+            helm_url: "{{ ocp4_workload_create_rwx_volume_installer_root_url }}/helm/{{ ocp4_workload_create_rwx_volume_helm_version }}/helm-linux-amd64.tar.gz"
+
+        - name: Install helm command
+          become: true
+          ansible.builtin.unarchive:
+            src: "{{ helm_url }}"
+            remote_src: true
+            dest: /usr/bin
+            mode: 0775
+            owner: root
+            group: root
+          retries: 10
+          register: r_client
+          until: r_client is success
+          delay: 30
+
+        - name: Link downloaded helm command to helm
+          become: true
+          ansible.builtin.file:
+            src: /usr/bin/helm-linux-amd64
+            dest: /usr/bin/helm
+            owner: root
+            group: root
+            state: link
+
+        - name: Create Helm Bash completion file
+          become: true
+          ansible.builtin.shell: /usr/bin/helm completion bash >/etc/bash_completion.d/helm
+
+    #############################################################################
+    # Setup S3 bucket and drivers
+    #############################################################################
+
+    - name: Create AWS S3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ ocp4_workload_create_rwx_volume_s3_bucket_name }}"
+        region: "{{ ocp4_workload_create_rwx_volume_region }}"
+        state: present
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+
+    - name: Install Amazon S3 CSI Driver
+      block:
+        - name: Add AWS helm repository
+          kubernetes.core.helm_repository:
+            name: aws-mountpoint-s3-csi-driver
+            repo_url: "{{ ocp4_workload_create_rwx_volume_helm_s3_driver_repo_url }}"
+
+        - name: Deploy AWS Mountpoint S3 CSI Driver
+          kubernetes.core.helm:
+            name: aws-mountpoint-s3-csi-driver
+            chart_ref: aws-mountpoint-s3-csi-driver/aws-mountpoint-s3-csi-driver
+            release_namespace: kube-system
+            create_namespace: true
+            update_repo_cache: true
+
+    #############################################################################
+    # Setup PersistentVolume
+    #############################################################################
+
+    - name: Create volume claim
+      kubernetes.core.k8s:
+        state: present
+        resource_definition: "{{ lookup('template', 'persistent_volume.yaml.j2') }}"
+
+# Leave this as the last task in the playbook.
+# --------------------------------------------
+- name: workload tasks complete
+  debug:
+    msg: "Workload tasks completed successfully."
+  when: not ocp4_workload_create_rwx_volume_silent | bool

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/workload.yml
@@ -37,7 +37,9 @@
       block:
         - name: Set URL for helm
           ansible.builtin.set_fact:
-            helm_url: "{{ ocp4_workload_create_rwx_volume_installer_root_url }}/helm/{{ ocp4_workload_create_rwx_volume_helm_version }}/helm-linux-amd64.tar.gz"
+            helm_url: >-
+              {{ "%s/helm/%s/helm-linux-amd64.tar.gz" |
+              format(ocp4_workload_create_rwx_volume_installer_root_url, ocp4_workload_create_rwx_volume_helm_version) }}
 
         - name: Install helm command
           become: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/templates/persistent_volume.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/templates/persistent_volume.yaml.j2
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ ocp4_workload_create_rwx_volume_pv_name }}
+spec:
+  capacity:
+    storage: {{ ocp4_workload_create_rwx_volume_pv_storage }}
+  accessModes:
+    - ReadWriteMany
+  mountOptions:
+    - allow-delete
+  csi:
+    driver: s3.csi.aws.com
+    volumeHandle: s3-csi-volume-marker
+    volumeAttributes:
+      bucketName: {{ ocp4_workload_create_rwx_volume_s3_bucket_name }}


### PR DESCRIPTION
##### SUMMARY

This new role was created by the Cluster Platform dev team on behalf of the Red Hat OpenShift support team. This role creates an AWS S3 bucket and the PersistentVolume for it, accessing it as ReadWriteMany. This capability is required by the support team to reproduce customer cases, reducing operational costs as detailed in [ITRPS-329](https://redhat.atlassian.net/browse/ITRPS-329).

##### ISSUE TYPE

- New role Pull Request

##### COMPONENT NAME

ocp4_workload_create_rwx_volume

##### ADDITIONAL INFORMATION

Main steps:
1. Setup dependencies
2. Setup Helm
3. Create the S3 bucket
4. Deploy S3 drivers using Helm
5. Create the volume on the cluster