### PR TITLE
[host-ocp4-assisted-destroy] Uses fqdn for ipaddr filter

### DIFF
--- a/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
@@ -30,7 +30,7 @@
       ansible.builtin.nsupdate:
         server: >-
           {{ cluster_dns_server
-          | ipaddr
+          | ansible.utils.ipaddr
           | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
           }}
         zone: "{{ cluster_dns_zone }}"


### PR DESCRIPTION
##### SUMMARY

New versions of ansible requires to use ansible.utils.ipaddr instead ipaddr

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-destroy role

