### PR TITLE
[host-ocp4-assisted-installer] Uses fqdn for ipaddr filter

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -70,7 +70,7 @@
             svcname: "{{ ai_ocp_vmname_master_prefix }}-svc"
             namespace: "{{ ai_ocp_namespace }}"
 
-        - name: Wait for the LoadBalancer value - masters
+        - name: Wait for the LoadBalancer value - control planes
           register: full_svc_masters
           kubernetes.core.k8s_info:
             api_version: v1
@@ -81,12 +81,12 @@
           retries: 10
           delay: 2
 
-        - name: Add A dns record - masters
+        - name: Add A dns record - control planes
           when: cluster_dns_server is defined
           ansible.builtin.nsupdate:
             server: >-
               {{ cluster_dns_server
-              | ipaddr
+              | ansible.utils.ipaddr
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
@@ -99,7 +99,7 @@
             key_secret: "{{ ddns_key_secret }}"
             key_algorithm: "hmac-sha256"
 
-        - name: Add A dns record - masters
+        - name: Add A dns record - control planes
           when: route53_aws_zone_id is defined
           amazon.aws.route53:
             state: present
@@ -120,7 +120,7 @@
           ansible.builtin.nsupdate:
             server: >-
               {{ cluster_dns_server
-              | ipaddr
+              | ansible.utils.ipaddr
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
@@ -172,12 +172,12 @@
           retries: 10
           delay: 2
 
-        - name: Add A dns record - masters
+        - name: Add A dns record - control plane
           when: cluster_dns_server is defined
           ansible.builtin.nsupdate:
             server: >-
               {{ cluster_dns_server
-              | ipaddr
+              | ansible.utils.ipaddr
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
@@ -232,7 +232,7 @@
           ansible.builtin.nsupdate:
             server: >-
               {{ cluster_dns_server
-              | ipaddr
+              | ansible.utils.ipaddr
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"


### PR DESCRIPTION
##### SUMMARY
New versions of ansible requires to use ansible.utils.ipaddr instead ipaddr



##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
host-ocp4-assisted-installer role
