### PR TITLE
[sandbox] [infra-dns] [infra_vmware_ibm_resources] Update vmware sandbox to support nsupdate (dnssandbox)

### DIFF
--- a/ansible/configs/sandbox/default_vars_vmware_ibm.yaml
+++ b/ansible/configs/sandbox/default_vars_vmware_ibm.yaml
@@ -43,15 +43,15 @@ wait_for_dns: true
 #additional_publicips: []
 additional_publicip_ocp:
   - name: ocp_api
-    dns: "api.{{ guid }}"
+    dns: "api.cluster-{{ guid }}"
     nthhost: 201
   - name: ocp_ingress
-    dns: "*.apps.{{ guid }}"
+    dns: "*.apps.cluster-{{ guid }}"
     nthhost: 202
 
 additional_publicips_default:
   - name: wildcard
-    dns: "*.{{ guid }}"
+    dns: "*.cluster-{{ guid }}"
     nthhost: 10
 
 additional_publicips: "{% if ocp_dns|default(False) %}{{ additional_publicip_ocp }}{% else %}{{ additional_publicips_default }}{% endif %}"

--- a/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
+++ b/ansible/roles-infra/infra-dns/tasks/nested_loop.yml
@@ -38,7 +38,7 @@
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
-            record: "{{ _instance_name }}.{{ guid }}"
+            record: "{{ _instance_name }}.cluster-{{ guid }}"
             type: A
             ttl: "{{ infra_dns_default_ttl }}"
             value: "{{ vars[infra_dns_inventory_var] | json_query(find_ip_query) }}"
@@ -50,7 +50,7 @@
         - name: Add public_dns entry to host
           ansible.builtin.add_host:
             name: "{{ _instance_name }}"
-            public_dns_name: "{{ _instance_name }}.{{ guid }}.{{ cluster_dns_zone }}"
+            public_dns_name: "{{ _instance_name }}.cluster-{{ guid }}.{{ cluster_dns_zone }}"
 
         - name: DNS alternative entry ({{ _dns_state | default('present') }})
           when: _alt_names | length > 0
@@ -64,10 +64,10 @@
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
-            record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+            record: "{{ _alt_name }}{{_index}}.cluster-{{ guid }}"
             type: CNAME
             ttl: "{{ infra_dns_default_ttl }}"
-            value: "{{ _instance_name }}.{{ guid }}"
+            value: "{{ _instance_name }}.cluster-{{ guid }}"
             port: "{{ cluster_dns_port | d('53') }}"
             key_name: "{{ ddns_key_name }}"
             key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"
@@ -126,7 +126,7 @@
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
-            record: "{{ _instance_name }}.{{ guid }}"
+            record: "{{ _instance_name }}.cluster-{{ guid }}"
             type: A
             ttl: "{{ infra_dns_default_ttl }}"
             port: "{{ cluster_dns_port | d('53') }}"
@@ -147,10 +147,10 @@
               | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
               }}
             zone: "{{ cluster_dns_zone }}"
-            record: "{{ _alt_name }}{{_index}}.{{ guid }}"
+            record: "{{ _alt_name }}{{_index}}.cluster-{{ guid }}"
             type: CNAME
             ttl: "{{ infra_dns_default_ttl }}"
-            value: "{{ _instance_name }}.{{ guid }}"
+            value: "{{ _instance_name }}.cluster-{{ guid }}"
             port: "{{ cluster_dns_port | d('53') }}"
             key_name: "{{ ddns_key_name }}"
             key_algorithm: "{{ ddns_key_algorithm | d('hmac-md5') }}"

--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_additional_public_ips.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/create_additional_public_ips.yaml
@@ -79,6 +79,7 @@
   register: _nat_request
 
 - name: Add additional dns records
+  when: route53_aws_zone_id is defined
   amazon.aws.route53:
     state: present
     aws_access_key_id: "{{ route53_aws_access_key_id }}"
@@ -92,3 +93,21 @@
   until: r_route53_add_record is success
   retries: 3
   delay: 10
+
+- name: Add A dns record - workers
+  when: cluster_dns_server is defined
+  ansible.builtin.nsupdate:
+    server: >-
+      {{ cluster_dns_server
+      | ansible.utils.ipaddr
+      | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+      }}
+    zone: "{{ cluster_dns_zone }}"
+    record: "{{ _additional.dns }}"
+    type: A
+    ttl: 30
+    port: "{{ cluster_dns_port | d('53') }}"
+    value: "{{ _additional_public_ip }}"
+    key_name: "{{ ddns_key_name }}"
+    key_secret: "{{ ddns_key_secret }}"
+    key_algorithm: "hmac-sha256"


### PR DESCRIPTION
##### SUMMARY

To keep consistent, the cluster name switches from guid to cluster-gluid, updated infra_vmware_ibm_resources to allow to use nsupdate 

##### ISSUE TYPE

- Feature Pull Request
- 
##### COMPONENT NAME
sandbox config
infra-dns role
infra_vmware_ibm_resources role

