### PR TITLE
[ocp4_workload_advanced_developer_suite] Implement retries for Gitlab and Quay integration commands

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_developer_suite/tasks/setup_platform_dependencies.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_developer_suite/tasks/setup_platform_dependencies.yml
@@ -227,3 +227,7 @@
     --url="{{ _quay_url }}"
   args:
     chdir: ~/tssc_cli
+  register: r_integrate
+  until: r_integrate.rc is success
+  retries: 10
+  delay: 60

--- a/ansible/roles_ocp_workloads/ocp4_workload_advanced_developer_suite/tasks/setup_platform_dependencies.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_advanced_developer_suite/tasks/setup_platform_dependencies.yml
@@ -36,6 +36,10 @@
     --group="{{ ocp4_workload_advanced_developer_suite_tssc_cli_gitlab_group }}"
   args:
     chdir: ~/tssc_cli
+  register: r_integrate
+  until: r_integrate.rc is success
+  retries: 10
+  delay: 60
 
 - name: Wait until Jenkins is fully up and running
   k8s_info:


### PR DESCRIPTION
##### SUMMARY

Retry the command in case of error, allowing the gitlab/quay takes longer to be available.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ocp4_workload_advanced_developer_suite role
