### PR TITLE
sap-hana-rhel9: fix broken CI, upgrade to AAP2.7

### DIFF
--- a/ansible/configs/sap-hana-rhel9/default_vars.yml
+++ b/ansible/configs/sap-hana-rhel9/default_vars.yml
@@ -2,7 +2,7 @@ output_dir: /tmp/output_dir
 
 ## Common repositories
 repo_method: satellite                      # Default method
-set_repositories_rhel9_lock_release: '9.2'    # Default Version Lock
+set_repositories_rhel9_lock_release: '9.6'    # Default Version Lock (avoid overwrite to newer version)
 # rhel_repos: will be only be added. The purge code in the role is not working (purge at the wrong place)  
 rhel_repos_zstream:
    - "rhel-9-for-x86_64-baseos-rpms"
@@ -17,7 +17,7 @@ rhel_repos_e4s:
 #   - "ansible-2-for-rhel-8-x86_64-rpms"
 #   - "ansible-2.9-for-rhel-8-x86_64-rpms"
 
-rhel_lock_release_sap: 9.2
+rhel_lock_release_sap: 9.6
 
 ## Networking
 subdomain_base_short: "{{ guid }}"
@@ -80,6 +80,7 @@ aap_download_client_id: rhsm_api
 #aap_download_client_id: cloud-services
 aap_pull_secret: "{{ ocp4_ai_pull_secret }}"
 # offline_token: "{{ rhsm_api_offline_token }}" # defined in playbook
+aap_release: 2.7
 
 # AA2 Downloadfile
 # https://access.redhat.com/downloads/content/480/ver=2.5/rhel---9/2.5/x86_64/product-software

--- a/ansible/configs/sap-hana-rhel9/default_vars_openshift_cnv.yaml
+++ b/ansible/configs/sap-hana-rhel9/default_vars_openshift_cnv.yaml
@@ -1,6 +1,6 @@
 ## Environment Sizing and OS
 
-bastion_instance_image: rhel-9.3
+bastion_instance_image: rhel-9.6
 bastion_instance_type: "sap-2-16"
 bastion_instance_count: 1
 
@@ -15,7 +15,7 @@ s4hana_instance_count: 1
 pv_size_s4hana: 200
 
 ## Variables required when deploying Ansible Tower alongside the HANA and bastion instances
-tower_instance_image: rhel-9.3
+tower_instance_image: rhel-9.6
 tower_instance_type: "sap-4-32"
 tower_instance_count: "{{ tower_instance_count }}"
 

--- a/ansible/configs/sap-hana-rhel9/pre_software.yml
+++ b/ansible/configs/sap-hana-rhel9/pre_software.yml
@@ -109,6 +109,8 @@
       when: install_common
       ansible.builtin.include_role:
         name: "common"
+      vars:
+        update_packages: false
 
     - name: Set Authorized Keys for default logins
       when: set_env_authorized_key

--- a/ansible/configs/sap-hana-rhel9/software.yml
+++ b/ansible/configs/sap-hana-rhel9/software.yml
@@ -274,7 +274,7 @@
         name: infra.aap_utilities.aap_setup_download
       vars:
         aap_setup_down_offline_token: "{{ rhsm_api_offline_token }}" # noqa: var-naming[no-role-prefix]
-        aap_setup_down_version: 2.6
+        aap_setup_down_version: "{{ aap_release }}"
         # aap_setup_down_dest_dir: "{{ playbook_dir }}"
         aap_setup_down_type: "setup-bundle"
         aap_setup_rhel_version: 9

--- a/ansible/configs/sap-hana-rhel9/templates/aap_inventory.generic.j2
+++ b/ansible/configs/sap-hana-rhel9/templates/aap_inventory.generic.j2
@@ -10,6 +10,9 @@
 [automationgateway]
 {{ groups['towers'][0] }}
 
+[automationmetrics]
+{{ groups['towers'][0] }}
+
 [database]
 {{ groups['towers'][0] }}
 
@@ -17,6 +20,9 @@
 {{ groups['towers'][0] }}
 
 [all:vars]
+ansible_connection=local
+routable_hostname={{ groups['towers'][0] }}
+
 postgresql_admin_username=postgres
 postgresql_admin_password={{ hostvars[bastion_hostname]['student_password'] }}
 
@@ -41,7 +47,23 @@ gateway_admin_password={{ hostvars[bastion_hostname]['student_password'] }}
 gateway_pg_host={{ groups['towers'][0] }}
 gateway_pg_password={{ hostvars[bastion_hostname]['student_password'] }}
 
-#controller_license_file=path_to_manifest
+automationmetrics_pg_host={{ groups['towers'][0] }}
+automationmetrics_pg_password={{ hostvars[bastion_hostname]['student_password'] }}
+automationmetrics_controller_read_pg_host={{ groups['towers'][0] }}
+automationmetrics_controller_read_pg_password={{ hostvars[bastion_hostname]['student_password'] }}
+
+mcp_allow_write_operations=true
+mcp_ignore_certificate_errors=true
+
+controller_license_file={{ playbook_dir }}/aap_unpacked/manifest.zip
 #certificates
 gateway_tls_cert=/home/cloud-user/aap-cert/fullchain.pem
 gateway_tls_key=/home/cloud-user/aap-cert/privkey.pem
+
+# Do not propagate AH content to speed up deployment
+hub_seed_collections=false
+hub_postinstall=false
+
+# Propagate postinstallation content
+controller_postinstall=true
+controller_postinstall_dir={{ playbook_dir }}/aap_postinstall

--- a/ansible/configs/sap-hana-rhel9/templates/aap_inventory.openshift_cnv.j2
+++ b/ansible/configs/sap-hana-rhel9/templates/aap_inventory.openshift_cnv.j2
@@ -10,6 +10,9 @@ tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
 [automationgateway]
 tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
 
+[automationmetrics]
+tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
+
 [database]
 tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
 
@@ -43,6 +46,14 @@ eda_pg_password={{ tower_password }}
 gateway_admin_password={{ tower_password }}
 gateway_pg_host=tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
 gateway_pg_password={{ tower_password }}
+
+automationmetrics_pg_host=tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
+automationmetrics_pg_password={{ tower_password }}
+automationmetrics_controller_read_pg_host=tower-{{ guid }}.{{ guid }}.{{ sandbox_openshift_apps_domain }}
+automationmetrics_controller_read_pg_password={{ tower_password }}
+
+mcp_allow_write_operations=true
+mcp_ignore_certificate_errors=true
 
 controller_license_file=/home/cloud-user/aap_unpacked/manifest.zip
 #certificates


### PR DESCRIPTION

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->
The CI was broken to a new installation requirement in AAP 2.6. 
To fix this

- the  AAP Server host and the bastion host are upgraded to RHEL 9.6, 
- Ansible Automation Platform was updated to 2.7

The SAP systems need to remain at RHEL 9.2 otherwise they break

This is a quick fix requested via slack chat

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
sap-hana-rhel9

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
