### PR TITLE
infra-openshift-cnv-resources / Create network -> Use valid json

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -10,7 +10,13 @@
       spec:
         config: "{{ config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    config:
+      cniVersion: "0.3.1"
+      type: "ovn-k8s-cni-overlay"
+      topology: "layer2"
+      name: "{{ _network.name }}{{ guid }}"
+      netAttachDefName: "{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}"
+      mtu: "{{ _network.mtu | default(1500) }}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"


### PR DESCRIPTION
The current configuration causes errors. See [1]:

```
TASK [infra-openshift-cnv-resources : Create network default] ******************
Monday 29 June 2026  11:26:18 +0000 (0:00:00.264)       0:00:12.447 *********** 
FAILED - RETRYING: [localhost]: Create network default (6 retries left).
FAILED - RETRYING: [localhost]: Create network default (5 retries left).
FAILED - RETRYING: [localhost]: Create network default (4 retries left).
FAILED - RETRYING: [localhost]: Create network default (3 retries left).
FAILED - RETRYING: [localhost]: Create network default (2 retries left).
FAILED - RETRYING: [localhost]: Create network default (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 6, "changed": false, "msg": "Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"admission webhook \\\\\"multus-validating-config.k8s.io\\\\\" denied the request: configuration string is not in JSON format\",\"code\":400}\\n'", "reason": "Bad Request"}
```

Relevant snippet being `configuration string is not in JSON format`.

In order to fix it, the config variable should be defined as a proper YAML dictionary, not a string.

https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/2605006/output

Affected item: [Red Hat Openshift Single Node](https://catalog.demo.redhat.com/catalog/babylon-catalog-prod?item=babylon-catalog-prod/zt-rhelbu.zt-openshift-sno.prod&utm_source=webapp&utm_medium=share-link)