### PR TITLE
fix(ee): add missing netaddr Python library to ee-multicloud requirements

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/requirements.txt
+++ b/tools/execution_environments/ee-multicloud-public/requirements.txt
@@ -9,6 +9,7 @@ equinix_metal
 dumb-init
 jsonpatch
 kubernetes>=12.0.0
+netaddr>=0.8.0
 ncclient
 # Fix openstacksdk version till this issue is solved: https://storyboard.openstack.org/#!/story/2010908
 openstacksdk==1.3.1


### PR DESCRIPTION
## Summary

- Add `netaddr>=0.8.0` to `tools/execution_environments/ee-multicloud-public/requirements.txt`

## Problem

The `ansible.utils.ipaddr` filter plugin requires the `netaddr` Python library. The `host-ocp4-assisted-installer` role uses this filter in DNS record creation tasks (`nsupdate`). Without `netaddr` in the EE image, jobs that use DDNS sandboxes fail with:

```
Failed to import the required Python library (netaddr) on automation-job-*'s Python /usr/bin/python3.12
```

This affects the `osp-on-ocp-cnv` catalog item and any other config using `ansible.utils.ipaddr`.

This fix was already applied in agnosticd-v2 (PR agnosticd/agnosticd-v2#150). This PR mirrors it in agnosticd v1, since the `ee-ubi9-aap2.5` build process can source `requirements.txt` from either repo.

## Test plan

- [ ] Rebuild `ee-ubi9-aap2.5` EE image from this branch
- [ ] Run an `osp-on-ocp-cnv` provision job with a DDNS sandbox
- [ ] Verify the `Add A dns record` task succeeds