### PR TITLE
fix(ec2): skip duplicate ODCR run when reservations already exist

### DIFF
--- a/ansible/cloud_providers/ec2_infrastructure_deployment.yml
+++ b/ansible/cloud_providers/ec2_infrastructure_deployment.yml
@@ -15,7 +15,19 @@
       include_role:
         name: infra-images
 
+    - name: Skip infra-aws-capacity-reservation (reservations already exist)
+      debug:
+        msg: >-
+          Skipping capacity reservation - valid reservations already exist
+          in {{ agnosticd_aws_capacity_reservation_results.region }}
+      when: >-
+        agnosticd_aws_capacity_reservation_results is defined
+        and agnosticd_aws_capacity_reservation_results.reservations | default({}) | length > 0
+
     - name: Run infra-aws-capacity-reservation
+      when: >-
+        agnosticd_aws_capacity_reservation_results is not defined
+        or agnosticd_aws_capacity_reservation_results.reservations | default({}) | length == 0
       include_role:
         name: infra-aws-capacity-reservation
       vars:


### PR DESCRIPTION
## Summary

- Skip the `infra-aws-capacity-reservation` role in `ec2_infrastructure_deployment.yml` (Step 001.1) when valid reservation results already exist from a prior run (e.g. `ocp4-cluster/pre_infra.yml` Step 000)
- Prevents the second run from cancelling valid reservations, selecting a different region, and leaving stale AZ variables that cause CloudFormation failures

## Problem

When configs like `ocp4-cluster` run `infra-aws-capacity-reservation` in `pre_infra.yml`, the role was unconditionally executed again in `ec2_infrastructure_deployment.yml`. The second run would:

1. Cancel reservations from the first run
2. Re-evaluate capacity (which may have shifted)
3. Potentially select a different region
4. Set `aws_region` to the new region via the role internals

However, the AZ variables (`aws_availability_zone`, `openshift_controlplane_aws_zones_odcr`, `openshift_machineset_aws_zones_odcr`) set by `pre_infra.yml` were NOT updated, causing CloudFormation to attempt subnet creation with a stale AZ from the old region.

**Example failure:**
```
Value (us-east-2c) for parameter availabilityZone is invalid.
Subnets can currently only be created in the following availability zones:
us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1e, us-east-1f.
```

## Fix

Add a `when` condition to skip the role if `agnosticd_aws_capacity_reservation_results` already contains valid reservations. Configs without their own pre_infra reservation logic are unaffected as results will not exist.

## Test plan

- [ ] Deploy an ocp4-cluster config with ODCR enabled and verify the reservation role only runs once (in pre_infra.yml)
- [ ] Verify a config without pre_infra reservation logic (e.g. a simple EC2 config) still runs the role in Step 001.1
- [ ] Confirm CloudFormation uses the correct AZ matching the selected region

Made with [Cursor](https://cursor.com)