### PR TITLE
fix(gcp): handle double-encoded JSON in gcp_credentials

### DIFF
--- a/ansible/roles/gcp-get-token/tasks/main.yml
+++ b/ansible/roles/gcp-get-token/tasks/main.yml
@@ -1,7 +1,17 @@
 ---
-- name: Load GCP credentials into string
-  set_fact:
-    gcp_creds: "{{ gcp_credentials if gcp_credentials is mapping else gcp_credentials | from_json }}"
+- name: Set gcp_creds from gcp_credentials
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_credentials }}"
+
+- name: Parse gcp_creds from JSON string if needed
+  when: gcp_creds is string
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_creds | from_json }}"
+
+- name: Parse gcp_creds again if double-encoded
+  when: gcp_creds is string
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_creds | from_json }}"
 
 - name: Set JWT header as string
   set_fact:

--- a/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
@@ -1,7 +1,17 @@
 ---
-- name: Load GCP credentials into string
+- name: Set gcp_creds from gcp_credentials
   ansible.builtin.set_fact:
-    gcp_creds: "{{ gcp_credentials if gcp_credentials is mapping else gcp_credentials | from_json }}"
+    gcp_creds: "{{ gcp_credentials }}"
+
+- name: Parse gcp_creds from JSON string if needed
+  when: gcp_creds is string
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_creds | from_json }}"
+
+- name: Parse gcp_creds again if double-encoded
+  when: gcp_creds is string
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_creds | from_json }}"
 
 - name: Call GCP get token role
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

Fixes GCP destroy failures caused by double-encoded JSON credentials when using newer EE images (ansible-core >= 2.18).

**Root cause:** The governor config applies `| to_json` to vault-decrypted GCP credentials that are already a JSON string, producing double-encoded JSON. The previous single-line `is mapping` check worked on ansible-core ~2.16 (EE `v0.1.2`) but fails on ansible-core ~2.18+ (EE `2026-03-10`) due to changes in how `AnsibleUnsafeText` interacts with Jinja2 type tests.

**Fix:** Replace the fragile one-liner with a multi-step approach using `is string` (more reliable than `is mapping`) that handles all three input forms:
- Already a dict (no parsing needed)
- Single-encoded JSON string (one `from_json`)
- Double-encoded JSON string (two `from_json` passes)

**Affected roles:**
- `gcp-get-token`
- `open-env-gcp-remove-project`

**Context:** PR #27028 changed the EE from `v0.1.2` to `2026-03-10`, triggering 3 GCP destroy failures (July 3-6). PR #27040 reverted the EE change. This fix unblocks future EE upgrades.

## Test plan

- [ ] Deploy and destroy an open-environment-gcp with EE `v0.1.2` (regression test)
- [ ] Deploy and destroy an open-environment-gcp with EE `2026-03-10` (validates fix)
- [ ] Verify `gcp_creds` is a dict with `client_email`, `private_key`, `project_id` keys in both cases