### PR TITLE
Fix selecting the correct rosa version for upgradable environments

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_common_pre.yml
@@ -50,7 +50,10 @@
 - name: Set ROSA version to latest upgradable version available for {{ rosa_version_base }}
   when: rosa_version == "latest-upgrade"
   vars:
-    _query: "[?starts_with(id, '{{ rosa_version_base }}') && available_upgrades != `null`] | [0]"
+    _rosa_minor_version: "{{ rosa_version_base | regex_replace('^openshift-v', '') }}"
+    _query: >-
+      [?starts_with(id, '{{ rosa_version_base }}')
+      && available_upgrades[?starts_with(@, '{{ rosa_version_base | regex_replace('^openshift-v', '') }}.')]] | [0]
     _latest_upgrade_version: "{{ r_rosa_versions.stdout | from_json | community.general.json_query(_query) }}"
   block:
   - name: Fail if no upgradable version was found for {{ rosa_version_base }}
@@ -62,7 +65,9 @@
     ansible.builtin.set_fact:
       _rosa_version_to_install: "{{ _latest_upgrade_version.raw_id }}"
       _rosa_ocp_cli_version: "{{ _latest_upgrade_version.raw_id }}"
-      _rosa_version_next: "{{ _latest_upgrade_version.available_upgrades[0] }}"
+      _rosa_version_next: >-
+        {{ _latest_upgrade_version.available_upgrades
+           | select('match', _rosa_minor_version ~ '\\.') | list | last }}
 
   rescue:
   - name: Fallback to latest ROSA version available for {{ rosa_version_base }}


### PR DESCRIPTION
##### SUMMARY

The logic to select an upgradable ROSA version didn't account for upgrades to the next major version. Fixed to only pick versions that can be upgraded to the next minor version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated