### PR TITLE
Fix 'true' -> true in cloud formation template for Rosa

### DIFF
--- a/ansible/configs/rosa-consolidated/files/cloud_providers/ec2_cloud_template.j2
+++ b/ansible/configs/rosa-consolidated/files/cloud_providers/ec2_cloud_template.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True"
+#jinja2: lstrip_blocks: True
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:


### PR DESCRIPTION
##### SUMMARY

Line 1: #jinja2: lstrip_blocks: "True" — the value is a string "True" instead of a boolean True. Newer Jinja2 versions enforce the type.

Update(files/cloud_providers/ec2_cloud_template.j2)
⎿  Added 1 line, removed 1 line
    1 -#jinja2: lstrip_blocks: "True"
    1 +#jinja2: lstrip_blocks: True
    2  ---
    3  AWSTemplateFormatVersion: "2010-09-09"
    4  Mappings:

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rosa-consolidated