### PR TITLE
Fix showroom deploy error with latest code

### DIFF
--- a/ansible/roles/showroom/tasks/40-showroom-render.yml
+++ b/ansible/roles/showroom/tasks/40-showroom-render.yml
@@ -72,7 +72,7 @@
 
 - name: Debug Render asciidoc via antora container
   ansible.builtin.debug:
-    var: "{{ r_podman_run_antora }}"
+    var: r_podman_run_antora
     verbosity: 2
 
 - name: Set showroom_host if not defined


### PR DESCRIPTION
##### SUMMARY

The showroom deploy failed with a variable error:
TASK [showroom : Debug Render asciidoc via antora container] *******************
Tuesday 07 July 2026  10:42:51 +0000 (0:00:00.022)       0:50:30.144 ********** 
[ERROR]: Task failed: argument 'var' is of type dict and we were unable to convert to _check_type_str_no_conversion: '{'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'not default_site_stat.stat.exists'}' is not a string and conversion is not allowed
Origin: /runner/project/ansible/roles/showroom/tasks/40-showroom-render.yml:73:3
71     - showroom-render
72
73 - name: Debug Render asciidoc via antora container
     ^ column 3
fatal: [bastion.szz82.internal]: FAILED! => {"msg": "argument 'var' is of type dict and we were unable to convert to _check_type_str_no_conversion: '{'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'not default_site_stat.stat.exists'}' is not a string and conversion is not allowed"}

Fixing by changing to use just the var:
      73  - name: Debug Render asciidoc via antora container
      74    ansible.builtin.debug:
      75 -    var: "{{ r_podman_run_antora }}"
      75 +    var: r_podman_run_antora
      76      verbosity: 2

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Agd V1 showroom role