### PR TITLE
fix: add retries for gcp_iam_service_account_key intermittent failures

### DIFF
--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -71,9 +71,9 @@
     state: present
   register: new_service_account
 
-- name: Wait 10 seconds for service account to exist
+- name: Wait for service account to propagate
   ansible.builtin.wait_for:
-    timeout: 10
+    timeout: 20
 
 - name: Define service account creds file
   ansible.builtin.set_fact:
@@ -105,6 +105,9 @@
     project: "{{ gcp_creds.project_id }}"
     state: present
   register: new_key
+  retries: 3
+  delay: 15
+  until: new_key is success
 
 - name: Get openenv project policy
   ansible.builtin.uri:


### PR DESCRIPTION
## Summary

- Add `retries: 3` / `delay: 15` / `until: new_key is success` to the `gcp_iam_service_account_key` task in `open-env-gcp-add-user-to-project`
- Increase SA propagation wait from 10s to 20s

## Problem

The `google.cloud.gcp_iam_service_account_key` module has an unfixed bug across **all versions** (1.0.2 through 1.13.0) where the GCP API intermittently returns an empty response body for key creation. The module then crashes with:

```
TypeError: 'NoneType' object is not subscriptable
```

at `json_content['privateKeyData']` in the `create()` function. This is tracked upstream as [google.cloud#370](https://github.com/ansible-collections/google.cloud/issues/370) and [ansible#70127](https://github.com/ansible/ansible/issues/70127).

The failure is intermittent — rerunning the task succeeds. The root cause appears to be a GCP API timing issue where the service account hasn't fully propagated before key creation is attempted.

## Fix

1. Add retries to the key creation task so transient API failures are handled automatically
2. Increase the wait after SA creation from 10s to 20s to reduce the probability of hitting the timing window

## Testing

Observed on prod1 job 26813 (`gcp-gpte.open-environment-gcp.prod-b7td7` provision). The SA was created successfully but key creation failed with the NoneType error. Retrying the job would succeed.