### PR TITLE
Fix helm install failure in EE containers without sudo

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/check-and-install-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/check-and-install-helm.yaml
@@ -9,43 +9,52 @@
     path: /usr/bin/helm
   register: r_helm_installed
 
+- name: Check if helm is in ~/bin
+  ansible.builtin.stat:
+    path: "~/bin/helm"
+  register: r_helm_installed_home
+
 - name: Install Helm if it's not there
-  when: not (r_helm_installed_local.stat.exists or r_helm_installed.stat.exists)
+  when:
+  - not r_helm_installed_local.stat.exists
+  - not r_helm_installed.stat.exists
+  - not r_helm_installed_home.stat.exists
   block:
   - name: Set URL for helm
     ansible.builtin.set_fact:
       helm_url: >-
         https://catalog-item-assets.s3.us-east-2.amazonaws.com/helm-linux-amd64.tar.gz
 
-  - name: Install Helm as root
-    become: true
-    block:
-    - name: Install helm command
-      ansible.builtin.unarchive:
-        src: "{{ helm_url }}"
-        remote_src: true
-        dest: /usr/local/bin
-        mode: "0775"
-        owner: root
-        group: root
-      retries: 10
-      register: r_client
-      until: r_client is success
-      delay: 30
+  - name: Ensure ~/bin directory exists
+    ansible.builtin.file:
+      path: ~/bin
+      state: directory
+      mode: u=rwx,g=rx,o=rx
 
-    - name: Link downloaded helm command to helm
-      ansible.builtin.file:
-        src: /usr/local/bin/linux-amd64/helm
-        dest: /usr/local/bin/helm
-        owner: root
-        group: root
-        state: link
+  - name: Install helm command
+    ansible.builtin.unarchive:
+      src: "{{ helm_url }}"
+      remote_src: true
+      dest: "~/bin"
+      mode: u=rwx,g=rwx,o=rx
+    retries: 10
+    register: r_client
+    until: r_client is success
+    delay: 30
 
-    - name: Create Helm Bash completion file
-      ansible.builtin.shell: /usr/local/bin/helm completion bash >/etc/bash_completion.d/helm
+  - name: Link downloaded helm command to helm
+    ansible.builtin.file:
+      src: "~/bin/linux-amd64/helm"
+      dest: "~/bin/helm"
+      state: link
+
+  - name: Create Helm Bash completion file
+    ansible.builtin.shell: "~/bin/helm completion bash > ~/.helm_completion"
+    args:
+      creates: "~/.helm_completion"
 
   - name: Get helm version
-    ansible.builtin.shell: /usr/local/bin/helm version
+    ansible.builtin.shell: "~/bin/helm version"
     register: r_helm_version
 
   - name: Emit Helm version


### PR DESCRIPTION
Install helm to ~/bin instead of /usr/local/bin to avoid requiring sudo, which is not available in AAP Execution Environment containers on OpenShift.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New config Pull Request
- New role Pull Request

##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
