### PR TITLE
fix(gcp): apply double-encoding fix to service_account_contents in open-env roles

### DIFF
--- a/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-add-user-to-project/tasks/main.yml
@@ -4,9 +4,19 @@
     msg:
     - "gcp_credentials: ({{ gcp_credentials }})"
 
-- name: Load GCP credentials into string
+- name: Set gcp_creds from gcp_credentials
   ansible.builtin.set_fact:
-    gcp_creds: "{{ gcp_credentials if gcp_credentials is mapping else gcp_credentials | from_json }}"
+    gcp_creds: "{{ gcp_credentials }}"
+
+- name: Parse gcp_creds from JSON string if needed
+  when: gcp_creds is string
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_creds | from_json }}"
+
+- name: Parse gcp_creds again if double-encoded
+  when: gcp_creds is string
+  ansible.builtin.set_fact:
+    gcp_creds: "{{ gcp_creds | from_json }}"
 
 - name: Check if email is Red Hat associate
   when:
@@ -43,7 +53,7 @@
 - name: Get all service accounts
   google.cloud.gcp_iam_service_account_info:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     project: "{{ gcp_creds.project_id }}"
   register: service_accounts
 
@@ -54,7 +64,7 @@
 - name: Delete any old OPEN Environment service accounts that might be orphaned
   google.cloud.gcp_iam_service_account:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     name: "{{ service_account_email }}"
     display_name: "OPEN Environment Service account {{ guid }}"
     project: "{{ gcp_creds.project_id }}"
@@ -64,7 +74,7 @@
 - name: Create a service account for OPEN Environment
   google.cloud.gcp_iam_service_account:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     name: "{{ service_account_email }}"
     display_name: "OPEN Environment Service account {{ guid }}"
     project: "{{ gcp_creds.project_id }}"
@@ -98,7 +108,7 @@
 - name: Create a service account key for OPEN Environment
   google.cloud.gcp_iam_service_account_key:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     service_account: "{{ new_service_account }}"
     private_key_type: TYPE_GOOGLE_CREDENTIALS_FILE
     path: "{{ svc_account_creds_file }}"
@@ -183,7 +193,7 @@
 - name: "Enable Google Cloud API services"
   google.cloud.gcp_serviceusage_service:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     name: "{{ item }}.googleapis.com"
     project: "{{ project_name }}"
     state: present
@@ -205,7 +215,7 @@
 - name: Create managed DNS zone for OPEN Environment
   google.cloud.gcp_dns_managed_zone:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     project: "{{ project_name }}"
     name: "{{ 'dns-zone-' + guid }}"
     dns_name: "{{ guid + '.' + gcp_root_dns_zone + '.' }}"
@@ -216,7 +226,7 @@
 - name: Fetch Root DNS zone Info
   google.cloud.gcp_dns_managed_zone_info:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     project: "{{ gcp_creds.project_id }}"
     dns_name: '{{ gcp_root_dns_zone + "." }}'
   register: gcp_managed_zone
@@ -224,7 +234,7 @@
 - name: Add delegation for NS to the Root DNS Zone
   google.cloud.gcp_dns_resource_record_set:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     project: "{{ gcp_creds.project_id }}"
     managed_zone: "{{ gcp_managed_zone.resources[0] }}"
     name: '{{ guid + "." + gcp_root_dns_zone + "." }}'

--- a/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
+++ b/ansible/roles/open-env-gcp-remove-project/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Delete OPEN Environment service account
   google.cloud.gcp_iam_service_account:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     name: "{{ service_account_email }}"
     display_name: "OPEN Environment Service account {{ guid }}"
     project: "{{ gcp_creds.project_id }}"
@@ -44,7 +44,7 @@
 - name: Fetch Root DNS zone Info
   google.cloud.gcp_dns_managed_zone_info:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     project: "{{ gcp_creds.project_id }}"
     dns_name: '{{ gcp_root_dns_zone + "." }}'
   register: gcp_managed_zone
@@ -52,7 +52,7 @@
 - name: Remove the DNS delegations
   google.cloud.gcp_dns_resource_record_set:
     auth_kind: serviceaccount
-    service_account_contents: "{{ gcp_credentials }}"
+    service_account_contents: "{{ gcp_creds | to_json }}"
     managed_zone:
       name: "{{ gcp_managed_zone.resources[0].name }}"
       dnsName: "{{ gcp_managed_zone.resources[0].dnsName }}"
@@ -121,7 +121,7 @@
   # - name: Delete GCP Project
   #   google.cloud.gcp_resourcemanager_project:
   #     auth_kind: serviceaccount
-  #     service_account_contents: "{{ gcp_credentials }}"
+  #     service_account_contents: "{{ gcp_creds | to_json }}"
   #     name: "{{ project_name }}"
   #     id: "{{ project_name }}"
   #     parent:


### PR DESCRIPTION
## Summary

PR #9833 fixed the `gcp_credentials` double-encoding issue in the `gcp_creds` parsing logic for `gcp-get-token` and `open-env-gcp-remove-project`, but missed two things:

1. **`open-env-gcp-add-user-to-project`** was not included at all — it still uses the old `is mapping` one-liner
2. **`service_account_contents` parameters** in both roles still referenced the raw `gcp_credentials` variable instead of the decoded `gcp_creds`

When `gcp_credentials` arrives as double-encoded JSON (governor applies `| to_json` to an already-JSON vault variable), the `google.cloud` modules reject it with `"File is not a valid GCP JSON service account key"` because the raw variable is still an escaped JSON string.

### Evidence

```
TASK [open-env-gcp-add-user-to-project : Create a service account key for OPEN Environment] ***
FAILED - RETRYING: Create a service account key for OPEN Environment (3 retries left).
FAILED - RETRYING: Create a service account key for OPEN Environment (2 retries left).
FAILED - RETRYING: Create a service account key for OPEN Environment (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 3, "changed": false, "msg": "File is not a valid GCP JSON service account key"}
```

### Changes

- **open-env-gcp-add-user-to-project**: Add the same multi-step double-encoding parser from PR #9833. Replace all 8 occurrences of `service_account_contents: "{{ gcp_credentials }}"` with `service_account_contents: "{{ gcp_creds | to_json }}"`.
- **open-env-gcp-remove-project**: Replace 4 occurrences of `service_account_contents: "{{ gcp_credentials }}"` with `service_account_contents: "{{ gcp_creds | to_json }}"` (parsing was already fixed by #9833).

### Testing

Fixes provision and destroy failures for `open-environment-gcp` when running on EE images with ansible-core >= 2.18.

Companion to #9833 and #9839.