### PR TITLE
Fix Jaeger operator install by mirroring deprecated kube-rbac-proxy

### DIFF
--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/kube_rbac_proxy_image_digest_mirror_set.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/kube_rbac_proxy_image_digest_mirror_set.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: kube-rbac-proxy-mirror
+spec:
+  imageDigestMirrors:
+  - source: gcr.io/kubebuilder/kube-rbac-proxy
+    mirrors:
+    - registry.k8s.io/kubebuilder/kube-rbac-proxy

--- a/ansible/roles/ocp4-workload-quarkus-workshop/files/kube_rbac_proxy_image_tag_mirror_set.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/files/kube_rbac_proxy_image_tag_mirror_set.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: kube-rbac-proxy-tag-mirror
+spec:
+  imageTagMirrors:
+  - source: gcr.io/kubebuilder/kube-rbac-proxy
+    mirrors:
+    - registry.k8s.io/kubebuilder/kube-rbac-proxy

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-jaeger.yaml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/install-jaeger.yaml
@@ -1,4 +1,33 @@
 ---
+- name: Mirror deprecated kube-rbac-proxy image for Jaeger operator
+  k8s:
+    state: present
+    merge_type:
+    - strategic-merge
+    - merge
+    definition: "{{ lookup('file', item ) | from_yaml }}"
+  loop:
+  - ./files/kube_rbac_proxy_image_digest_mirror_set.yaml
+  - ./files/kube_rbac_proxy_image_tag_mirror_set.yaml
+
+- name: Wait for image mirror configuration to roll out to nodes
+  k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: "{{ item }}"
+  register: r_mcp
+  retries: 60
+  delay: 30
+  until:
+    - r_mcp.resources | length > 0
+    - r_mcp.resources[0].status.updatedMachineCount is defined
+    - r_mcp.resources[0].status.machineCount is defined
+    - r_mcp.resources[0].status.updatedMachineCount == r_mcp.resources[0].status.machineCount
+    - r_mcp.resources[0].status.degraded is not defined or not r_mcp.resources[0].status.degraded
+  loop:
+  - worker
+  - master
+
 - name: Create OpenShift Objects for jaeger
   k8s:
     state: present
@@ -36,6 +65,34 @@
       spec:
         approved: true
 
+- name: Wait for Jaeger subscription current CSV
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: Subscription
+    name: jaeger
+    namespace: openshift-operators
+  register: r_jaeger_subscription
+  retries: 30
+  delay: 20
+  until:
+    - r_jaeger_subscription.resources | length > 0
+    - r_jaeger_subscription.resources[0].status.currentCSV is defined
+    - r_jaeger_subscription.resources[0].status.currentCSV | length > 0
+
+- name: Wait for Jaeger operator CSV to succeed
+  k8s_info:
+    api_version: operators.coreos.com/v1alpha1
+    kind: ClusterServiceVersion
+    name: "{{ r_jaeger_subscription.resources[0].status.currentCSV }}"
+    namespace: openshift-operators
+  register: r_jaeger_csv
+  retries: 40
+  delay: 30
+  until:
+    - r_jaeger_csv.resources | length > 0
+    - r_jaeger_csv.resources[0].status.phase is defined
+    - r_jaeger_csv.resources[0].status.phase == "Succeeded"
+
 - name: Wait for Jaeger CRD
   k8s_info:
     api_version: apiextensions.k8s.io/v1
@@ -45,5 +102,3 @@
   retries: 200
   delay: 10
   until: r_jaeger_crd.resources | list | length == 1
-
-

--- a/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
+++ b/ansible/roles/ocp4-workload-quarkus-workshop/tasks/workload.yml
@@ -137,7 +137,7 @@
   k8s_info:
     api_version: operators.coreos.com/v1alpha1
     kind: Subscription
-    name: jaeger-product
+    name: jaeger
     namespace: openshift-operators
   register: r_jaeger_sub
 


### PR DESCRIPTION
…mage.

The community Jaeger operator still references gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1, which is no longer available. Mirror that image to registry.k8s.io before installing the operator and wait for the CSV to reach Succeeded.

<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
