### PR TITLE
ec2_cloud_template.j2 - Change lstrip_blocks from string to bool

### DIFF
--- a/ansible/configs/sap-integration/files/ec2_cloud_template.j2
+++ b/ansible/configs/sap-integration/files/ec2_cloud_template.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True"
+#jinja2: lstrip_blocks: True
 ---
 AWSTemplateFormatVersion: "2010-09-09"
 Mappings:


### PR DESCRIPTION
Newer Jinja2 (with updated execution environments) requires a boolean, not the string "True".

Example error: https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/2625120/output

