### PR TITLE
Fix jinja2 lstrip_blocks syntax in cloud_template.j2

### DIFF
--- a/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
+++ b/ansible/roles-infra/infra-ec2-template-generate/templates/cloud_template.j2
@@ -1,4 +1,4 @@
-#jinja2: lstrip_blocks: "True"
+#jinja2: lstrip_blocks: True
 #touch
 ---
 AWSTemplateFormatVersion: "2010-09-09"


### PR DESCRIPTION
Newer Jinja2 (with updated execution environments) requires a boolean, not the string "True".

Example error: https://aap2-prod-us-east-2.aap.infra.demo.redhat.com/#/jobs/playbook/2625120/output

