### PR TITLE
Fix Jinja2 rendering errors in ocp4_workload_rosa_machinepool

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_rosa_machinepool/tasks/add_metal_node.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rosa_machinepool/tasks/add_metal_node.yml
@@ -44,7 +44,7 @@
         - _r_machine_status.resources.{{_inner_loop_index |int }}.status.providerStatus.instanceState == "running"
       delay: 10
       retries: 40
-      loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int ) }}"
+      loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int) | list }}"
       loop_control:
         index_var: _inner_loop_index
 
@@ -63,7 +63,7 @@
         - _r_node_status.resources.{{_inner_loop_index |int }}.status.conditions | json_query(_query) | join
       delay: 30
       retries: 50
-      loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int ) }}"
+      loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int) | list }}"
       loop_control:
         index_var: _inner_loop_index
 
@@ -87,7 +87,7 @@
     - name: Delete ROSA Metal Machinepool
       vars:
         _query: '[?id == `{{ ocp4_workload_rosa_machinepool_name }}`].id'
-      when: 'ocp4_workload_rosa_machinepool_name == _machinepool_list | json_query(_query) | join'
+      when: 'ocp4_workload_rosa_machinepool_name == _machinepool_list | json_query(_query) | default([]) | join'
       ansible.builtin.command: >-
         {{ ocp4_workload_rosa_machinepool_binary_path }}/rosa delete machinepool
         --cluster={{ ocp4_workload_rosa_machinepool_cluster_name }}


### PR DESCRIPTION
##### SUMMARY

- Convert range() to list for Ansible variable storage compatibility
- Add default([]) guard before join filter to handle empty json_query results

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ocp4_workload_rosa_machinepool