### PR TITLE
ocp4_machineset_config - Fix conditional value

### DIFF
--- a/ansible/roles/ocp4_machineset_config/tasks/main.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/main.yml
@@ -11,5 +11,4 @@
 
 - name: Enable cluster autoscaler
   include_tasks: enable-cluster-autoscaler.yml
-  when: >-
-    ocp4_machineset_config_groups | json_query('[?autoscale]')
+  when: (ocp4_machineset_config_groups | json_query('[?autoscale]')) | length > 0)


### PR DESCRIPTION
This does not work with newer AAP versions due to how conditionals are valued.