### PR TITLE
fix(rosa-consolidated): skip become during destroy in EE

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cli.yml
@@ -7,12 +7,12 @@
 # --no-same-owner:
 # https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233
 - name: Unzip rosa-linux.tar.gz
-  become: true
+  become: "{{ ACTION == 'provision' }}"
   ansible.builtin.unarchive:
     src: /tmp/rosa-linux.tar.gz
     dest: "{{ rosa_binary_path }}"
     remote_src: true
-    owner: root
+    owner: "{{ omit if ACTION != 'provision' else 'root' }}"
     # group: root # setting group fails in EE.
     mode: u=rwx,go=rx
     extra_opts:
@@ -24,5 +24,5 @@
     state: absent
 
 - name: Create rosa Bash completion file
-  become: true
-  shell: "{{ rosa_binary_path }}/rosa completion bash >/etc/bash_completion.d/rosa"
+  become: "{{ ACTION == 'provision' }}"
+  ansible.builtin.shell: "{{ rosa_binary_path }}/rosa completion bash >/etc/bash_completion.d/rosa"


### PR DESCRIPTION
## Summary

The `install_rosa_cli.yml` tasks use `become: true` and `owner: root`, which requires sudo. During provision this runs on bastion hosts via SSH where sudo is available. During destroy it runs on `hosts: localhost` inside the EE container (`ee-multicloud`) where sudo is not installed, causing all ROSA destroys to fail with `/bin/sh: sudo: command not found`.

This fix conditions `become` and `owner` on `ACTION == 'provision'` so destroy runs without privilege escalation (it only needs `/tmp` which is already writable).

## Affected governors

All `rosa-consolidated` based governors:
- `ROSA_MOBB` (ee-multicloud:2026-03-10)
- `ROSA_OPS_HOE` (ee-multicloud:2025-02-14)
- `ROSA_UPLIFT` (ee-multicloud:v0.1.2)

## Affected subjects

- `sandboxes-gpte.rosa-mobb.prod-vrvzj`
- `sandboxes-gpte.rosa-ops-hoe.prod-fx72w`
- `sandboxes-gpte.rosa-uplift.prod-69mg6`

## Test plan

- [ ] Verify provision still works (become: true on bastion hosts)
- [ ] Verify destroy works in EE without sudo
- [ ] Requeue affected subjects after new tags are cut