### PR TITLE
Fix Ansible 2.19 compatibility in ROSA machinepool and machineset config

### DIFF
--- a/ansible/roles/ocp4_machineset_config/tasks/main.yml
+++ b/ansible/roles/ocp4_machineset_config/tasks/main.yml
@@ -11,4 +11,4 @@
 
 - name: Enable cluster autoscaler
   include_tasks: enable-cluster-autoscaler.yml
-  when: (ocp4_machineset_config_groups | json_query('[?autoscale]')) | length > 0)
+  when: (ocp4_machineset_config_groups | json_query('[?autoscale]')) | length > 0

--- a/ansible/roles_ocp_workloads/ocp4_workload_rosa_machinepool/tasks/add_metal_node.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rosa_machinepool/tasks/add_metal_node.yml
@@ -41,7 +41,7 @@
       until:
         - _r_machine_status.resources is defined
         - _r_machine_status.resources | length >= ocp4_workload_rosa_machinepool_replicas | int
-        - _r_machine_status.resources.{{_inner_loop_index |int }}.status.providerStatus.instanceState == "running"
+        - _r_machine_status.resources[_inner_loop_index | int].status.providerStatus.instanceState == "running"
       delay: 10
       retries: 40
       loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int) | list }}"
@@ -60,7 +60,7 @@
       until:
         - _r_node_status.resources is defined
         - _r_node_status.resources | length >= ocp4_workload_rosa_machinepool_replicas | int
-        - _r_node_status.resources.{{_inner_loop_index |int }}.status.conditions | json_query(_query) | join
+        - _r_node_status.resources[_inner_loop_index | int].status.conditions | json_query(_query) | join
       delay: 30
       retries: 50
       loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int) | list }}"
@@ -87,7 +87,7 @@
     - name: Delete ROSA Metal Machinepool
       vars:
         _query: '[?id == `{{ ocp4_workload_rosa_machinepool_name }}`].id'
-      when: 'ocp4_workload_rosa_machinepool_name == _machinepool_list | json_query(_query) | default([]) | join'
+      when: (_machinepool_list | json_query(_query) | default([])) | length > 0
       ansible.builtin.command: >-
         {{ ocp4_workload_rosa_machinepool_binary_path }}/rosa delete machinepool
         --cluster={{ ocp4_workload_rosa_machinepool_cluster_name }}

--- a/ansible/roles_ocp_workloads/ocp4_workload_rosa_machinepool/tasks/add_metal_node.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_rosa_machinepool/tasks/add_metal_node.yml
@@ -60,7 +60,7 @@
       until:
         - _r_node_status.resources is defined
         - _r_node_status.resources | length >= ocp4_workload_rosa_machinepool_replicas | int
-        - _r_node_status.resources[_inner_loop_index | int].status.conditions | json_query(_query) | join
+        - (_r_node_status.resources[_inner_loop_index | int].status.conditions | json_query(_query) | join('')) == "True"
       delay: 30
       retries: 50
       loop: "{{ range(0, ocp4_workload_rosa_machinepool_replicas | int) | list }}"
@@ -87,7 +87,7 @@
     - name: Delete ROSA Metal Machinepool
       vars:
         _query: '[?id == `{{ ocp4_workload_rosa_machinepool_name }}`].id'
-      when: (_machinepool_list | json_query(_query) | default([])) | length > 0
+      when: (_machinepool_list | json_query(_query) | default([], true)) | length > 0
       ansible.builtin.command: >-
         {{ ocp4_workload_rosa_machinepool_binary_path }}/rosa delete machinepool
         --cluster={{ ocp4_workload_rosa_machinepool_cluster_name }}


### PR DESCRIPTION
Fixed a few tasks to work with newer ansible versions:

- Fix `ocp4_machineset_config` autoscaler `when` clause syntax error (extra closing parenthesis)
- Fix `ocp4_workload_rosa_machinepool` resource indexing and Ansible conditional handling in `add_metal_node.yml`
- Make rescue cleanup null-safe when `json_query` returns `None` during machinepool delete