### PR TITLE
fix(rosa): skip bash completion during destroy in EE

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cli.yml
@@ -24,5 +24,6 @@
     state: absent
 
 - name: Create rosa Bash completion file
-  become: "{{ ACTION == 'provision' }}"
+  when: ACTION == 'provision'
+  become: true
   ansible.builtin.shell: "{{ rosa_binary_path }}/rosa completion bash >/etc/bash_completion.d/rosa"


### PR DESCRIPTION
## Summary
- The bash completion task writes to `/etc/bash_completion.d/` which requires root
- During destroy, `become` was conditionalized but the shell redirect still fails without root
- Fix: skip the task entirely during destroy with `when: ACTION == 'provision'`

Follow-up to #9848 — that PR fixed `become` and `owner` but missed the bash completion redirect.