### PR TITLE
fix(rosa): remove become/root from terraform tasks in uninstall_rosa

### DIFF
--- a/ansible/configs/rosa-consolidated/uninstall_rosa.yml
+++ b/ansible/configs/rosa-consolidated/uninstall_rosa.yml
@@ -30,21 +30,19 @@
   block:
   - name: Install Terraform
     when: rosa_install_terraform | default(true) | bool
-    become: true
     ansible.builtin.unarchive:
       src: "{{ rosa_terraform_url }}"
       remote_src: true
-      dest: /usr/local/bin
+      dest: /tmp
       mode: ug=rwx,o=rx
-      owner: root
-      group: root
+      extra_opts:
+      - --no-same-owner
     retries: 10
     register: r_terraform
     until: r_terraform is success
     delay: 30
 
   - name: Restore terraform-vpc directory from output-dir
-    become: true
     ansible.builtin.unarchive:
       src: "{{ output_dir }}/terraform-vpc.tar.gz"
       dest: "/tmp/"
@@ -55,7 +53,7 @@
   - name: Run Terraform destroy
     ansible.builtin.command:
       cmd: >-
-        /usr/local/bin/terraform destroy
+        /tmp/terraform destroy
           -var region={{ aws_region }}
           -var cluster_name={{ rosa_cluster_name }}
           -auto-approve


### PR DESCRIPTION
## Summary
- `uninstall_rosa.yml` runs during destroy on `hosts: localhost` inside the EE container
- The EE runs as a random non-root UID on OCP-based AAP2 (SCC restricted) — no sudo, no privilege escalation
- The "Install Terraform" task used `become: true`, `dest: /usr/local/bin`, `owner: root`, `group: root` — all fail in EE
- Fix: install terraform to `/tmp` instead, drop `become`/`owner`/`group`, add `--no-same-owner`
- Also drops `become` from the terraform-vpc restore task (writes to `/tmp/` which is writable)
- Updates terraform binary path in the destroy command from `/usr/local/bin/terraform` to `/tmp/terraform`

Follow-up to #9848 and #9851 which fixed `install_rosa_cli.yml` but missed `uninstall_rosa.yml`.

Affects HCP ROSA destroys (rosa_deploy_hcp: true) — e.g. ROSA_OPS_HOE, ROSA_MOBB governors.