### PR TITLE
Fix ocp4_workload_openshift_data_foundation 4.21 deployments

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_openshift_data_foundation/tasks/workload.yml
@@ -75,7 +75,7 @@
     definition: "{{ lookup('template', 'subscription.yaml.j2') | from_yaml }}"
 
 - name: "Config for channel {{ ocp4_workload_openshift_data_foundation_channel }}"
-  when: ocp4_workload_openshift_data_foundation_channel not in ["stable-4.19", "stable-4.20"]
+  when: ocp4_workload_openshift_data_foundation_channel in ["stable-4.12","stable-4.14", "stable-4.16", "stable-4.18"]
   ansible.builtin.set_fact:
     _console_plugin_api_version: "console.openshift.io/v1alpha1"
     _storage_systems_enabled: true


### PR DESCRIPTION
##### SUMMARY

Fix `ocp4_workload_openshift_data_foundation` 4.21 deployment and future deployments. 

storagesystems is not available anymore since 4.19.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

- ocp4_workload_openshift_data_foundation