### PR TITLE
fix: rosa destroy fails with sudo in EE due to become truthy string

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cli.yml
@@ -7,16 +7,21 @@
 # --no-same-owner:
 # https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233
 - name: Unzip rosa-linux.tar.gz
-  become: "{{ ACTION == 'provision' }}"
   ansible.builtin.unarchive:
     src: /tmp/rosa-linux.tar.gz
     dest: "{{ rosa_binary_path }}"
     remote_src: true
-    owner: "{{ omit if ACTION != 'provision' else 'root' }}"
-    # group: root # setting group fails in EE.
     mode: u=rwx,go=rx
     extra_opts:
     - --no-same-owner
+
+- name: Set rosa binary ownership
+  when: ACTION == 'provision'
+  become: true
+  ansible.builtin.file:
+    path: "{{ rosa_binary_path }}/rosa"
+    owner: root
+    mode: u=rwx,go=rx
 
 - name: cleanup archive file
   ansible.builtin.file:

--- a/ansible/configs/rosa-consolidated/install_rosa_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cli.yml
@@ -6,7 +6,20 @@
 
 # --no-same-owner:
 # https://github.com/habitat-sh/builder/issues/365#issuecomment-382862233
-- name: Unzip rosa-linux.tar.gz
+- name: Unzip rosa-linux.tar.gz (provision)
+  when: ACTION == 'provision'
+  become: true
+  ansible.builtin.unarchive:
+    src: /tmp/rosa-linux.tar.gz
+    dest: "{{ rosa_binary_path }}"
+    remote_src: true
+    owner: root
+    mode: u=rwx,go=rx
+    extra_opts:
+    - --no-same-owner
+
+- name: Unzip rosa-linux.tar.gz (destroy)
+  when: ACTION != 'provision'
   ansible.builtin.unarchive:
     src: /tmp/rosa-linux.tar.gz
     dest: "{{ rosa_binary_path }}"
@@ -14,14 +27,6 @@
     mode: u=rwx,go=rx
     extra_opts:
     - --no-same-owner
-
-- name: Set rosa binary ownership
-  when: ACTION == 'provision'
-  become: true
-  ansible.builtin.file:
-    path: "{{ rosa_binary_path }}/rosa"
-    owner: root
-    mode: u=rwx,go=rx
 
 - name: cleanup archive file
   ansible.builtin.file:


### PR DESCRIPTION
## Problem

ROSA destroy jobs fail with `sudo: command not found` in Execution Environment containers.

The root cause is `become: "{{ ACTION == 'provision' }}"` in `install_rosa_cli.yml`. During destroy, this Jinja2 expression evaluates to the **string** `"False"` — but Ansible treats any non-empty string as truthy for `become`, so it still attempts privilege escalation via sudo. EE containers run under OCP Security Context Constraints with random high UIDs and no sudo binary, causing the fatal error.

### Error

```
TASK [rosa-consolidated : Unzip rosa-linux.tar.gz] *****************************
fatal: [bastion]: FAILED! => {"msg": "Failed to set execute bit on remote files
(rc: 127, err: sudo: command not found\n)"}
```

### Affected subjects

Multiple `sandboxes-gpte.rosa.prod` AnarchySubjects stuck in `destroy-failed` state on us-east-1 (e.g. `rosa.prod-7gjjl`, `rosa.prod-648fp`).

## Fix

- Remove `become` and `owner` from the unarchive task — `--no-same-owner` already prevents tar from attempting ownership changes that require root
- Add a separate `ansible.builtin.file` task gated by `when: ACTION == 'provision'` for setting root ownership during provision only

This avoids the Jinja2 string-truthiness trap entirely by using `when:` (which properly evaluates boolean expressions) instead of `become:` with a template.