### PR TITLE
Fix Multus network config JSON serialization in infra-openshift-cnv-resources

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -1,16 +1,7 @@
 ---
 - name: Create network {{ _network.name }}
   kubernetes.core.k8s:
-    definition:
-      apiVersion: k8s.cni.cncf.io/v1
-      kind: NetworkAttachmentDefinition
-      metadata:
-        name: "{{ _network.name }}{{ guid }}"
-        namespace: "{{ openshift_cnv_namespace }}"
-      spec:
-        config: "{{ config | to_json }}"
-  vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    definition: "{{ lookup('ansible.builtin.template', 'net-attach-def.yaml') }}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/templates/net-attach-def.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/templates/net-attach-def.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: "{{ _network.name }}{{ guid }}"
+  namespace: "{{ openshift_cnv_namespace }}"
+spec:
+  config: '{"cniVersion":"0.3.1","type":"ovn-k8s-cni-overlay","topology":"layer2","name":"{{ _network.name }}{{ guid }}","netAttachDefName":"{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}","mtu":{{ _network.mtu | default(1500) }}}'


### PR DESCRIPTION
## Summary

- Converts the `config` variable in `create_network.yaml` from a Python dict string literal to a proper YAML dictionary
- The Python dict syntax with single quotes was not producing valid JSON when passed through `to_json`, causing Multus validating webhook to reject NetworkAttachmentDefinition creation
- Error: `admission webhook "multus-validating-config.k8s.io" denied the request: configuration string is not in JSON format`
- This is the same fix as PRs #9776 and #9827 which have been open since April and June respectively
- Tagged as `zero-touch-prod-1.1.1` for immediate use by zerotouch items that depend on CNV network creation

## Test plan

- [ ] Verify NetworkAttachmentDefinition creation succeeds on CNV clusters with Multus validating webhook enabled
- [ ] Test with zt-ocp-lab-developer-cnv which provisions VMs with network attachment