### PR TITLE
fix(ansible-bu-workshop): disable become on localhost workloads

### DIFF
--- a/ansible/configs/ansible-bu-workshop/workloads.yml
+++ b/ansible/configs/ansible-bu-workshop/workloads.yml
@@ -2,7 +2,7 @@
 - name: Install {{ _workload_title_ }}  workloads on localhost
   hosts: localhost
   gather_facts: false
-  become: true
+  become: false
   tasks:
     - name: Deploying {{ _workload_title_ }} workloads  on localhost
       when: _workloads_.localhost | default("") | length > 0


### PR DESCRIPTION
## Summary

- `workloads.yml` has `become: true` on the `hosts: localhost` play
- This causes Ansible to invoke `sudo` on the AAP2 controller node / inside the execution environment container
- New on-prem LB controllers and EE containers (`quay.io/agnosticd/ee-multicloud`) do not have `sudo` installed, so provisioning fails at `ansible_bu_aws_access_policy : Grab Route53 Zone ID` with `sudo: command not found` (rc: 127)
- Localhost workloads only make AWS SDK (boto3) calls — no privilege escalation is needed

**Fix**: `become: true` → `become: false` for the localhost play only.

Jira: GPTEINFRA-17299

## Test plan
- [ ] CI passes for `ANS_BU_WKSP_AUTO_SATELLITE` catalog item
- [ ] `ansible_bu_aws_access_policy` role completes successfully without `sudo` error