### PR TITLE
fix(ansible_bu_aws_access_policy): disable become to fix sudo not found in EE

### DIFF
--- a/ansible/roles/ansible_bu_aws_access_policy/tasks/main.yml
+++ b/ansible/roles/ansible_bu_aws_access_policy/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - name: AWS Access Policy block
+  become: false
   environment:
     AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
     AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"


### PR DESCRIPTION
## Summary

- The role runs on `localhost` inside an execution environment container (`quay.io/agnosticd/ee-multicloud`) where `sudo` is not installed
- `workloads.yml` sets `become: true` at the play level, causing Ansible to invoke `sudo` for all localhost workloads
- `ansible_bu_aws_access_policy` only makes AWS SDK (boto3) calls — no privilege escalation is needed or possible in the EE container
- Adding `become: false` at the block level in the role overrides the play-level directive, scoped to just this role

Jira: GPTEINFRA-17299

## Test plan
- [ ] CI passes for `ANS_BU_WKSP_AUTO_SATELLITE` catalog item
- [ ] `ansible_bu_aws_access_policy : Grab Route53 Zone ID` no longer fails with `sudo: command not found`