### PR TITLE
fix(ansible_bu_setup_workshop): disable become on localhost delegate

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/common/fetch_instances_info.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/common/fetch_instances_info.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Grab ec2 instances info
+  become: false
   environment:
     AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
     AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"


### PR DESCRIPTION
## Summary
- Adds `become: false` to the `Grab ec2 instances info` task in `ansible_bu_setup_workshop` which delegates to localhost
- Without this, the task inherits `become: true` from the play and fails with `sudo: command not found` inside the EE
- Same root cause as #9857 which fixed the same issue in `ansible_bu_aws_access_policy`

## Failed job
https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/42871/output

## Error
```
TASK [ansible_bu_setup_workshop : Grab ec2 instances info]
fatal: [ansible-1.example.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "/bin/sh: sudo: command not found\n", "rc": 127}
```

## Jira
GPTEINFRA-17300

🤖 Generated with [Claude Code](https://claude.com/claude-code)