### PR TITLE
fix(ansible_bu_setup_workshop): disable become on navigator localhost delegate

### DIFF
--- a/ansible/roles/ansible_bu_setup_workshop/tasks/common/ansible-navigator.yml
+++ b/ansible/roles/ansible_bu_setup_workshop/tasks/common/ansible-navigator.yml
@@ -1,5 +1,6 @@
 ---
 - name: Grab ec2 instances info
+  become: false
   environment:
     AWS_ACCESS_KEY_ID: "{{ aws_access_key_id }}"
     AWS_SECRET_ACCESS_KEY: "{{ aws_secret_access_key }}"


### PR DESCRIPTION
## Summary
- The "Grab ec2 instances info" task in `ansible-navigator.yml` delegates to localhost but inherits `become: true` from the play, causing `sudo: command not found` inside the execution environment
- Same root cause as #9858 — this is a second occurrence of the identical task in a different file

## Test plan
- [ ] Deploy ansible_bu_setup_workshop and verify "Grab ec2 instances info" task succeeds without sudo error

🤖 Generated with [Claude Code](https://claude.com/claude-code)