### PR TITLE
Added become: false block to create_ssh_provision_key

### DIFF
--- a/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
+++ b/ansible/roles-infra/create_ssh_provision_key/tasks/main.yaml
@@ -1,46 +1,50 @@
 ---
-- include_tasks: checks.yaml
-- name: Generate SSH keys
-  command: >-
-    ssh-keygen
-    -t {{ ssh_provision_key_type | quote }}
-    -f {{ ssh_provision_key_path | quote }}
-    -q -N ""
-  args:
-    creates: "{{ ssh_provision_key_path }}"
-  register: r_ssh_key_gen
+- name: Create SSH provision key
+  become: false
+  block:
+    - include_tasks: checks.yaml
 
-- name: Fix permission of ssh key
-  file:
-    path: "{{ ssh_provision_key_path }}"
-    mode: 0400
+    - name: Generate SSH keys
+      command: >-
+        ssh-keygen
+        -t {{ ssh_provision_key_type | quote }}
+        -f {{ ssh_provision_key_path | quote }}
+        -q -N ""
+      args:
+        creates: "{{ ssh_provision_key_path }}"
+      register: r_ssh_key_gen
 
-- name: Generate SSH pub key content
-  command: >-
-    ssh-keygen -y -f {{ ssh_provision_key_path | quote }}
-  changed_when: false
-  register: r_ssh_provision_pubkey
+    - name: Fix permission of ssh key
+      file:
+        path: "{{ ssh_provision_key_path }}"
+        mode: 0400
 
-- name: Save all facts for SSH
-  set_fact:
-    ssh_provision_pubkey_content: "{{ r_ssh_provision_pubkey.stdout.strip() }}"
-    ssh_provision_pubkey_path: "{{ ssh_provision_pubkey_path }}"
-    ssh_provision_key_path: "{{ ssh_provision_key_path }}"
-    ssh_provision_key_name: "{{ ssh_provision_key_name }}"
-    ssh_provision_key_type: "{{ ssh_provision_key_type }}"
+    - name: Generate SSH pub key content
+      command: >-
+        ssh-keygen -y -f {{ ssh_provision_key_path | quote }}
+      changed_when: false
+      register: r_ssh_provision_pubkey
 
-- name: Write SSH pub key
-  copy:
-    content: "{{ ssh_provision_pubkey_content }}"
-    dest: "{{ ssh_provision_pubkey_path }}"
+    - name: Save all facts for SSH
+      set_fact:
+        ssh_provision_pubkey_content: "{{ r_ssh_provision_pubkey.stdout.strip() }}"
+        ssh_provision_pubkey_path: "{{ ssh_provision_pubkey_path }}"
+        ssh_provision_key_path: "{{ ssh_provision_key_path }}"
+        ssh_provision_key_name: "{{ ssh_provision_key_name }}"
+        ssh_provision_key_type: "{{ ssh_provision_key_type }}"
 
-- name: Report user info for SSH provision key as user data
-  agnosticd_user_info:
-    data:
-      ssh_provision_key: "{{ lookup('file', ssh_provision_key_path) }}"
-      ssh_provision_pubkey: "{{ ssh_provision_pubkey_content }}"
-  when: create_ssh_provision_key_enable_user_info_data | bool
+    - name: Write SSH pub key
+      copy:
+        content: "{{ ssh_provision_pubkey_content }}"
+        dest: "{{ ssh_provision_pubkey_path }}"
 
-- include_role:
-    name: agnosticd_save_output_dir
-  when: r_ssh_key_gen is changed
+    - name: Report user info for SSH provision key as user data
+      agnosticd_user_info:
+        data:
+          ssh_provision_key: "{{ lookup('file', ssh_provision_key_path) }}"
+          ssh_provision_pubkey: "{{ ssh_provision_pubkey_content }}"
+      when: create_ssh_provision_key_enable_user_info_data | bool
+
+    - include_role:
+        name: agnosticd_save_output_dir
+      when: r_ssh_key_gen is changed


### PR DESCRIPTION
(Do Not merge yet) Added a `become: false` block to `create_ssh_provision_key` so it works when run on AAP EE (New EE's do not have sudo anymore).

See https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/43044/output 

Looks like a big change because I indented all lines to include them in the block, but all tasks remain unchanged. If any other items start failing we can revert.