### PR TITLE
fix(rosa): remove --no-same-owner from terraform zip unarchive

### DIFF
--- a/ansible/configs/rosa-consolidated/uninstall_rosa.yml
+++ b/ansible/configs/rosa-consolidated/uninstall_rosa.yml
@@ -35,8 +35,6 @@
       remote_src: true
       dest: /tmp
       mode: ug=rwx,o=rx
-      extra_opts:
-      - --no-same-owner
     retries: 10
     register: r_terraform
     until: r_terraform is success


### PR DESCRIPTION
## Summary

Remove \`extra_opts: --no-same-owner\` from the "Install Terraform" task in
\`uninstall_rosa.yml\`. The terraform binary URL is a \`.zip\` file — \`--no-same-owner\`
is a GNU tar flag that \`unzip\` doesn't understand, causing:

```
caution:  both -n and -o specified; ignoring -o
UnZip 6.00 of 20 April 2009, by Info-ZIP.
Usage: unzip [-Z] [-opts[modifiers]] file[.zip] [list] [-x xlist] [-d exdir]
```

This was introduced in PR #9852 which correctly added \`--no-same-owner\` to
the tar-based tasks but also applied it to the zip-based terraform download.

The adjacent \`terraform-vpc.tar.gz\` restore task correctly keeps
\`--no-same-owner\` since it is an actual tar archive.

\`unzip\` does not restore UID/GID by default (that requires \`-X\`), so no
equivalent flag is needed.

## Test plan

- [ ] HCP ROSA destroy job successfully installs terraform binary
- [ ] Terraform VPC destroy completes