### PR TITLE
Update create_network.yaml to fix network config

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -10,7 +10,13 @@
       spec:
         config: "{{ config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    config:
+      cniVersion: "0.3.1"
+      type: "ovn-k8s-cni-overlay"
+      topology: "layer2"
+      name: "{{ _network.name }}{{ guid }}"
+      netAttachDefName: "{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}"
+      mtu: "{{ _network.mtu | default(1500) | int }}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,7 +8,7 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        config: "{{ config | to_json }}"
+        config: "{{ _network_cni_config | to_json }}"
   vars:
     config:
       cniVersion: "0.3.1"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,7 +8,7 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        config: "{{ _network_cni_config | to_json }}"
+        config: "{{ config | to_json }}"
   vars:
     config:
       cniVersion: "0.3.1"


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY
To fix below error:
```
TASK [infra-openshift-cnv-resources : Create network default] ******************
Thursday 09 July 2026  18:52:04 +0000 (0:00:00.270)       0:00:13.264 ********* 
FAILED - RETRYING: [localhost]: Create network default (6 retries left).
..........................
..........................
FAILED - RETRYING: [localhost]: Create network default (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 6, "changed": false, "msg": "Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"admission webhook \\\\\"multus-validating-config.k8s.io\\\\\" denied the request: configuration string is not in JSON format\",\"code\":400}\\n'", "reason": "Bad Request"}
```

Job Link: [43762](https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/43762/output)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
