### PR TITLE
fix: install runtime collections to /collections in EE containers

### DIFF
--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -21,22 +21,24 @@
       | agnosticd_filter_out_installed_collections(installed_collections)
       | to_yaml }}
 
-- name: Set default collections install path
+- name: Find writable collections path
   ansible.builtin.set_fact:
-    __collections_install_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
+    __collections_install_path: "{{ item }}"
+  when: __collections_install_path is not defined and item is writable
+  loop: "{{ lookup('config', 'COLLECTIONS_PATHS') }}"
 
-- name: Use /collections if default path is not writable
-  when: not __collections_install_path is writable
+- name: Fall back to /tmp/collections if no configured path is writable
+  when: __collections_install_path is not defined
   block:
-    - name: Create /collections directory
+    - name: Create /tmp/collections directory
       ansible.builtin.file:
-        path: /collections/ansible_collections
+        path: /tmp/collections/ansible_collections
         state: directory
         mode: "0755"
 
-    - name: Override collections install path
+    - name: Set fallback collections install path
       ansible.builtin.set_fact:
-        __collections_install_path: /collections
+        __collections_install_path: /tmp/collections
 
 - name: Install collections from requirements.yml (EE)
   environment:

--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -21,16 +21,25 @@
       | agnosticd_filter_out_installed_collections(installed_collections)
       | to_yaml }}
 
+- name: Create writable collections directory
+  ansible.builtin.file:
+    path: /collections/ansible_collections
+    state: directory
+    mode: "0755"
+
 - name: Install collections from requirements.yml (EE)
-  vars:
-    __collections_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
   command: >-
     ansible-galaxy collection install
     -r "{{ tempfile_1.path }}"
-    -p "{{ __collections_path | quote }}"
+    -p /collections
     --force-with-deps
-
   register: r_ee_ansible_galaxy_install_collections
+  failed_when: >-
+    r_ee_ansible_galaxy_install_collections.rc != 0
+    or 'PermissionError' in r_ee_ansible_galaxy_install_collections.stderr
+    or 'Permission denied' in r_ee_ansible_galaxy_install_collections.stderr
   until: r_ee_ansible_galaxy_install_collections is successful
   retries: 10
   delay: 30

--- a/ansible/install_collections_ee.yml
+++ b/ansible/install_collections_ee.yml
@@ -21,11 +21,22 @@
       | agnosticd_filter_out_installed_collections(installed_collections)
       | to_yaml }}
 
-- name: Create writable collections directory
-  ansible.builtin.file:
-    path: /collections/ansible_collections
-    state: directory
-    mode: "0755"
+- name: Set default collections install path
+  ansible.builtin.set_fact:
+    __collections_install_path: "{{ lookup('config', 'COLLECTIONS_PATHS')[0] }}"
+
+- name: Use /collections if default path is not writable
+  when: not __collections_install_path is writable
+  block:
+    - name: Create /collections directory
+      ansible.builtin.file:
+        path: /collections/ansible_collections
+        state: directory
+        mode: "0755"
+
+    - name: Override collections install path
+      ansible.builtin.set_fact:
+        __collections_install_path: /collections
 
 - name: Install collections from requirements.yml (EE)
   environment:
@@ -33,7 +44,7 @@
   command: >-
     ansible-galaxy collection install
     -r "{{ tempfile_1.path }}"
-    -p /collections
+    -p "{{ __collections_install_path }}"
     --force-with-deps
   register: r_ee_ansible_galaxy_install_collections
   failed_when: >-


### PR DESCRIPTION
## Summary

Fix silent failure of `ansible-galaxy collection install` in EE containers.

`ansible-galaxy` exits 0 on `PermissionError` when the target path is not
writable ([ansible bug](https://github.com/ansible/ansible/issues/84932)).
This means git-based collections (e.g. `rhpds.assisted_installer`) silently
fail to install, and the destroy job later fails with:

```
ERROR! couldn't resolve module/action 'rhpds.assisted_installer.list_clusters'
```

### Root cause

The EE's `COLLECTIONS_PATHS` are:
1. `/home/runner/.ansible/collections` - may not be writable under OCP random UIDs
2. `/collections` - does not exist
3. `/usr/share/ansible/collections` - read-only (EE image layer)

The old code installed to `COLLECTIONS_PATHS[0]` which could hit path 1 (not writable).
Galaxy crashes with `PermissionError` but exits 0. The `command` module sees rc=0
and reports `changed`.

### Fix

- Install to `/collections` (path 2) — already in the EE search path, just needs
  to be created. Guaranteed writable on the container overlay.
- `failed_when` checks stderr for `PermissionError` / `Permission denied` since
  `ansible-galaxy` doesn't set a non-zero exit code on write failures.
- `GIT_TERMINAL_PROMPT=0` prevents git from hanging on credential prompts for
  unreachable collection repos.

## Test plan

- [ ] Verify `osp-on-ocp-cnv` destroy job installs `rhpds.assisted_installer` and resolves the module
- [ ] Verify standard (non-git) collections still work via EE filter
- [ ] Verify `failed_when` catches actual permission errors instead of silent success