### PR TITLE
Fix agnosticd_user_info JSON serialization with ansible-core 2.19

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -123,7 +123,7 @@ class ActionModule(ActionBase):
                     fh.write('- ' + json.dumps(body) + "\n")
 
             if data or user:
-                data = json.loads(json.dumps(data))
+                data = json.loads(json.dumps(data, default=str))
                 user_data = None
                 try:
                     with open(os.path.join(output_dir, f'{action}-user-data.yaml'), 'r') as fh:


### PR DESCRIPTION
## Summary

- Add `default=str` to `json.dumps(data)` in the `agnosticd_user_info` action plugin
- ansible-core 2.19 wraps template results in `_AnsibleTaggedStr` objects that the default JSON encoder cannot serialize, causing `string indices must be integers, not '_AnsibleTaggedStr'` errors

## Context

Job 45651 on prod0 failed at the "Save user information for user access" task in `ocp4_workload_rhsso_authentication`. The `data` dict passed to `agnosticd_user_info` contained tagged strings that `json.dumps` could not serialize.

## Test plan

- [ ] Deploy any item that uses `agnosticd_user_info` with `user` and `data` parameters on an EE with ansible-core 2.19+
- [ ] Verify user data is saved correctly to the `provision-user-data.yaml` file