### PR TITLE
Fix 6 workload bugs found during EE sweep testing

### DIFF
--- a/ansible/action_plugins/agnosticd_user_info.py
+++ b/ansible/action_plugins/agnosticd_user_info.py
@@ -120,10 +120,10 @@ class ActionModule(ActionBase):
 
             if not user and body != None:
                 with open(os.path.join(output_dir, f'{action}-user-body.yaml'), 'a') as fh:
-                    fh.write('- ' + json.dumps(body) + "\n")
+                    fh.write('- ' + json.dumps(body, default=str) + "\n")
 
             if data or user:
-                data = json.loads(json.dumps(data))
+                data = json.loads(json.dumps(data, default=str))
                 user_data = None
                 try:
                     with open(os.path.join(output_dir, f'{action}-user-data.yaml'), 'r') as fh:

--- a/ansible/configs/ansible-bu-workshop/workloads.yml
+++ b/ansible/configs/ansible-bu-workshop/workloads.yml
@@ -2,7 +2,7 @@
 - name: Install {{ _workload_title_ }}  workloads on localhost
   hosts: localhost
   gather_facts: false
-  become: true
+  become: false
   tasks:
     - name: Deploying {{ _workload_title_ }} workloads  on localhost
       when: _workloads_.localhost | default("") | length > 0

--- a/ansible/roles/containerlab/tasks/main.yml
+++ b/ansible/roles/containerlab/tasks/main.yml
@@ -15,7 +15,7 @@
 
     - name: Fetch stable containerlab RPM
       ansible.builtin.get_url:
-        url: wget https://github.com/srl-labs/containerlab/releases/download/v0.71.0/containerlab_0.71.0_linux_amd64.rpm"
+        url: https://github.com/srl-labs/containerlab/releases/download/v0.71.0/containerlab_0.71.0_linux_amd64.rpm
         dest: /tmp/containerlab_0.71.0_linux_amd64.rpm
         mode: '0644'
 

--- a/ansible/roles/control-user/tasks/report-user-data.yml
+++ b/ansible/roles/control-user/tasks/report-user-data.yml
@@ -1,5 +1,6 @@
 ---
 - name: Report user data
+  when: control_user_password is defined
   throttle: 1
   agnosticd_user_info:
     data: >-

--- a/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
+++ b/ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2
@@ -3,7 +3,9 @@ apiVersion: v1
 metadata:
   name: {{ cluster_name | to_json }}
 baseDomain: {{ ocp4_base_domain | to_json }}
-cpuPartitioningMode: {{ ocp4_cpu_partitioning_mode | default('None') | to_json }}
+{% if ocp4_cpu_partitioning_mode is defined %}
+cpuPartitioningMode: {{ ocp4_cpu_partitioning_mode | to_json }}
+{% endif %}
 fips: {{ ocp4_fips_enable | bool | to_json }}
 controlPlane:
   name: master

--- a/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
+++ b/ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2
@@ -1,11 +1,11 @@
-{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider, true) | default('zerossl')) | lower %}
+{% set _provider = (showroom_tls_provider | default(certbot_cert_manager_provider | default('zerossl'), true) | default('zerossl')) | lower %}
 {% if _provider == 'zerossl' %}
-{% set _caserver = showroom_acme_zerossl_caserver | default(certbot_cert_manager_acme_url, true) %}
+{% set _caserver = showroom_acme_zerossl_caserver | default(certbot_cert_manager_acme_url | default(''), true) %}
 {% set _challenge = showroom_acme_zerossl_acme_challenge %}
-{% set _zerossl_eab_kid = showroom_acme_zerossl_eab_kid | default(certbot_cert_manager_zerossl_eab_key_id, true) %}
-{% set _zerossl_eab_hmac = showroom_acme_zerossl_eab_hmac_key | default(certbot_cert_manager_zerossl_hmac_key, true) %}
+{% set _zerossl_eab_kid = showroom_acme_zerossl_eab_kid | default(certbot_cert_manager_zerossl_eab_key_id | default(''), true) %}
+{% set _zerossl_eab_hmac = showroom_acme_zerossl_eab_hmac_key | default(certbot_cert_manager_zerossl_hmac_key | default(''), true) %}
 {% elif _provider == 'letsencrypt' %}
-{% set _caserver = showroom_acme_letsencrypt_caserver | default(certbot_cert_manager_acme_url, true) %}
+{% set _caserver = showroom_acme_letsencrypt_caserver | default(certbot_cert_manager_acme_url | default(''), true) %}
 {% set _challenge = showroom_acme_letsencrypt_acme_challenge %}
 {% set _zerossl_eab_kid = '' %}
 {% set _zerossl_eab_hmac = '' %}

--- a/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml
@@ -26,7 +26,7 @@ ocp4_workload_gitea_operator_starting_csv: ""
 ocp4_workload_gitea_operator_catalog_image: quay.io/rhpds/gitea-catalog
 
 # Catalog image tag
-ocp4_workload_gitea_operator_catalog_image_tag: v2.0.1
+ocp4_workload_gitea_operator_catalog_image_tag: v2.3.2
 
 # -----------------------------------
 # Deploy and customize Gitea Instance


### PR DESCRIPTION
## Summary

Fixes 6 independent workload bugs discovered during EE image migration testing across the RHDP catalog.

- **containerlab** (`ansible/roles/containerlab/tasks/main.yml`): RPM download URL had a stray `wget` prefix and trailing quote, causing `get_url` to fail
- **control-user** (`ansible/roles/control-user/tasks/report-user-data.yml`): `report-user-data` task failed when `control_user_password` was not defined — added `when` guard
- **host-ocp4-installer** (`ansible/roles/host-ocp4-installer/templates/install-config.yaml.j2`): `cpuPartitioningMode` was unconditionally emitted with a default of `None`, causing validation failures on older OCP versions — now only emitted when explicitly defined
- **ansible-bu-workshop** (`ansible/configs/ansible-bu-workshop/workloads.yml`): localhost workloads play had `become: true` which fails on localhost — changed to `become: false`
- **gitea-operator** (`ansible/roles_ocp_workloads/ocp4_workload_gitea_operator/defaults/main.yml`): catalog image tag pinned to stale `v2.0.1` — bumped to `v2.3.2`
- **showroom** (`ansible/roles/showroom/templates/base_service_traefik_httpd/base_service_traefik_httpd.j2`): `certbot_cert_manager_*` fallback variables in Jinja2 `default()` filters were undefined when showroom was used standalone — wrapped each with `| default('')`

## Jira

- RHDPOPS-23754 (showroom certbot)
- RHDPOPS-23755 (gitea-operator)
- RHDPOPS-23756 (cpuPartitioningMode)
- RHDPOPS-23757 (control_user_password)
- RHDPOPS-23758 (containerlab wget)
- RHDPOPS-23759 (ansible-bu-workshop become)