### PR TITLE
roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml - Fix overlapping config variable and add better config formatting

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,9 +8,15 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        config: "{{ config | to_json }}"
+        config: "{{ network_config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    network_config:
+      cniVersion: "0.3.1"
+      type: ovn-k8s-cni-overlay
+      topology: layer2
+      name: "{{ _network.name }}{{ guid }}"
+      netAttachDefName: "{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}"
+      mtu: "{{ _network.mtu | default(1500) }}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"


### PR DESCRIPTION
Fixes deployment issues such as https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/47915/output

AAP passes a config extra var (catalog name like zero-touch-base-rhel) that was shadowing the task's config var, so the NAD ended up with garbage instead of CNI JSON. Renamed it to network_config and switched to a dict for better readability.