### PR TITLE
Revert "roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml - Fix overlapping config variable and add better config formatting"

### DIFF
--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,9 +8,9 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        config: "{{ config | to_json }}"
+        config: "{{ network_config | to_json }}"
   vars:
-    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    network_config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -10,7 +10,15 @@
       spec:
         config: "{{ network_config | to_json }}"
   vars:
-    network_config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
+    network_config: >-
+      {{ {
+        "cniVersion": "0.3.1",
+        "type": "ovn-k8s-cni-overlay",
+        "'topology": "layer2",
+        "name": _network.name ~ guid,
+        "netAttachDefName": openshift_cnv_namespace ~ "/" ~ _network.name ~ guid,
+        "mtu": _network.mtu | default(1500) | int
+      } }}
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"

--- a/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
+++ b/ansible/roles-infra/infra-openshift-cnv-resources/tasks/create_network.yaml
@@ -8,15 +8,9 @@
         name: "{{ _network.name }}{{ guid }}"
         namespace: "{{ openshift_cnv_namespace }}"
       spec:
-        config: "{{ network_config | to_json }}"
+        config: "{{ config | to_json }}"
   vars:
-    network_config:
-      cniVersion: "0.3.1"
-      type: ovn-k8s-cni-overlay
-      topology: layer2
-      name: "{{ _network.name }}{{ guid }}"
-      netAttachDefName: "{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}"
-      mtu: "{{ _network.mtu | default(1500) }}"
+    config: "{'cniVersion':'0.3.1','type':'ovn-k8s-cni-overlay','topology':'layer2','name': '{{ _network.name }}{{ guid }}', 'netAttachDefName': '{{ openshift_cnv_namespace }}/{{ _network.name }}{{ guid }}', 'mtu': {{ _network.mtu | default(1500) }}}"
   register: r_createnetwork
   until: r_createnetwork is success
   retries: "{{ openshift_cnv_retries }}"


### PR DESCRIPTION
Reverts redhat-cop/agnosticd#9866