### PR TITLE
Fix showroom helm install for non-root EE containers

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/check-and-install-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/check-and-install-helm.yaml
@@ -9,8 +9,13 @@
     path: /usr/bin/helm
   register: r_helm_installed
 
+- name: Check if helm is in ~/.local/bin
+  ansible.builtin.stat:
+    path: "{{ ansible_user_dir }}/.local/bin/helm"
+  register: r_helm_installed_user
+
 - name: Install Helm if it's not there
-  when: not (r_helm_installed_local.stat.exists or r_helm_installed.stat.exists)
+  when: not (r_helm_installed_local.stat.exists or r_helm_installed.stat.exists or r_helm_installed_user.stat.exists)
   block:
   - name: Set URL for helm
     ansible.builtin.set_fact:
@@ -44,10 +49,51 @@
     - name: Create Helm Bash completion file
       ansible.builtin.shell: /usr/local/bin/helm completion bash >/etc/bash_completion.d/helm
 
-  - name: Get helm version
-    ansible.builtin.shell: /usr/local/bin/helm version
-    register: r_helm_version
+    rescue:
+    - name: Install Helm to user-writable location (no sudo available)
+      block:
+      - name: Create ~/.local/bin directory
+        ansible.builtin.file:
+          path: "{{ ansible_user_dir }}/.local/bin"
+          state: directory
+          mode: "0755"
 
-  - name: Emit Helm version
-    ansible.builtin.debug:
-      msg: "Helm version installed: {{ r_helm_version.stdout }}"
+      - name: Download and extract helm to temp directory
+        ansible.builtin.unarchive:
+          src: "{{ helm_url }}"
+          remote_src: true
+          dest: "{{ ansible_user_dir }}/.local/bin"
+          mode: "0775"
+        retries: 10
+        register: r_client
+        until: r_client is success
+        delay: 30
+
+      - name: Link extracted helm binary
+        ansible.builtin.file:
+          src: "{{ ansible_user_dir }}/.local/bin/linux-amd64/helm"
+          dest: "{{ ansible_user_dir }}/.local/bin/helm"
+          state: link
+
+      - name: Update r_helm_installed_user fact
+        ansible.builtin.set_fact:
+          r_helm_installed_user:
+            stat:
+              exists: true
+
+- name: Set helm binary path
+  ansible.builtin.set_fact:
+    _showroom_helm_binary: >-
+      {% if r_helm_installed_local.stat.exists %}/usr/local/bin/helm{%
+      elif r_helm_installed.stat.exists %}/usr/bin/helm{%
+      elif r_helm_installed_user.stat.exists | default(false) %}{{ ansible_user_dir }}/.local/bin/helm{%
+      else %}/usr/local/bin/helm{% endif %}
+
+- name: Get helm version
+  ansible.builtin.command: "{{ _showroom_helm_binary }} version"
+  register: r_helm_version
+  changed_when: false
+
+- name: Emit Helm version
+  ansible.builtin.debug:
+    msg: "Helm version installed: {{ r_helm_version.stdout }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -10,6 +10,7 @@
   environment:
     KUBECONFIG: "{{ _showroom_kubeconfig | default(omit) }}"
   kubernetes.core.helm_template:
+    binary_path: "{{ _showroom_helm_binary | default(omit) }}"
     chart_repo_url: "{{ ocp4_workload_showroom_chart_package_url }}"
     chart_ref: "{{ ocp4_workload_showroom_deployer_chart_name }}"
     chart_version: "{{ ocp4_workload_showroom_deployer_chart_version }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm.yaml
@@ -10,6 +10,7 @@
   environment:
     KUBECONFIG: "{{ _showroom_kubeconfig | default(omit) }}"
   kubernetes.core.helm_template:
+    binary_path: "{{ _showroom_helm_binary | default(omit) }}"
     chart_repo_url: "{{ ocp4_workload_showroom_chart_package_url }}"
     chart_ref: "{{ ocp4_workload_showroom_deployer_chart_name }}"
     chart_version: "{{ ocp4_workload_showroom_deployer_chart_version }}"


### PR DESCRIPTION
## Summary

- The showroom role's `check-and-install-helm.yaml` uses `become: true` to install helm to `/usr/local/bin` with root ownership. RHDP execution environments run as uid 1000 without `sudo` installed, causing a fatal error: `/bin/sh: sudo: command not found`.
- Added a `rescue` block that catches the `become` failure and falls back to installing helm in `~/.local/bin` (user-writable, no privileges needed).
- Set a `_showroom_helm_binary` fact pointing to whichever helm path was found or installed, and pass it via `binary_path` to the `kubernetes.core.helm_template` calls in both `deploy-showroom-helm.yaml` and `deploy-showroom-helm-zerotouch.yaml`.
- Fully backwards compatible: on hosts where `become` succeeds, behavior is unchanged.

## Test plan

- [ ] Provision a showroom catalog item on an EE (non-root) environment and verify helm installs to `~/.local/bin` without error
- [ ] Provision a showroom catalog item on a traditional (root-capable) host and verify the existing `/usr/local/bin` path still works