### PR TITLE
fix: use correct package for OCP install, when specifying minor version

### DIFF
--- a/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
+++ b/ansible/roles/host-ocp4-installer/tasks/install_installer.yml
@@ -12,15 +12,48 @@
   - (ocp4_installer_version | string).split('.') | length >= 3
   ansible.builtin.set_fact:
     ocp4_installer_url: >-
+      {% if ocp4_installer_version is version_compare('4.16', '<') -%}
       {{ '{0}/ocp/{1}/openshift-install-linux-{1}.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         ocp4_installer_version
       ) }}
-    ocp4_client_url: >-
-      {{ '{0}/ocp/{1}/openshift-client-linux-{1}.tar.gz'.format(
+      {%- else -%}
+      {%   if ansible_distribution_major_version is version_compare('9', '>=') -%}
+      {%     if ansible_architecture == 'x86_64' %}
+      {{ '{0}/ocp/{1}/openshift-install-rhel{2}-amd64.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version,
+        ansible_distribution_major_version
+      ) }}
+      {%      else %}
+      {{ '{0}/ocp/{1}/openshift-install-linux-{2}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version,
+        ansible_architecture
+      ) }}
+      {%      endif %}
+      {%-   else -%}
+      {{ '{0}/ocp/{1}/openshift-install-linux-{1}.tar.gz'.format(
         ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         ocp4_installer_version
       ) }}
+      {%-   endif %}
+      {%- endif %}
+    ocp4_client_url: >-
+      {% if ocp4_installer_version is version_compare('4.15', '<') -%}
+      {{ '{0}/ocp/{1}/openshift-client-linux{2}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version,
+        '' if ansible_architecture == 'x86_64' else '-' ~ ansible_architecture
+      ) }}
+      {%- else -%}
+      {{ '{0}/ocp/{1}/openshift-client-linux-{2}-rhel{3}.tar.gz'.format(
+        ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
+        ocp4_installer_version,
+        'amd64' if ansible_architecture == 'x86_64' else ansible_architecture,
+        ansible_distribution_major_version
+      ) }}
+      {%- endif %}
 
 # ocp4_installer_version = 4.1 .. 4.99
 # -> latest stable installer for that major version


### PR DESCRIPTION
##### SUMMARY
https://redhat.atlassian.net/browse/ITRPS-401

The way that binaries are selected to install OCP, were different if requesting a specific minor version (XX.YY.ZZ) than if only specifying the major version (XX.YY). That difference makes FIPS brake when OCP 4.16+ is selected and minor version is specified.
This PR fixes it by mirroring the logic used when the minor version isn't requested.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- roles/host-ocp4-installer

##### ADDITIONAL INFORMATION
 - Testing done with multiple versions, with/without minor version, with/without FIPS enabled.
