### PR TITLE
Retry assisted-installer host wait on transient API failures

### DIFF
--- a/ansible/roles/host-ocp4-assisted-scale/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-scale/tasks/main.yaml
@@ -129,6 +129,10 @@
         infra_env_id: "{{ newinfraenv.result.id }}"
         configure_hosts: "{{ ai_configure_hosts }}"
         wait_timeout: 600
+      register: r_wait_for_hosts
+      until: r_wait_for_hosts is succeeded
+      retries: 3
+      delay: 20
 
 - name: Approve CSR
   include_tasks: approve_csr_nodes.yaml


### PR DESCRIPTION
## Summary
- Wraps `rhpds.assisted_installer.wait_for_hosts` in `until/retries` (3 x 20s) to handle transient empty or non-JSON API responses that crash the module
- The `configure_hosts` operations (hostname/role assignment) are idempotent, so re-runs are safe
- Mirrors rhpds/agnosticd-v2#185 for v1

## Campaign
RHDPOPS-23814

## Test plan
- [ ] Deploy a catalog item using `host-ocp4-assisted-scale` (e.g. rhacs-demo) and confirm the wait task completes