### PR TITLE
Add retry logic to assisted-installer wait_for_hosts

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -503,6 +503,10 @@
         infra_env_id: "{{ newinfraenv.result.id }}"
         configure_hosts: "{{ ai_configure_hosts }}"
         wait_timeout: 600
+      register: r_wait_for_hosts
+      until: r_wait_for_hosts is succeeded
+      retries: 3
+      delay: 20
 
     - name: Start cluster installation
       rhpds.assisted_installer.install_cluster:


### PR DESCRIPTION
Same fix as #9871 (host-ocp4-assisted-scale) applied to the host-ocp4-assisted-installer role.

The `wait_for_hosts` task can fail on transient Assisted Installer API errors. Adding `until/retries/delay` makes it retry up to 3 times with 20s between attempts.

Companion v2 change needed at: https://github.com/rhpds/agnosticd-v2/blob/5744e00fe05787e752334db87b0497cf8f5970ba/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml#L153