### PR TITLE
fix(open-env-azure): handle Azure DevOps account resources blocking RG deletion

### DIFF
--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/empty_resource_group.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/empty_resource_group.yml
@@ -18,3 +18,30 @@
   loop: "{{ r_resources.response }}"
   loop_control:
     loop_var: resource
+
+- name: Delete Azure DevOps (Visual Studio) account resources
+  when:
+    - r_resources.response | length > 0
+    - resource.type is defined
+    - resource.type | lower == "microsoft.visualstudio/account"
+  ansible.builtin.command: >
+    az resource delete --ids {{ resource.id }}
+  register: r_vs_account_delete
+  failed_when: false
+  changed_when: r_vs_account_delete.rc == 0
+  loop: "{{ r_resources.response }}"
+  loop_control:
+    loop_var: resource
+    label: "{{ resource.name }}"
+
+- name: Warn if Azure DevOps account could not be deleted (billing still linked)
+  when:
+    - r_vs_account_delete is defined
+    - r_vs_account_delete.results is defined
+    - r_vs_account_delete.results | selectattr('rc', 'defined') | selectattr('rc', 'ne', 0) | list | length > 0
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: Could not delete Azure DevOps account resource(s) in {{ az_resource_group }}.
+      This is typically caused by Azure DevOps billing still being linked to the subscription.
+      Billing must be removed manually via Azure DevOps Organization Settings > Billing.
+      The resource group deletion will be attempted but may fail for this RG.

--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -143,7 +143,27 @@
         location: "{{ item.location }}"
         force_delete_nonempty: yes
         state: absent
+      register: r_delete_resource_groups
+      failed_when: false
       loop: "{{ allresourcegroups.resourcegroups }}"
+
+    - name: Report resource groups that failed to delete
+      when:
+        - r_delete_resource_groups.results is defined
+        - r_delete_resource_groups.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
+      vars:
+        _failed_rgs: >-
+          {{ r_delete_resource_groups.results
+             | selectattr('failed', 'defined')
+             | selectattr('failed')
+             | map(attribute='item')
+             | map(attribute='name')
+             | list }}
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Failed to delete resource group(s): {{ _failed_rgs | join(', ') }}.
+          Continuing with remaining cleanup. These RGs may require manual intervention
+          (e.g. Azure DevOps billing must be removed via Organization Settings > Billing).
 
     - name: Get subscription FQID
       set_fact:
@@ -211,3 +231,21 @@
     - name: Log out of Azure CLI
       command: >
         az logout
+
+    - name: Fail if any resource groups could not be deleted
+      when:
+        - r_delete_resource_groups.results is defined
+        - r_delete_resource_groups.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
+      vars:
+        _failed_rgs: >-
+          {{ r_delete_resource_groups.results
+             | selectattr('failed', 'defined')
+             | selectattr('failed')
+             | map(attribute='item')
+             | map(attribute='name')
+             | list }}
+      ansible.builtin.fail:
+        msg: >-
+          Resource group(s) could not be deleted: {{ _failed_rgs | join(', ') }}.
+          All other cleanup (pool release, tags, role assignments) completed successfully.
+          Manual cleanup required for the listed resource group(s).

--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -133,8 +133,19 @@
       loop_control:
         label: "{{ item.name }}"
 
-    - name: Delete all resource groups owned by the subscription (RG's created by the lab user)
-      when: allresourcegroups.resourcegroups|length>0
+    - name: Split resource groups into VisualStudioOnline and regular
+      ansible.builtin.set_fact:
+        _vs_online_rgs: >-
+          {{ allresourcegroups.resourcegroups
+             | selectattr('name', 'match', '^VisualStudioOnline-')
+             | list }}
+        _regular_rgs: >-
+          {{ allresourcegroups.resourcegroups
+             | rejectattr('name', 'match', '^VisualStudioOnline-')
+             | list }}
+
+    - name: Delete regular resource groups (hard fail)
+      when: _regular_rgs | length > 0
       environment:
         AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
       azure.azcollection.azure_rm_resourcegroup:
@@ -143,17 +154,29 @@
         location: "{{ item.location }}"
         force_delete_nonempty: yes
         state: absent
-      register: r_delete_resource_groups
-      failed_when: false
-      loop: "{{ allresourcegroups.resourcegroups }}"
+      loop: "{{ _regular_rgs }}"
 
-    - name: Report resource groups that failed to delete
+    - name: Delete VisualStudioOnline resource groups (best-effort)
+      when: _vs_online_rgs | length > 0
+      environment:
+        AZURE_SUBSCRIPTION_ID: "{{ pool_subscription_id }}"
+      azure.azcollection.azure_rm_resourcegroup:
+        auth_source: env
+        name: "{{ item.name }}"
+        location: "{{ item.location }}"
+        force_delete_nonempty: yes
+        state: absent
+      register: r_delete_vs_rgs
+      failed_when: false
+      loop: "{{ _vs_online_rgs }}"
+
+    - name: Report VisualStudioOnline resource groups that failed to delete
       when:
-        - r_delete_resource_groups.results is defined
-        - r_delete_resource_groups.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
+        - r_delete_vs_rgs.results is defined
+        - r_delete_vs_rgs.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
       vars:
         _failed_rgs: >-
-          {{ r_delete_resource_groups.results
+          {{ r_delete_vs_rgs.results
              | selectattr('failed', 'defined')
              | selectattr('failed')
              | map(attribute='item')
@@ -161,9 +184,9 @@
              | list }}
       ansible.builtin.debug:
         msg: >-
-          WARNING: Failed to delete resource group(s): {{ _failed_rgs | join(', ') }}.
-          Continuing with remaining cleanup. These RGs may require manual intervention
-          (e.g. Azure DevOps billing must be removed via Organization Settings > Billing).
+          WARNING: Failed to delete VisualStudioOnline resource group(s): {{ _failed_rgs | join(', ') }}.
+          This is typically caused by Azure DevOps billing still linked to the subscription.
+          Billing must be removed manually via Azure DevOps Organization Settings > Billing.
 
     - name: Get subscription FQID
       set_fact:
@@ -232,13 +255,13 @@
       command: >
         az logout
 
-    - name: Fail if any resource groups could not be deleted
+    - name: Fail if any VisualStudioOnline resource groups could not be deleted
       when:
-        - r_delete_resource_groups.results is defined
-        - r_delete_resource_groups.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
+        - r_delete_vs_rgs.results is defined
+        - r_delete_vs_rgs.results | selectattr('failed', 'defined') | selectattr('failed') | list | length > 0
       vars:
         _failed_rgs: >-
-          {{ r_delete_resource_groups.results
+          {{ r_delete_vs_rgs.results
              | selectattr('failed', 'defined')
              | selectattr('failed')
              | map(attribute='item')
@@ -246,6 +269,6 @@
              | list }}
       ansible.builtin.fail:
         msg: >-
-          Resource group(s) could not be deleted: {{ _failed_rgs | join(', ') }}.
+          VisualStudioOnline resource group(s) could not be deleted: {{ _failed_rgs | join(', ') }}.
           All other cleanup (pool release, tags, role assignments) completed successfully.
-          Manual cleanup required for the listed resource group(s).
+          Manual cleanup required — remove Azure DevOps billing via Organization Settings.


### PR DESCRIPTION
## Summary

- Fixes destroy job failures caused by `microsoft.visualstudio/account` resources in Azure sandbox subscriptions
- When a lab user creates an Azure DevOps org with billing linked to the sandbox subscription, the `VisualStudioOnline-*` resource group cannot be deleted via ARM API
- Previously this hard-failed the play, **skipping all downstream cleanup** (pool release, tag reset, role assignments, app registrations) — leaving the subscription in a zombie state

## Changes

**`empty_resource_group.yml`**: Best-effort deletion of `microsoft.visualstudio/account` resources before RG deletion (succeeds when billing isn't set up; fails gracefully when it is)

**`main.yml`**: 
- RG deletion task now uses `failed_when: false` + `register` instead of hard-failing the play
- Warns about which RGs failed to delete
- All downstream cleanup (pool release, tags, role assignments, app reg deletion) now **always runs**
- Final `fail` task at the end reports the error after cleanup is complete

## Context

Azure DevOps billing cannot be disconnected via ARM or Azure DevOps REST API from a service principal — it requires manual action in the DevOps org settings (Organization Settings > Billing > Remove billing). Tested with both the open-env SP and an admin user account; both hit the same `ResourceGroupDeletionBlocked` / `Conflict: Billing is set up` error.

**Example failed job**: `prod0` job 55903 — GUID `cl85m`, user `depowell@redhat.com`, subscription `pool-00-30`

## Test plan

- [ ] Verify destroy succeeds (with warning) when a `VisualStudioOnline-*` RG with billing-linked DevOps org exists
- [ ] Verify pool release, tag reset, and role assignment cleanup all complete despite RG deletion failure
- [ ] Verify destroy still works normally when no VS account resources are present
- [ ] Verify VS account deletion succeeds when billing is NOT linked