### PR TITLE
fix(gcp): skip SSH key secret creation during destroy

### DIFF
--- a/ansible/roles-infra/infra-gcp-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-gcp-ssh-key/tasks/main.yml
@@ -55,8 +55,8 @@
         - r_ssh_key.rc == 0
 
 - when:
-  - stat_infra_ssh_key.stat.exists
-  - ACTION | default('provision') != 'destroy'
+    - stat_infra_ssh_key.stat.exists
+    - ACTION | default('provision') != 'destroy'
   block:
     - name: Create secret to store bastion SSH key
       environment:

--- a/ansible/roles-infra/infra-gcp-ssh-key/tasks/main.yml
+++ b/ansible/roles-infra/infra-gcp-ssh-key/tasks/main.yml
@@ -54,7 +54,9 @@
         - r_ssh_key is changed
         - r_ssh_key.rc == 0
 
-- when: stat_infra_ssh_key.stat.exists
+- when:
+  - stat_infra_ssh_key.stat.exists
+  - ACTION | default('provision') != 'destroy'
   block:
     - name: Create secret to store bastion SSH key
       environment:


### PR DESCRIPTION
## Summary

- Skip `gcloud secrets create` when `ACTION=destroy` in the `infra-gcp-ssh-key` role
- Fixes 68+ failed GCP destroy jobs on prod0

## Root cause

`infra-gcp-ssh-key` tries to create a GCP Secret Manager secret whenever the SSH key exists locally. During destroy, the key exists (restored from S3), so the role attempts `gcloud secrets create`. But the Secret Manager API is only enabled by `open-env-gcp-add-user-to-project` for open environments — standard `ocp4-cluster` GCP projects (`cluster-<guid>`) never have it enabled.

```
API [secretmanager.googleapis.com] not enabled on project [cluster-kz7k8].
Would you like to enable and retry (this will take a few minutes)? (y/N)?
ERROR: (gcloud.secrets.create) ...
```

Example: [job 55982](https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/55982/output)

## Fix

Add `ACTION | default('provision') != 'destroy'` condition to the secret creation block. During destroy the key is already available locally from the S3 output_dir restore — no need to store it again.