### PR TITLE
fix(gcp): handle zombie environments on destroy

### DIFF
--- a/ansible/cloud_providers/gcp_destroy_env.yml
+++ b/ansible/cloud_providers/gcp_destroy_env.yml
@@ -8,6 +8,7 @@
   become: false
   tasks:
     - name: Run infra-gcp-template-destroy
+      when: not gcp_zombie_env | default(false) | bool
       include_role:
         name: infra-gcp-template-destroy
     - name: Remove Google Cloud SDK

--- a/ansible/configs/ocp4-cluster/destroy_env_gcp.yml
+++ b/ansible/configs/ocp4-cluster/destroy_env_gcp.yml
@@ -21,11 +21,40 @@
     ansible.builtin.include_role:
       name: infra-gcp-install-sdk
 
+  - name: Check if Compute API is enabled on project
+    environment:
+      PATH: '{{ output_dir }}/google-cloud-sdk/bin:/usr/bin:/usr/local/bin'
+      CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: "{{ gcp_credentials_file }}"
+      CLOUDSDK_COMPUTE_REGION: "{{ gcp_region }}"
+      CLOUDSDK_CONFIG: "{{ output_dir }}/.gcloud-{{ guid }}"
+      CLOUDSDK_CORE_PROJECT: "{{ gcp_project_id }}"
+    ansible.builtin.command: >-
+      gcloud services list
+      --enabled
+      --filter=config.name:compute.googleapis.com
+      --format="value(config.name)"
+    register: r_compute_api_check
+    failed_when: false
+
+  - name: Set zombie environment fact
+    ansible.builtin.set_fact:
+      gcp_zombie_env: "{{ r_compute_api_check.rc != 0 or 'compute.googleapis.com' not in r_compute_api_check.stdout }}"
+
+  - name: Zombie environment detected
+    when: gcp_zombie_env | bool
+    ansible.builtin.debug:
+      msg: >-
+        Compute API not enabled on project {{ gcp_project_id }}.
+        This is a partially provisioned environment — skipping
+        infrastructure teardown and proceeding to project cleanup.
+
   - name: Get private SSH key from secrets
+    when: not gcp_zombie_env | bool
     ansible.builtin.include_role:
       name: infra-gcp-ssh-key
 
   - name: Run infra-gcp-create-inventory role
+    when: not gcp_zombie_env | bool
     ansible.builtin.include_role:
       name: infra-gcp-create-inventory
 
@@ -47,9 +76,11 @@
   become: false
   tasks:
   - name: Start GCP instances
+    when: not gcp_zombie_env | default(false) | bool
     ansible.builtin.include_tasks: gcp_instances_start.yml
 
   - name: Destroy firewall rules
+    when: not gcp_zombie_env | default(false) | bool
     ansible.builtin.include_tasks: gcp_fw_destroy.yml
 
 - name: Have the OpenShift installer cleanup what it did


### PR DESCRIPTION
## Summary

Two fixes for GCP destroy failures:

1. **Skip SSH key secret creation during destroy** — `infra-gcp-ssh-key` tried to `gcloud secrets create` during destroy when the key existed locally (from S3 restore). The Secret Manager API is only enabled for open environments, so this failed for all standard `ocp4-cluster` GCP destroys.

2. **Detect and handle zombie environments** — when a provision fails before GCP APIs are enabled on the child project (`cluster-<guid>`), every subsequent destroy step fails because compute/secretmanager/deploymentmanager/dns APIs aren't available. Now the destroy checks if the Compute API is enabled early on. If not, it sets `gcp_zombie_env=true` and skips all infrastructure teardown, falling through to `open-env-gcp-remove-project` which uses the parent project's REST API credentials to delete the zombie GCP project.

## Impact

- Fixes **68+ failed destroy jobs** on prod0
- Unblocks cleanup of partially-provisioned GCP environments

## Changed files

- `ansible/roles-infra/infra-gcp-ssh-key/tasks/main.yml` — skip secret creation when `ACTION=destroy`
- `ansible/configs/ocp4-cluster/destroy_env_gcp.yml` — add Compute API check, set `gcp_zombie_env` fact, guard all compute-dependent steps
- `ansible/cloud_providers/gcp_destroy_env.yml` — skip `infra-gcp-template-destroy` for zombie envs

## Example failures

- [job 55982](https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/55982/output) — `secretmanager.googleapis.com` not enabled
- [job 56118](https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/56118/output) — `compute.googleapis.com` not enabled