### PR TITLE
control_user/tasks/create-user.yml - Fix logic for newer ansible vers…

### DIFF
--- a/ansible/roles/control-user/tasks/create-user.yml
+++ b/ansible/roles/control-user/tasks/create-user.yml
@@ -4,8 +4,8 @@
   ansible.builtin.user:
     name: "{{ control_user_name }}"
     group: "{{ control_user_private_group }}"
-    append: "{{ control_user_groups_append | default(true) }}"
     groups: "{{ control_user_groups | default(omit) }}"
+    append: "{{ control_user_groups_append | default(true) if control_user_groups is defined else omit }}"
     update_password: "{{ control_user_password_update | default(omit) }}"
     state: present
 


### PR DESCRIPTION
…ions

ansible.builtin.user became stricter in 2.21: append: true requires groups now.

If groups is not defined it will cause some labs to fail e.g. https://prod0.apps.ocpv-infra01.dal12.infra.demo.redhat.com/#/jobs/playbook/56888/output

