### PR TITLE
Replace unarchive with tar in ROSA destroy to fix sudo error

### DIFF
--- a/ansible/configs/rosa-consolidated/install_rosa_cli.yml
+++ b/ansible/configs/rosa-consolidated/install_rosa_cli.yml
@@ -20,13 +20,9 @@
 
 - name: Unzip rosa-linux.tar.gz (destroy)
   when: ACTION != 'provision'
-  ansible.builtin.unarchive:
-    src: /tmp/rosa-linux.tar.gz
-    dest: "{{ rosa_binary_path }}"
-    remote_src: true
-    mode: u=rwx,go=rx
-    extra_opts:
-    - --no-same-owner
+  ansible.builtin.command:
+    cmd: tar xzf /tmp/rosa-linux.tar.gz --no-same-owner -C {{ rosa_binary_path }}
+    creates: "{{ rosa_binary_path }}/rosa"
 
 - name: cleanup archive file
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

- The `ansible.builtin.unarchive` module internally calls `sudo` for its stat check even when `become: false` is set at the play level, causing every ROSA-based destroy job to fail with `sudo: command not found` inside the EE container
- Replaces the destroy-path `unarchive` task with a direct `tar` command, which avoids the module's internal stat behavior entirely
- The provision-path `unarchive` is unchanged (it uses `become: true` and needs root for ownership)

## Impact

- 140+ destroy failures per month on `ocp-dr-trident-binder` alone
- Affects all `rosa-consolidated` based catalog items
- Jira: [RHDPOPS-23828](https://redhat.atlassian.net/browse/RHDPOPS-23828)

## Error

```
TASK [Unzip rosa-linux.tar.gz]
ansible.errors.AnsibleError: Failed to get information on remote file (/tmp):
  /bin/sh: sudo: command not found
```

Confirmed on both prod0 (DAL12) and prod1 (WDC07) controllers across multiple guids.

## Test plan

- [ ] Deploy a `rosa-consolidated` based item on integration (e.g. trident-base)
- [ ] Destroy it and verify the ROSA CLI tar extraction succeeds
- [ ] Confirm destroy completes without `sudo: command not found`