### PR TITLE
Allow destroy to proceed when EC2 GPU instances cannot start

### DIFF
--- a/ansible/configs/ocp4-cluster/ec2_instances_start.yaml
+++ b/ansible/configs/ocp4-cluster/ec2_instances_start.yaml
@@ -18,6 +18,7 @@
     state: started
     wait: false
   loop: "{{ r_stopped_instances.instances }}"
+  ignore_errors: true
 
 - name: Wait until all EC2 instances are running
   when: r_stopped_instances.instances | length > 0
@@ -30,3 +31,4 @@
   until: r_running_instances.instances | length | int >= r_stopped_instances.instances | length | int
   delay: 10
   retries: 60
+  ignore_errors: true


### PR DESCRIPTION
## Summary

- Add `ignore_errors: true` to the EC2 instance start and wait tasks in `ocp4-cluster/ec2_instances_start.yaml`
- GPU instance types (g6.12xlarge, g6.16xlarge) frequently hit `InsufficientInstanceCapacity` during destroy, blocking cleanup of all downstream resources (VPCs, security groups, EBS volumes)
- AWS terminates stopped instances without issue -- they do not need to be running first

## Impact

- 84 destroy failures in 30 days for openshift-ai-v3 alone
- $8,183/mo in leaked cloud costs from orphaned resources
- Prior art: Ahsen Shah's PR #9769 used the same pattern for similar GPU capacity issues

## Test plan

- [ ] Provision an openshift-ai-v3 environment
- [ ] Verify destroy completes successfully
- [ ] Confirm no regressions for non-GPU ocp4-cluster destroys