### PR TITLE
fix(ee-multicloud-public): port OCP container group entrypoint fixes

### DIFF
--- a/tools/execution_environments/ee-multicloud-public/ansible.cfg
+++ b/tools/execution_environments/ee-multicloud-public/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 nocows                  = 1
 roles_path              = dynamic-roles:roles:roles-infra:roles_studentvm:roles_ocp_workloads
+collections_path        = /home/runner/.ansible/collections:/collections:/usr/share/ansible/collections
 forks                   = 50
 become                  = False
 gathering               = smart

--- a/tools/execution_environments/ee-multicloud-public/entrypoint.sh
+++ b/tools/execution_environments/ee-multicloud-public/entrypoint.sh
@@ -154,6 +154,92 @@ if [ ! -d "/runner/requirements_collections/ansible_collections" ]; then
 fi
 export HOME=/home/runner
 
-# chain exec whatever we were asked to run (ideally an init system) to keep any envvar state we've set
-log_debug "chain exec-ing requested command $*"
-exec "${@}"
+# Ensure collections path includes all expected locations.
+# AAP may override this, so we set it explicitly to include all paths.
+if [ -z "${ANSIBLE_COLLECTIONS_PATH:-}" ]; then
+  export ANSIBLE_COLLECTIONS_PATH="/home/runner/.ansible/collections:/collections:/usr/share/ansible/collections"
+else
+  export ANSIBLE_COLLECTIONS_PATH="/home/runner/.ansible/collections:${ANSIBLE_COLLECTIONS_PATH}"
+fi
+
+mkdir -p /home/runner/.ansible/collections 2>/dev/null || true
+chmod -R ug+rwx /home/runner/.ansible/collections 2>/dev/null || true
+
+log_debug "Original arguments: $*"
+
+export ORIGINAL_ARGUMENTS=("$@")
+args=("$@")
+
+# Path to the optional dynamic dependency installer
+INSTALL_PLAYBOOK="./ansible/install_dynamic_dependencies.yml"
+
+# Detect Kubernetes environment (container group on OCP/k8s).
+# KUBERNETES_SERVICE_HOST is injected by k8s into every pod. If set, we know
+# we're running in a container group, not on a bare-metal execution node.
+# In this mode, job data (inventory, extravars) arrives via the receptor stdin
+# stream after ansible-runner worker starts — it is NOT on disk when the
+# entrypoint runs. We install an ansible-playbook wrapper that runs the dynamic
+# dependency install after ansible-runner unpacks the job data but before the
+# actual playbook is parsed.
+if [[ -n "${KUBERNETES_SERVICE_HOST:-}" ]]; then
+  log_debug "Kubernetes environment detected. Installing ansible-playbook wrapper."
+
+  WRAPPER_DIR="/runner/.ep-wrapper/bin"
+  mkdir -p "${WRAPPER_DIR}"
+
+  cat > "${WRAPPER_DIR}/ansible-playbook" <<'WRAPPER'
+#!/usr/bin/env bash
+set -eu
+
+REAL_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '.ep-wrapper' | tr '\n' ':' | sed 's/:$//')
+REAL=$(PATH="$REAL_PATH" command -v ansible-playbook)
+
+INSTALL_PLAYBOOK="./ansible/install_dynamic_dependencies.yml"
+
+if [ -z "${_EP_DEPS_INSTALLED:-}" ] && [ -f /runner/env/extravars ] && [ -f "${INSTALL_PLAYBOOK}" ]; then
+  export _EP_DEPS_INSTALLED=1
+  "${REAL}" "${INSTALL_PLAYBOOK}" \
+    -i /runner/inventory/hosts \
+    -e @/runner/env/extravars \
+    2>&1 || true
+fi
+
+exec "${REAL}" "$@"
+WRAPPER
+
+  chmod +x "${WRAPPER_DIR}/ansible-playbook"
+
+  export PATH="${WRAPPER_DIR}:${PATH}"
+
+  exec "${ORIGINAL_ARGUMENTS[@]}"
+fi
+
+# Detect AAP execution node environment (-u root pattern)
+AAP=0
+for ((i = 1; i < ${#args[@]}; i++)); do
+  if [[ "${args[i]}" == "-u" && "${args[i+1]:-}" == "root" ]]; then
+    AAP=1
+    break
+  fi
+done
+
+if (( AAP == 1 )); then
+  log_debug "AAP environment detected. Running with fixed extra-vars"
+  if [ -f "${INSTALL_PLAYBOOK}" ]; then
+    /usr/local/bin/ansible-playbook "${INSTALL_PLAYBOOK}" -i /runner/inventory/hosts -e @/runner/env/extravars
+  else
+    log_debug "Install playbook ${INSTALL_PLAYBOOK} not found, skipping dynamic dependency install"
+  fi
+else
+  shift 2
+  log_debug "Non-AAP environment. Running with processed arguments"
+  log_debug "Remaining arguments: $*"
+  if [ -f "${INSTALL_PLAYBOOK}" ]; then
+    /usr/local/bin/ansible-playbook "${INSTALL_PLAYBOOK}" "$@"
+  else
+    log_debug "Install playbook ${INSTALL_PLAYBOOK} not found, skipping dynamic dependency install"
+  fi
+fi
+
+log_debug "chain exec-ing requested command: ${ORIGINAL_ARGUMENTS[*]}"
+exec "${ORIGINAL_ARGUMENTS[@]}"


### PR DESCRIPTION
## Summary

Port entrypoint fixes from [rhpds/agnosticd-v2](https://github.com/rhpds/agnosticd-v2/tree/main/tools/execution_environments/ee-multicloud-public) that enable `ee-multicloud-public` to work on AAP 2.4+ when running jobs via **container groups on OpenShift**.

This ports the following PRs:
- [rhpds/agnosticd-v2#133](https://github.com/rhpds/agnosticd-v2/pull/133) — Kubernetes detection + ansible-playbook wrapper
- [rhpds/agnosticd-v2#162](https://github.com/rhpds/agnosticd-v2/pull/162) — file existence guards for v1 projects
- [rhpds/agnosticd-v2#164](https://github.com/rhpds/agnosticd-v2/pull/164) — variable scoping fix for `set -eu`

## Problem

When AAP runs jobs via container groups on OCP, pods start with `ansible-runner worker --private-data-dir=/runner`. Job data (inventory, extravars) arrives via the receptor stdin stream **after** the entrypoint completes — it is not on disk at entrypoint time.

The current entrypoint does a simple `exec "${@}"`, which works for basic cases but:
1. Does not set `ANSIBLE_COLLECTIONS_PATH`, so AAP may not find installed collections
2. Does not handle dynamic dependency installation for projects that use it
3. Has no awareness of the three different execution contexts (OCP container group, AAP bare-metal execution node, ansible-navigator)

## Solution

### `entrypoint.sh`
- **Kubernetes detection** via `KUBERNETES_SERVICE_HOST` env var (injected by k8s into every pod)
- **ansible-playbook wrapper** installed at `/runner/.ep-wrapper/bin/` that shadows the real binary — when ansible-runner later invokes `ansible-playbook`, the wrapper installs dynamic dependencies first (now that job data is available), then `exec`s the real binary
- **AAP execution node detection** via `-u root` argument pattern for bare-metal AAP
- **File existence guards** on `install_dynamic_dependencies.yml` — v1 projects that lack this file skip gracefully
- **`ANSIBLE_COLLECTIONS_PATH`** set explicitly with `/home/runner/.ansible/collections`, `/collections`, and `/usr/share/ansible/collections`
- **Collections directory** created with correct permissions

### `ansible.cfg`
- Added `collections_path` to match the entrypoint's `ANSIBLE_COLLECTIONS_PATH`

## Compatibility

- **agnosticd v1 projects**: The `install_dynamic_dependencies.yml` file won't exist, so all three code paths (K8s, AAP, navigator) skip dependency installation gracefully via the `[ -f ]` guard
- **agnosticd v2 projects**: Full dynamic dependency installation works across all execution contexts
- **ansible-navigator**: Continues to work via the `shift 2` fallback path
- **Bare-metal AAP**: Detected via `-u root` pattern, same as upstream

## Test plan

- [ ] Run a v1 project job on OCP container group — should complete without entrypoint errors
- [ ] Run a v1 project job on bare-metal AAP execution node — should skip dependency install gracefully
- [ ] Run with ansible-navigator locally — should work as before
- [ ] Verify `ANSIBLE_COLLECTIONS_PATH` is set correctly in all three modes