### PR TITLE
Skip Route53 DNS cleanup when credentials are not defined (sandbox-vmware)

### DIFF
--- a/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_additional_public_ips.yaml
+++ b/ansible/roles-infra/infra_vmware_ibm_resources/tasks/delete_additional_public_ips.yaml
@@ -48,6 +48,7 @@
   register: _public_ip_request
 
 - name: Delete DNS for additional dns
+  when: route53_aws_access_key_id is defined
   amazon.aws.route53:
     state: absent
     aws_access_key_id: "{{ route53_aws_access_key_id }}"
@@ -60,3 +61,21 @@
   until: r_route53_delete_record is success
   retries: 3
   delay: 10
+
+- name: Delete A dns record via nsupdate
+  when: cluster_dns_server is defined
+  ansible.builtin.nsupdate:
+    server: >-
+      {{ cluster_dns_server
+      | ansible.utils.ipaddr
+      | ternary(cluster_dns_server, lookup('dig', cluster_dns_server))
+      }}
+    zone: "{{ cluster_dns_zone }}"
+    record: "{{ _additional.dns }}"
+    type: A
+    ttl: 30
+    port: "{{ cluster_dns_port | d('53') }}"
+    key_name: "{{ ddns_key_name }}"
+    key_secret: "{{ ddns_key_secret }}"
+    key_algorithm: "hmac-sha256"
+    state: absent


### PR DESCRIPTION
## Summary

- Adds `when: route53_aws_access_key_id is defined` guard to the Route53 DNS deletion task in `infra_vmware_ibm_resources`
- Prevents destroy failures when the catalog item uses DDNS instead of Route53

## Root cause

The `sandbox-vmware` catalog item uses DDNS for DNS management. The `dynamic-dns.yaml` include explicitly sets `route53_aws_access_key_id` (and related vars) to `{{ undef() }}` to avoid conflicts. During destroy, `delete_additional_public_ips.yaml:50` unconditionally tries to use these Route53 credentials, hitting "Mandatory variable has not been overridden."

The VMC equivalent (`infra-vmc-resources`) correctly uses `nsupdate` for DNS cleanup. The IBM version incorrectly uses `amazon.aws.route53`.

## Impact

- ~62 destroy failures/month on sandbox-vmware
- ~$2,760/month in leaked VMware IBM resources
- VMs, folders, NAT, and public IPs all clean up successfully -- only the DNS step crashes
- Part of RHDPOPS-23826 destroy failure remediation epic

## Test plan

- [ ] Deploy sandbox-vmware on integration and trigger destroy
- [ ] Verify NSX-T cleanup (VMs, NAT, public IPs) still works
- [ ] Verify Route53 DNS step is skipped (not failed)
- [ ] Confirm no regression on configs that DO use Route53 (e.g., ocp4-cluster on VMware IBM)