### PR TITLE
Handle JSONDecodeError in assisted-destroy list_clusters

### DIFF
--- a/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-destroy/tasks/main.yaml
@@ -70,14 +70,17 @@
         offline_token: "{{ ai_offline_token }}"
         owner: true
       register: listclusters
+      ignore_errors: true
 
     - name: Filter the created clusters
       ansible.builtin.set_fact:
         cluster_id: "{{ item.id }}"
-      when: item.name == cluster_name
-      loop: "{{ listclusters.result }}"
+      when:
+        - listclusters is succeeded
+        - item.name == cluster_name
+      loop: "{{ listclusters.result | default([]) }}"
       loop_control:
-        label: "{{ item.name }}"
+        label: "{{ item.name | default('unknown') }}"
 
     - name: Remove Assisted Installer Cluster
       rhpds.assisted_installer.delete_cluster:


### PR DESCRIPTION
## Summary
- Add `ignore_errors: true` to the `list_clusters` task in `host-ocp4-assisted-destroy` so destroy proceeds when the Assisted Installer API returns an empty response body
- Add `default([])` guard on the loop and `listclusters is succeeded` condition on the filter task
- Prevents `JSONDecodeError: Expecting value: line 1 column 1` from blocking destroy cleanup

## Context
This fixes destroy failures on `aap-product-demos-cnv-aap25` and any other catalog item using Assisted Installer on CNV. The `list_clusters` module crashes when the API returns an empty body, but the destroy should proceed to clean up DNS, Ceph, and other resources regardless.

## Test plan
- [ ] Deploy `aap-product-demos-cnv-aap25` on integration
- [ ] Trigger destroy and verify the assisted-destroy role completes
- [ ] Confirm remaining cleanup tasks (DNS, Ceph) still execute after list_clusters failure