### PR TITLE
Replace static pause with CRD wait for NVIDIA GPU operator

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/tasks/nvidia_gpu_operator.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_nvidia_gpu_setup/tasks/nvidia_gpu_operator.yml
@@ -22,11 +22,23 @@
   retries: 40
   delay: 6
 
-- name: 120 second pause for NVIDIA GPU operator setup
-  pause:
-    seconds: 180
+- name: Wait for NVIDIA GPU ClusterPolicy CRD
+  kubernetes.core.k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: clusterpolicies.nvidia.com
+  register: r_gpu_crd
+  retries: 60
+  delay: 10
+  until:
+    - r_gpu_crd.resources is defined
+    - r_gpu_crd.resources | length == 1
 
 - name: Setup NVIDIA GPU Cluster Policy
   kubernetes.core.k8s:
     state: present
     definition: "{{ lookup('file', 'nvidia_gpu_clusterpolicy.json') | from_yaml }}"
+  retries: 10
+  delay: 15
+  register: r_gpu_clusterpolicy
+  until: r_gpu_clusterpolicy is not failed


### PR DESCRIPTION
## Summary

- Replace the brittle 180-second static pause with a proper CRD existence check before creating the NVIDIA GPU ClusterPolicy resource
- Add retry logic to the ClusterPolicy creation task itself

## Problem

The `ocp4_workload_nvidia_gpu_setup` role fails on llm-d-intro (and other GPU workloads) with:

```
"Failed to find exact match for nvidia.com/v1.ClusterPolicy by [kind, name, singularName, shortNames]"
```

The NVIDIA GPU operator subscription is created, then a fixed 180-second pause runs, then the playbook immediately tries to create a `ClusterPolicy` CR. If the operator hasn't finished installing (CRD not yet registered), the task fails with no retry.

This causes **0% deploy success rate** for llm-d-intro -- 18 consecutive failures over 7 days, 93 failures in 30 days.

## Fix

1. Replace the static `pause: 180` with a `k8s_info` loop that waits for the `clusterpolicies.nvidia.com` CRD to exist (up to 10 minutes, checking every 10 seconds)
2. Add `retries: 10` with `delay: 15` on the ClusterPolicy creation task for transient failures

This follows the same pattern used by other operator-dependent roles in this repo (e.g., `ocp4_workload_quarkus_super_heroes_demo` waiting for Kafka CRD).

## Test plan

- [ ] Deploy llm-d-intro on AWS with GPU instance -- verify ClusterPolicy is created after CRD wait
- [ ] Verify no regression on other configs using this role (openshift-ai-v3, ai-driven-aap)

## Affected catalog items

- `published.llm-d-intro` (0% success rate, fully broken)
- Any other catalog item using `ocp4_workload_nvidia_gpu_setup` role