### PR TITLE
feat(sandbox-ibm): Add IAM policies for containers-kubernetes and related services

### DIFF
--- a/ansible/roles-infra/sandbox-ibm/tasks/create_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_access.yml
@@ -125,6 +125,10 @@
   retries: 3
   delay: 10
 
+- name: Create sandbox policies for access group
+  when: not ibm_rhoic_install
+  ansible.builtin.include_tasks: create_sandbox_policies.yml
+
 - name: Set access group for RHOIC install
   when: ibm_rhoic_install
   ansible.builtin.include_tasks: create_rhoic_access_groups.yml

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_sandbox_policies.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_sandbox_policies.yml
@@ -21,7 +21,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -42,7 +42,7 @@
             operator: "stringEquals"
             value: "containers-kubernetes"
   register: r_sandbox_kube_policy
-  until: r_sandbox_kube_policy.status == 201
+  until: r_sandbox_kube_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -52,7 +52,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -72,7 +72,7 @@
             operator: "stringEquals"
             value: "cloud-object-storage"
   register: r_sandbox_cos_policy
-  until: r_sandbox_cos_policy.status == 201
+  until: r_sandbox_cos_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -82,7 +82,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -102,7 +102,7 @@
             operator: "stringEquals"
             value: "container-registry"
   register: r_sandbox_registry_policy
-  until: r_sandbox_registry_policy.status == 201
+  until: r_sandbox_registry_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -112,7 +112,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -134,7 +134,7 @@
             operator: "stringEquals"
             value: "iam-identity"
   register: r_sandbox_iam_policy
-  until: r_sandbox_iam_policy.status == 201
+  until: r_sandbox_iam_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -144,7 +144,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -165,7 +165,7 @@
             operator: "stringEquals"
             value: "cloudcerts"
   register: r_sandbox_cloudcerts_policy
-  until: r_sandbox_cloudcerts_policy.status == 201
+  until: r_sandbox_cloudcerts_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -175,7 +175,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -195,7 +195,7 @@
             operator: "stringEquals"
             value: "globalcatalog"
   register: r_sandbox_catalog_policy
-  until: r_sandbox_catalog_policy.status == 201
+  until: r_sandbox_catalog_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -205,7 +205,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -227,7 +227,7 @@
             operator: "stringEquals"
             value: "kms"
   register: r_sandbox_kms_policy
-  until: r_sandbox_kms_policy.status == 201
+  until: r_sandbox_kms_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -237,7 +237,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -260,7 +260,7 @@
             operator: "stringEquals"
             value: "{{ sandbox_default_resource_group }}"
   register: r_sandbox_rg_policy
-  until: r_sandbox_rg_policy.status == 201
+  until: r_sandbox_rg_policy.status in [201, 409]
   retries: 3
   delay: 10
 
@@ -270,7 +270,7 @@
     method: POST
     headers:
       Authorization: Bearer {{ auth_token }}
-    status_code: 201
+    status_code: [201, 409]
     body_format: json
     body:
       type: "access"
@@ -291,6 +291,6 @@
             operator: "stringEquals"
             value: "schematics"
   register: r_sandbox_schematics_policy
-  until: r_sandbox_schematics_policy.status == 201
+  until: r_sandbox_schematics_policy.status in [201, 409]
   retries: 3
   delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/create_sandbox_policies.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/create_sandbox_policies.yml
@@ -1,0 +1,296 @@
+---
+- name: Get resource groups
+  ansible.builtin.uri:
+    url: "https://resource-controller.cloud.ibm.com/v2/resource_groups?account_id={{ sandbox_account_id }}"
+    headers:
+      Authorization: Bearer {{ auth_token }}
+  register: r_resource_groups
+  until: r_resource_groups.status == 200
+  retries: 3
+  delay: 10
+
+- name: Set default resource group ID
+  ansible.builtin.set_fact:
+    sandbox_default_resource_group: "{{ r_resource_groups.json | to_json | from_json | json_query(_rg_query) }}"
+  vars:
+    _rg_query: "resources[?contains(keys(@), 'name')] | [?name=='Default'].id | [0]"
+
+- name: Create containers-kubernetes policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Containers-kubernetes policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Administrator"
+        - role_id: "crn:v1:bluemix:public:iam::::serviceRole:Writer"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "containers-kubernetes"
+  register: r_sandbox_kube_policy
+  until: r_sandbox_kube_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create cloud object storage policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Cloud object storage policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Administrator"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "cloud-object-storage"
+  register: r_sandbox_cos_policy
+  until: r_sandbox_cos_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create container registry policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Container registry policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Administrator"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "container-registry"
+  register: r_sandbox_registry_policy
+  until: r_sandbox_registry_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create iam-identity policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - IAM-identity policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam-identity::::serviceRole:ServiceIdCreator"
+        - role_id: "crn:v1:bluemix:public:iam-identity::::serviceRole:UserApiKeyCreator"
+        - role_id: "crn:v1:bluemix:public:iam::::role:Editor"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "iam-identity"
+  register: r_sandbox_iam_policy
+  until: r_sandbox_iam_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create cloudcerts policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Cloudcerts policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Editor"
+        - role_id: "crn:v1:bluemix:public:iam::::serviceRole:Manager"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "cloudcerts"
+  register: r_sandbox_cloudcerts_policy
+  until: r_sandbox_cloudcerts_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create global catalog policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Global catalog policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Viewer"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "globalcatalog"
+  register: r_sandbox_catalog_policy
+  until: r_sandbox_catalog_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create kms policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - KMS policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Administrator"
+        - role_id: "crn:v1:bluemix:public:iam::::serviceRole:Manager"
+        - role_id: "crn:v1:bluemix:public:kms::::serviceRole:KeyPurge"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "kms"
+  register: r_sandbox_kms_policy
+  until: r_sandbox_kms_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create default resource group policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Default resource group policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Viewer"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "resourceType"
+            operator: "stringEquals"
+            value: "resource-group"
+          - name: "resource"
+            operator: "stringEquals"
+            value: "{{ sandbox_default_resource_group }}"
+  register: r_sandbox_rg_policy
+  until: r_sandbox_rg_policy.status == 201
+  retries: 3
+  delay: 10
+
+- name: Create schematics policy
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies"
+    method: POST
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 201
+    body_format: json
+    body:
+      type: "access"
+      description: "Sandbox - Schematics policy"
+      subjects:
+        - attributes:
+          - name: "access_group_id"
+            value: "{{ sandbox_access_group }}"
+      roles:
+        - role_id: "crn:v1:bluemix:public:iam::::role:Administrator"
+        - role_id: "crn:v1:bluemix:public:iam::::serviceRole:Manager"
+      resources:
+        - attributes:
+          - name: "accountId"
+            operator: "stringEquals"
+            value: "{{ sandbox_account_id }}"
+          - name: "serviceName"
+            operator: "stringEquals"
+            value: "schematics"
+  register: r_sandbox_schematics_policy
+  until: r_sandbox_schematics_policy.status == 201
+  retries: 3
+  delay: 10

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_access.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_access.yml
@@ -45,6 +45,10 @@
   retries: 3
   delay: 10
 
+- name: Clean up sandbox policies
+  when: not ibm_rhoic_install
+  ansible.builtin.include_tasks: remove_sandbox_policies.yml
+
 - name: Clean up IBM RHOIC policies and access groups
   when: ibm_rhoic_install
   ansible.builtin.include_tasks: remove_rhoic_access.yml

--- a/ansible/roles-infra/sandbox-ibm/tasks/remove_sandbox_policies.yml
+++ b/ansible/roles-infra/sandbox-ibm/tasks/remove_sandbox_policies.yml
@@ -1,0 +1,42 @@
+---
+- name: Get Access Group ID
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v2/groups?account_id={{ sandbox_account_id }}"
+    headers:
+      Authorization: Bearer {{ auth_token }}
+  register: r_sandbox_access_groups
+  until: r_sandbox_access_groups.status == 200
+  retries: 3
+  delay: 10
+
+- name: Set access group ID
+  ansible.builtin.set_fact:
+    sandbox_access_group: "{{ r_sandbox_access_groups['json']['groups'] | json_query(ag_query) }}"
+  vars:
+    ag_query: "[?name=='sandbox_ag'].id | [0]"
+
+- name: Get policies for sandbox access group
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies?account_id={{ sandbox_account_id }}&access_group_id={{ sandbox_access_group }}"
+    headers:
+      Authorization: Bearer {{ auth_token }}
+  register: r_sandbox_policies
+  until: r_sandbox_policies.status == 200
+  retries: 3
+  delay: 10
+
+- name: Delete sandbox policies
+  when: r_sandbox_policies.json.policies | length > 0
+  ansible.builtin.uri:
+    url: "https://iam.cloud.ibm.com/v1/policies/{{ item }}"
+    method: DELETE
+    headers:
+      Authorization: Bearer {{ auth_token }}
+    status_code: 204
+  loop: "{{ r_sandbox_policies.json | to_json | from_json | json_query(_policy_query) }}"
+  vars:
+    _policy_query: "policies[?contains(keys(@), 'description') && starts_with(description, 'Sandbox -')].id"
+  register: r_sandbox_policy_delete
+  until: r_sandbox_policy_delete.status == 204
+  retries: 3
+  delay: 10


### PR DESCRIPTION
## Summary

- Add dynamic IAM policy creation for the standard IBM sandbox flow (`sandbox_ag` access group)
- Adds policies for: `containers-kubernetes`, `cloud-object-storage`, `container-registry`, `iam-identity`, `cloudcerts`, `globalcatalog`, `kms`, `resource-group`, and `schematics`
- Add corresponding cleanup on destroy (deletes policies matching `"Sandbox - "` description prefix)

## Context

The dedicated RHOIC catalog item (`IBM_RG_RHOIC`) was retired. Users are now told to deploy RHOIC within the IBM Public Cloud Blank Open Environment sandbox. However, the `sandbox_ag` access group only has VPC Editor and resource group Viewer policies — it's missing the `containers-kubernetes` permissions (and other related services) needed to install and manage OpenShift clusters.

Users see these errors when navigating to "Red Hat OpenShift on IBM Cloud" in the console:
1. "There was a problem loading the network data" — missing Viewer platform role for `containers-kubernetes`
2. "Unable to determine if a Cloud Pak license entitlement has been assigned" — same missing role

## Changes

| File | Change |
|------|--------|
| `create_sandbox_policies.yml` | **New** — creates 9 IAM policies on `sandbox_ag` (mirrors `create_rhoic_policies.yml`) |
| `remove_sandbox_policies.yml` | **New** — deletes policies with `"Sandbox - "` description prefix on destroy |
| `create_access.yml` | Includes `create_sandbox_policies.yml` for non-RHOIC flow |
| `remove_access.yml` | Includes `remove_sandbox_policies.yml` for non-RHOIC flow |

## Security

- Existing cleanup already deletes **all SIDs** and removes **all users** (except account admin) on destroy
- New policies are cleaned up by description prefix, matching the pattern used by the RHOIC flow
- No new access groups created — policies attach to the existing `sandbox_ag`

## Test plan

- [x] Provision IBM Public Cloud Blank Open Environment in dev
- [ ] Verify user can navigate to "Red Hat OpenShift on IBM Cloud" without permission errors
- [ ] Verify user can create an OpenShift cluster in the sandbox
- [ ] Destroy the environment and verify policies are cleaned up from `sandbox_ag`