### PR TITLE
feat(acm-observability): add optional Prometheus retention config

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -157,5 +157,5 @@
     namespace: "{{ namespace }}"
   register: r_vm_status
   until: r_vm_status.resources[0].status.printableStatus|default('') == "Running"
-  retries: "{{ ai_workers_vm_ready_retries | default(120) }}"
+  retries: "{{ ai_workers_vm_ready_retries | default(30) }}"
   delay: "{{ ai_workers_vm_ready_delay | default(10) }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -157,5 +157,5 @@
     namespace: "{{ namespace }}"
   register: r_vm_status
   until: r_vm_status.resources[0].status.printableStatus|default('') == "Running"
-  retries: "{{ ai_workers_vm_ready_retries | default(30) }}"
-  delay: "{{ ai_workers_vm_ready_delay | default(10) }}"
+  retries: "{{ ai_workers_vm_ready_retries }}"
+  delay: "{{ ai_workers_vm_ready_delay }}"

--- a/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/kubevirt/create_workers.yaml
@@ -157,5 +157,5 @@
     namespace: "{{ namespace }}"
   register: r_vm_status
   until: r_vm_status.resources[0].status.printableStatus|default('') == "Running"
-  retries: 30
-  delay: 10
+  retries: "{{ ai_workers_vm_ready_retries | default(120) }}"
+  delay: "{{ ai_workers_vm_ready_delay | default(10) }}"

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -12,6 +12,8 @@ ai_control_plane_etcd_disk_size: 8Gi
 ai_workers_cores: 16
 ai_workers_memory: 64Gi
 ai_workers_root_disk_size: 100Gi
+ai_workers_vm_ready_retries: 30
+ai_workers_vm_ready_delay: 10
 ai_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 ai_ocp_vmname_sno: "sno-{{ cluster_name }}"
 ai_ocp_vmname_master_prefix: "control-plane-{{ cluster_name }}"

--- a/ansible/roles_ocp_workloads/ocp4_workload_acm_multicluster_observability/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_acm_multicluster_observability/defaults/main.yml
@@ -13,3 +13,8 @@ tmp_kubeconfig: "{{ tmp_dir }}/.kube/config"
 
 ## MultiCluster Observability related variables ##
 ocp4_workload_acm_multicluster_observability_namespace: open-cluster-management-observability
+
+## Cluster Prometheus retention (applied to cluster-monitoring-config ConfigMap)
+## Set these in your catalog item to cap emptyDir Prometheus disk usage.
+ocp4_workload_cluster_monitoring_retention: ""
+ocp4_workload_cluster_monitoring_retention_size: ""

--- a/ansible/roles_ocp_workloads/ocp4_workload_acm_multicluster_observability/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_acm_multicluster_observability/tasks/workload.yml
@@ -119,6 +119,57 @@
         state: present
         definition: "{{ lookup('template','./templates/multiclusterobservability-cr.yml.j2') | from_yaml }}"
 
+- name: Set Prometheus retention in cluster-monitoring-config
+  when: ocp4_workload_cluster_monitoring_retention | default('') | length > 0
+  block:
+    - name: Get current cluster-monitoring-config
+      kubernetes.core.k8s_info:
+        api_version: v1
+        kind: ConfigMap
+        name: cluster-monitoring-config
+        namespace: openshift-monitoring
+      register: r_cluster_monitoring_config
+
+    - name: Parse current monitoring config
+      set_fact:
+        _current_monitoring_config: >-
+          {{ (r_cluster_monitoring_config.resources[0].data['config.yaml'] | default('{}'))
+             | from_yaml | default({}) }}
+
+    - name: Build retention settings
+      set_fact:
+        _prometheus_retention: >-
+          {{ _current_monitoring_config.get('prometheusK8s', {})
+             | combine({
+                 'retention': ocp4_workload_cluster_monitoring_retention
+               })
+          }}
+
+    - name: Add retentionSize if set
+      when: ocp4_workload_cluster_monitoring_retention_size | default('') | length > 0
+      set_fact:
+        _prometheus_retention: >-
+          {{ _prometheus_retention
+             | combine({
+                 'retentionSize': ocp4_workload_cluster_monitoring_retention_size
+               })
+          }}
+
+    - name: Apply merged cluster-monitoring-config
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: cluster-monitoring-config
+            namespace: openshift-monitoring
+          data:
+            config.yaml: >-
+              {{ _current_monitoring_config
+                 | combine({'prometheusK8s': _prometheus_retention}, recursive=true)
+                 | to_nice_yaml }}
+
 # Leave this as the last task in the playbook.
 - name: workload tasks complete
   debug:


### PR DESCRIPTION
## Summary
- Add optional Prometheus retention and retentionSize support to the `ocp4_workload_acm_multicluster_observability` workload
- Uses read-merge-write pattern to safely patch `cluster-monitoring-config` without overwriting existing monitoring configuration
- Opt-in: only applies when `ocp4_workload_cluster_monitoring_retention` is set in the catalog item

## Context
HCP catalog items running Prometheus on emptyDir with default 15-day retention can fill 100Gi worker root disks, causing disk pressure cascades. This adds a reusable mechanism for any catalog item using this workload to cap Prometheus retention.

## Usage
Set in your catalog item's `common.yaml`:
```yaml
ocp4_workload_cluster_monitoring_retention: 3d
ocp4_workload_cluster_monitoring_retention_size: 40GB
```

## Test plan
- [ ] Deploy a catalog item with these variables set
- [ ] Verify `cluster-monitoring-config` ConfigMap contains retention settings
- [ ] Verify existing ConfigMap content (enableUserWorkload, additionalAlertmanagerConfigs) is preserved
- [ ] Deploy without the variables set and verify no change to cluster-monitoring-config