### PR TITLE
Fix rosa-consolidated HCP destroy Terraform install failure

### DIFF
--- a/ansible/configs/rosa-consolidated/uninstall_rosa.yml
+++ b/ansible/configs/rosa-consolidated/uninstall_rosa.yml
@@ -30,11 +30,10 @@
   block:
   - name: Install Terraform
     when: rosa_install_terraform | default(true) | bool
-    ansible.builtin.unarchive:
-      src: "{{ rosa_terraform_url }}"
-      remote_src: true
-      dest: /tmp
-      mode: ug=rwx,o=rx
+    ansible.builtin.shell: >-
+      curl -sLo /tmp/terraform.zip "{{ rosa_terraform_url }}"
+      && unzip -o /tmp/terraform.zip -d /tmp
+      && chmod ug=rwx,o=rx /tmp/terraform
     retries: 10
     register: r_terraform
     until: r_terraform is success


### PR DESCRIPTION
## Summary

- Replaces `ansible.builtin.unarchive` with a direct shell command for Terraform binary install during HCP destroy
- The `unarchive` module passes `--no-same-owner` to `unzip`, but `unzip 6.00` misinterprets this as `-n` (never overwrite), conflicting with `-o` (overwrite) and causing rc=10 on every attempt
- This exhausts all 10 retries and fails the entire HCP destroy pipeline, even though the ROSA cluster itself was successfully deleted upstream

## Impact

- **147 destroy failures** in the last 30 days for `ocp-dr-trident-binder`
- **$3,801 leaked cloud cost** from orphaned resources
- Jira: [RHDPOPS-23973](https://redhat.atlassian.net/browse/RHDPOPS-23973)

## Root cause

```
/usr/bin/unzip -o --no-same-owner terraform_1.11.2_linux_amd64.zip -d /tmp
caution: both -n and -o specified; ignoring -o
```

`unzip 6.00` (2009) does not support `--no-same-owner`. Ansible's `unarchive` module adds this flag automatically when running as root. The EE container runs as root, so every HCP destroy hits this.

## Fix

Replace `unarchive` with `curl + unzip + chmod` in a single shell command. Same retry logic preserved.

## Test plan

- [ ] Verify HCP destroy succeeds on integration (ocp-dr-trident-binder)
- [ ] Confirm Terraform binary is correctly installed at `/tmp/terraform`
- [ ] Confirm downstream `terraform destroy` for VPC cleanup runs