### PR TITLE
Fix cloud-native-camel: variablize Pipelines operator channel

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/defaults/main.yml
@@ -14,6 +14,12 @@ camel_ns_suffix: camel
 shared_tools_ns: shared-tools
 ocp4_workload_cloud_architecture_workshop_user_prefix: user
 # ------------------------------------------------
+# OpenShift Pipelines
+# ------------------------------------------------
+
+ocp4_workload_cloud_architecture_workshop_pipelines_operator_channel: pipelines-1.17
+
+# ------------------------------------------------
 # OpenShift Gitops
 # ------------------------------------------------
 

--- a/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_user_settings.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_summit_2024_cloud_native_camel/tasks/install_user_settings.yml
@@ -66,7 +66,7 @@
         namespace: openshift-operators
       spec:
         installPlanApproval: Automatic
-        channel: pipelines-1.14
+        channel: "{{ ocp4_workload_cloud_architecture_workshop_pipelines_operator_channel }}"
         name: openshift-pipelines-operator-rh
         source: redhat-operators
         sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Summary

The `cloud-native-camel` catalog item has been failing CI. The Pipelines operator channel `pipelines-1.14` was hardcoded in the task file and has since been removed from the Red Hat operator catalog. This caused OLM dependency resolution to fail globally, blocking all operator InstallPlans — including AMQ Streams, which is the visible timeout in the job log.

### What changed

- **`defaults/main.yml`** — added `ocp4_workload_cloud_architecture_workshop_pipelines_operator_channel: pipelines-1.17` (follows the same naming convention as GitOps, AMQ Streams, etc.)
- **`tasks/install_user_settings.yml`** — replaced hardcoded `pipelines-1.14` with the new variable

### Why this matters

The Pipelines channel was the only operator in this role with a hardcoded channel — GitOps uses `latest`, AMQ Streams uses a variable, etc. By variablizing it, agnosticV can now override the channel per catalog item without needing agnosticd code changes when Red Hat prunes old channels.

### Companion PR

- agnosticV: rhpds/agnosticv#27528 (adds the channel override to `cloud-native-camel/common.yaml`)

## Test plan

- [ ] Deploy `cloud-native-camel` on dev/integration after merge
- [ ] Confirm Pipelines operator installs on `pipelines-1.17` channel
- [ ] Confirm AMQ Streams, Gitea, cert-manager all install without OLM resolution errors