### PR TITLE
Support exclude parameter in CUDA repo configuration

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/setup_nvidia_cuda/tasks/main.yml
@@ -17,6 +17,7 @@
         baseurl: "{{ repo.baseurl }}"
         enabled: "{{ repo.enabled | default(true) }}"
         gpgcheck: "{{ repo.gpgcheck | default(false) }}"
+        exclude: "{{ repo.exclude | default(omit) }}"
       loop: "{{ setup_nvidia_cuda_rhel_repos }}"
       loop_control:
         loop_var: repo


### PR DESCRIPTION
## Summary
- Passes through the `exclude` field from repo config to `yum_repository` module in the `setup_nvidia_cuda` role
- Allows consumers to exclude specific packages (e.g. `cccl-13*` which obsoletes `cuda-cccl-12-8` and breaks CUDA 12.x installations)
- Uses `default(omit)` so existing configurations are unaffected

## Context
NVIDIA released `cccl-13-3` which obsoletes `cuda-cccl-12-8`, causing depsolve failures during RHAIIS provisioning. The CUDA repo needs an `exclude=cccl-13*` directive to prevent the obsoleting package from being considered. This change enables that by passing the `exclude` parameter through to the `yum_repository` module.

## Test plan
- [ ] Deploy RHAIIS catalog item with `exclude: "cccl-13*"` in repo config
- [ ] Verify CUDA toolkit and all dependencies install without depsolve errors
- [ ] Verify existing catalog items without `exclude` are unaffected