### PR TITLE
Add zstd prerequisite for ollama role

### DIFF
--- a/ansible/collections/ansible_collections/agnosticd/ai/roles/service_vm_ollama/tasks/main.yml
+++ b/ansible/collections/ansible_collections/agnosticd/ai/roles/service_vm_ollama/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Install prerequisites for Ollama
+  ansible.builtin.package:
+    name:
+      - zstd
+    state: present
+
 - name: Install Ollama including systemd service
   ansible.builtin.shell:
     cmd: "curl -fsSL https://ollama.com/install.sh | sh"


### PR DESCRIPTION
The Ollama install script now requires zstd for extraction. This adds zstd as a prerequisite package before running the installer.

Error without this fix:
```
ERROR: This version requires zstd for extraction. Please install zstd and try again:
  - RHEL/CentOS/Fedora: sudo dnf install zstd
```