### PR TITLE
Add --no-same-owner to output_dir restore unarchive

### DIFF
--- a/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
+++ b/ansible/roles/agnosticd_restore_output_dir/tasks/restore-from-s3.yml
@@ -31,6 +31,7 @@
     dest: "{{ output_dir }}"
     extra_opts:
     - --strip-components=1
+    - --no-same-owner
 
 - name: Remove archive file from output_dir
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

Cherry-pick of 7fcdb70ab to fix destroy failures on `cloud-architecture-workshop` (and likely other catalog items) when the provision runs on prod0/prod1 (OpenShift-based, UID 1001160000) but the destroy runs on aap2 (standalone AAP, UID 0). The `unarchive` task fails because `gtar` can't restore ownership to a UID that doesn't exist in the container.

Adding `--no-same-owner` tells tar to use the current user's ownership instead of the archived ownership.

## Failing jobs

- [Job 317038](https://aap2-prod-us-west-2.aap.infra.demo.redhat.com#/jobs/317038/) (x7xlb)
- [Job 317144](https://aap2-prod-us-west-2.aap.infra.demo.redhat.com#/jobs/317144/) (h4c55)
- [Job 316718](https://aap2-prod-us-west-2.aap.infra.demo.redhat.com#/jobs/316718/) (vg5c5)

## Test result
[https://prod1.apps.ocpv-infra02.wdc07.infra.demo.redhat.com/#/jobs/67281/](vscode-file://vscode-app/Applications/Cursor.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)

<img width="1598" height="923" alt="Screenshot 2026-07-28 at 12 23 10 PM" src="https://github.com/user-attachments/assets/1d460de9-3839-4a0f-b96c-215b9ca3f3cc" />
