### PR TITLE
Add user as owner of app registration during open-env provisioning

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -148,6 +148,19 @@
       until:
         - azapp.applications | length > 0
 
+    - name: Add user as owner of the application registration
+      when:
+        - internal_user | default(false) | bool
+      ansible.builtin.command: >-
+        az rest --method POST
+        --url "https://graph.microsoft.com/v1.0/applications/{{ azapp.applications[0].object_id }}/owners/$ref"
+        --headers "Content-Type=application/json"
+        --body "{\"@odata.id\": \"https://graph.microsoft.com/v1.0/directoryObjects/{{ azuser.ad_users[0].object_id }}\"}"
+      register: add_owner_result
+      failed_when:
+        - add_owner_result.rc != 0
+        - "'One or more added object references already exist' not in add_owner_result.stderr"
+
     - name: Get password
       when: azappcreate.changed
       set_fact: azpass="{{ azappcreate.stdout | from_json | json_query('password') }}"


### PR DESCRIPTION
## Summary
- Adds the requesting user as an Entra ID owner of the app registration (`api://openenv-{guid}`) created during Azure Open Environment provisioning
- Users currently get Custom-Owner on the subscription (ARM RBAC) but have no Entra ID ownership of the app registration, preventing them from managing credentials (client secrets)
- This affects all Azure subscription-based open environments, including those used for ARO external authentication (OIDC) testing

## Problem
The `open-env-azure-add-user-to-subscription` role creates a service principal via `az ad sp create-for-rbac`, but only the automation service principal becomes the app registration owner. The Entra ID admin portal is restricted to admin users, and the custom roles that previously granted credential management were revoked after a security incident. Users cannot create client secrets on the SP created for them.

## Fix
After the app registration is created and its info retrieved (`azapp`), a new task calls the Microsoft Graph API to add the requesting user as an owner of the app registration. This is idempotent — if the user is already an owner, it will not fail.

The task runs inside the existing `az login` / `az logout` block, using the same authenticated CLI session. It is guarded by `internal_user` (same pattern as the existing subscription role assignment task).

## Test plan
- [ ] Deploy an Azure subscription-based open environment with a Red Hat internal user
- [ ] Verify the requesting user appears as an owner of the `api://openenv-{guid}` app registration
- [ ] Verify the user can create a client secret via `az ad app credential reset --id <app-id> --append`
- [ ] Verify re-provisioning (idempotency) does not fail with "already exists" error