### PR TITLE
Handle idempotency for Add SP to group task

### DIFF
--- a/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-add-user-to-subscription/tasks/main.yml
@@ -185,6 +185,10 @@
         tenant: "{{ azure_tenant }}"
         present_members:
           - "{{ azsp.service_principals[0].object_id }}"
+      register: add_sp_to_group_result
+      failed_when:
+        - add_sp_to_group_result is failed
+        - "'already exist' not in add_sp_to_group_result.module_stderr | default('')"
 
     - name: Log out of Azure CLI
       command: >


### PR DESCRIPTION
## Summary
- The `azure_rm_adgroup` module throws a fatal error when the service principal is already a member of the `RH-RHPDS-Application Developer Role` group
- Adds `failed_when` to ignore the "already exist" error from the Microsoft Graph API
- Matches the idempotency pattern used by the existing `Set user as Owner for the subscription` task

## Problem
During Azure Open Environment provisioning, the `Add SP to group` task fails with `Request_BadRequest: "One or more added object references already exist"` if the SP is already a member of the group. Unlike the ARM-based `azure_rm_roleassignment` module, `azure_rm_adgroup` does not handle this case gracefully.

## Test plan
- [ ] Deploy an Azure subscription-based open environment
- [ ] Verify the provisioning completes successfully
- [ ] Re-run provisioning for the same environment and verify the task does not fail on the duplicate membership