### PR TITLE
Add VM-hosted showroom support to ansible-lightspeed env_type

### DIFF
--- a/ansible/configs/ansible-lightspeed/destroy_env.yml
+++ b/ansible/configs/ansible-lightspeed/destroy_env.yml
@@ -2,6 +2,28 @@
 - name: Import default destroy playbook
   import_playbook: ../../cloud_providers/{{cloud_provider}}_destroy_env.yml
 
+- name: Remove Showroom from bastion VM
+  hosts: bastions
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Stop and remove showroom podman containers
+      when: showroom_deploy_on_bastion_enable | default(false) | bool
+      block:
+        - name: Stop showroom systemd service
+          ansible.builtin.systemd:
+            name: showroom
+            state: stopped
+            enabled: false
+          ignore_errors: true
+
+        - name: Remove showroom podman pods and containers
+          ansible.builtin.shell: >-
+            podman pod rm -f showroom 2>/dev/null;
+            podman rm -fa 2>/dev/null;
+            true
+          ignore_errors: true
+
 - name: Delete Showroom
   hosts: localhost
   connection: local

--- a/ansible/configs/ansible-lightspeed/post_software.yml
+++ b/ansible/configs/ansible-lightspeed/post_software.yml
@@ -77,13 +77,27 @@
               subdomain_base: "{{ subdomain_base }}"
               subdomain_internal: "{{ aws_dns_zone_private_chomped | default('') }}"
 
+- name: Deploy Showroom on bastion VM
+  hosts: bastions
+  gather_facts: false
+  become: true
+  tags:
+    - step005_03
+    - post_software
+    - showroom
+  tasks:
+    - name: Deploy Showroom as podman containers on bastion
+      when: showroom_deploy_on_bastion_enable | default(false) | bool
+      include_role:
+        name: showroom
+
 - name: PostSoftware flight-check
   hosts: localhost
   connection: local
   gather_facts: false
   become: false
   tags:
-    - step005_03
+    - step005_04
     - post_software
   tasks:
 


### PR DESCRIPTION
## Summary

- Add a new play in `post_software.yml` that deploys the bundled `showroom` role on bastion hosts as podman containers, gated behind `showroom_deploy_on_bastion_enable` (default `false`)
- Add corresponding destroy path in `destroy_env.yml` to stop the showroom systemd service and remove podman containers on teardown
- Existing shared-cluster showroom path is unchanged — no impact to other catalog items using this env_type

## Motivation

The shared OCP cluster showroom pattern (`ocp4_workload_showroom`) has a namespace leak bug in its destroy path — namespaces are not cleaned up on teardown. This caused 622 orphaned namespaces on `cluster1.openshift.shared.redhatworkshops.io`, exhausting EBS volume attachment capacity and blocking new showroom pods from scheduling.

The VM-hosted pattern deploys showroom as podman containers directly on the bastion, eliminating the external cluster dependency entirely.