### PR TITLE
Fix showroom iframe quote and URL scheme for port 80

### DIFF
--- a/ansible/roles/showroom/tasks/60-showroom-verify.yml
+++ b/ansible/roles/showroom/tasks/60-showroom-verify.yml
@@ -5,11 +5,25 @@
 
 - name: Compute port suffix when non-standard port is used
   ansible.builtin.set_fact:
-    f_port_suffix: "{% if (showroom_primary_port | default(443) | int) != 443 %}:{{ showroom_primary_port }}{% endif %}"
+    f_port_suffix: >-
+      {% if (showroom_primary_port | default(443) | int) not in [443, 80] -%}
+      :{{ showroom_primary_port }}
+      {%- endif %}
+
+- name: Compute URL scheme
+  ansible.builtin.set_fact:
+    f_url_scheme: >-
+      {% if (showroom_primary_port | default(443) | int) == 80 -%}
+      http
+      {%- else -%}
+      https
+      {%- endif %}
 
 - name: Capture lab_ui_url as fact
   ansible.builtin.set_fact:
-    f_lab_ui_url: "https://{{ showroom_host }}{{ f_port_suffix | default('') }}/{{ showroom_primary_path }}"
+    f_lab_ui_url: >-
+      {{ f_url_scheme }}://{{ showroom_host -}}
+      {{ f_port_suffix | default('') }}/{{ showroom_primary_path }}
 
 - name: Output showroom view(s) URLs as userinfo and userdata
   agnosticd_user_info:

--- a/ansible/roles/showroom/templates/index.html.j2
+++ b/ansible/roles/showroom/templates/index.html.j2
@@ -15,7 +15,7 @@
 {% elif showroom_tab_services | length > 0 %}
     <div class="content">
 			<div class="split left">
-                <iframe id="doc"  src="./{{ showroom_component_name }}/"index.html" width="100%" style="border:none;"></iframe>
+                <iframe id="doc"  src="./{{ showroom_component_name }}/index.html" width="100%" style="border:none;"></iframe>
 			</div>
 			<div class="split right">
 				<div class="tab">


### PR DESCRIPTION
## Summary

- Fix stray quote in `index.html.j2` iframe src attribute (line 18) that caused 404 errors
- Fix `60-showroom-verify.yml` to use `http://` scheme when `showroom_primary_port` is 80, instead of hardcoding `https://`
- Suppress redundant port suffixes (`:80` for http, `:443` for https) in `lab_ui_url`

Needed for `rhel-podman-desktop` catalog item which runs showroom on bastion via podman (port 80, no TLS) alongside noVNC on port 443.