### PR TITLE
Fix Azure DevOps cleanup loop_control.label template error

### DIFF
--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/empty_resource_group.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/empty_resource_group.yml
@@ -32,7 +32,7 @@
   loop: "{{ r_resources.response }}"
   loop_control:
     loop_var: resource
-    label: "{{ resource.name }}"
+    label: "{{ resource.name | default(resource.id | default('unnamed resource')) }}"
 
 - name: Warn if Azure DevOps account could not be deleted (billing still linked)
   when:


### PR DESCRIPTION
## What Changed
Fixed loop_control.label template error in Azure DevOps resource cleanup task

## Why
Task was failing with: `Failed to template loop_control.label: 'dict object' has no attribute 'name'`

## Files Changed
- `ansible/roles/open-env-azure-remove-user-from-subscription/tasks/empty_resource_group.yml`:
  - Line 35: `{{ resource.name }}` → `{{ resource.name | default(resource.id | default('unnamed resource')) }}`

## Fix Details
The label template now uses a default filter chain:
1. Try `resource.name` first
2. Fall back to `resource.id` if name is missing
3. Fall back to `'unnamed resource'` if both are missing

This prevents template errors while still providing useful labels when attributes are available.

## Tested
- [x] Destroy job: https://prod1.apps.ocpv-infra02.wdc07.infra.demo.redhat.com/#/jobs/playbook/92745/output
- [ ] Integration deploy via rhpds/agnosticv#27661
- [ ] Cleanup task handles missing resource.name

## Impact
Fixes Azure subscription cleanup failures when Azure DevOps resources don't have name attribute

## Jira
GPTEINFRA-17534