### PR TITLE
Filter app registrations before loop in destroy role

### DIFF
--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -243,8 +243,7 @@
     - name: Delete open environment app registrations
       ansible.builtin.command: >-
         az rest --method DELETE --url https://graph.microsoft.com/v1.0/applications/{{ item.object_id }}
-      with_items: "{{ all_apps.applications }}"
-      when: item.app_display_name == oe_app_reg or item.app_display_name == oe_aro_app_reg
+      with_items: "{{ all_apps.applications | selectattr('app_display_name', 'in', [oe_app_reg, oe_aro_app_reg]) | list }}"
 
     - name: Remove pool allocation from the database
       ansible.builtin.uri:


### PR DESCRIPTION
## Summary
- The `Delete open environment app registrations` task in the destroy role iterates over **every app registration in the tenant** (~17,000+), producing ~17,000 `skipping` lines and 6.8MB of job output
- Pre-filters the list with `selectattr` before the loop so only the 2 target apps (`api://openenv-{guid}` and `api://openenv-aro-{guid}`) are iterated
- Reduces job output from ~18,000 lines to ~1,000 lines

## Change
```yaml
# Before: loops 17,000+ items, skips all but 2
with_items: "{{ all_apps.applications }}"
when: item.app_display_name == oe_app_reg or item.app_display_name == oe_aro_app_reg

# After: loops only the 2 matching items
with_items: "{{ all_apps.applications | selectattr('app_display_name', 'in', [oe_app_reg, oe_aro_app_reg]) | list }}"
```

## Test plan
- [x] Verified Jinja2 `selectattr('app_display_name', 'in', [...])` filter works with Ansible playbook locally
- [x] Confirmed filter returns empty list when no matches (safe for environments without app registrations)
- [ ] Run a destroy on a dev environment and verify job output is <1,000 lines