### PR TITLE
Make assisted-installer cluster install timeout configurable

### DIFF
--- a/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/tasks/main.yaml
@@ -512,8 +512,8 @@
       rhpds.assisted_installer.install_cluster:
         cluster_id: "{{ newcluster.result.id }}"
         offline_token: "{{ ai_offline_token }}"
-        wait_timeout: 5400
-      async: 5400
+        wait_timeout: "{{ ai_cluster_install_timeout }}"
+      async: "{{ ai_cluster_install_timeout }}"
       poll: 60
     - name: Obtain OpenShift cluster credentials
       register: ai_credentials

--- a/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
+++ b/ansible/roles/host-ocp4-assisted-installer/vars/main.yaml
@@ -14,6 +14,7 @@ ai_workers_memory: 64Gi
 ai_workers_root_disk_size: 100Gi
 ai_workers_vm_ready_retries: 30
 ai_workers_vm_ready_delay: 10
+ai_cluster_install_timeout: 5400
 ai_ocp_namespace: "{{ sandbox_openshift_namespace | default(env_type + '-' + guid)}}"
 ai_ocp_vmname_sno: "sno-{{ cluster_name }}"
 ai_ocp_vmname_master_prefix: "control-plane-{{ cluster_name }}"


### PR DESCRIPTION
## Summary
The `host-ocp4-assisted-installer` task **Start cluster installation** hardcodes `async: 5400` / `wait_timeout: 5400` (90 min). On Ceph-backed CNV environments the assisted-installer cluster install can run slightly past 90 minutes, so Ansible kills the still-progressing install with `Timeout exceeded`.

Observed in prod job 116558 (HCP-on-CNV, guid `bfgzt`): the install ran 13:30:53 → 15:02:03 = **91m 9s** and was killed while still polling `finished=0`.

## Change
- Add `ai_cluster_install_timeout` to `roles/host-ocp4-assisted-installer/vars/main.yaml`, defaulting to **5400** — behavior is unchanged for every existing consumer.
- Use the var for both `async` and `wait_timeout` on the install task.

This lets consumers raise the timeout via agnosticv **without** changing the conservative role default — the same pattern @agonzalezrh requested for `ai_workers_vm_ready_retries` on #9886 ("add a default value ... use agV to set a higher value").

The higher value for HCP-on-CNV is set in agnosticv (`ai_cluster_install_timeout: 7200`), not here.

Related: RHDPOPS-23971.