### PR TITLE
Fix workload ocp4_workload_s3_model_copy_to_minio

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_s3_model_copy_to_minio/templates/add-models-job.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_s3_model_copy_to_minio/templates/add-models-job.yaml.j2
@@ -20,10 +20,10 @@ spec:
             - '-ec'
             - |-
               # Install AWS CLI
-              pip install awscli
+              pip install awscli boto3==1.37.38
 
               # Install MinIO Client (mc)
-              curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+              curl -O --location https://dl.min.io/client/mc/release/linux-amd64/mc
               chmod +x mc
 
               # Set up AWS credentials


### PR DESCRIPTION
##### SUMMARY

Fix boto3 error when attempting to copy models to s3 using awscli

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_s3_model_copy_to_minio

##### ADDITIONAL INFORMATION
Error message found in the logs of `copy-models-to-minio` job via the Java4AI workshop:
```ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.```

This change fixes the boto3 dependency issue and encourages curl to follow redirects when needed.