### PR TITLE
perf(open-env-azure): use filtered Graph API query for app registration lookup

### DIFF
--- a/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
+++ b/ansible/roles/open-env-azure-remove-user-from-subscription/tasks/main.yml
@@ -159,18 +159,19 @@
         state: absent
       loop: "{{ role_assignments.roleassignments }}"
 
-    - name: Get all azure applications in the subscription
-      azure.azcollection.azure_rm_adapplication_info:
-        auth_source: cli
-        tenant: "{{ azure_tenant }}"
-      register: all_apps
-
-    - ansible.builtin.set_fact: oe_app_reg="api://openenv-{{ guid }}"
-    - ansible.builtin.set_fact: oe_aro_app_reg="api://openenv-aro-{{ guid }}"
-    - name: Delete open environment app registrations
+    - name: Find open environment app registrations by name
       ansible.builtin.command: >-
-        az rest --method DELETE --url https://graph.microsoft.com/v1.0/applications/{{ item.object_id }}
-      with_items: "{{ all_apps.applications | selectattr('app_display_name', 'in', [oe_app_reg, oe_aro_app_reg]) | list }}"
+        az ad app list
+        --filter "displayName eq 'api://openenv-{{ guid }}' or displayName eq 'api://openenv-aro-{{ guid }}'"
+        --query "[].id" -o tsv
+      register: r_openenv_app_ids
+      changed_when: false
+
+    - name: Delete open environment app registrations
+      when: r_openenv_app_ids.stdout_lines | length > 0
+      ansible.builtin.command: >-
+        az rest --method DELETE --url https://graph.microsoft.com/v1.0/applications/{{ item }}
+      loop: "{{ r_openenv_app_ids.stdout_lines }}"
 
     # ── Phase 3: Clean up DNS and resource groups ──
 


### PR DESCRIPTION
## Summary

- Replace `azure_rm_adapplication_info` (lists **all** tenant app registrations) with `az ad app list --filter` targeting the specific `api://openenv-{guid}` and `api://openenv-aro-{guid}` display names
- Server-side OData filter returns results in **<1 second** vs **~207 seconds** for the unfiltered full-tenant listing
- Handles both regular and ARO app registrations via a single `or` filter query

### Tested

```
$ time az ad app list --filter "displayName eq 'api://openenv-22nmc' or displayName eq 'api://openenv-aro-22nmc'" --query "[].id" -o tsv
bcf2c386-1689-ex-94c2-ex
d3b8f714-c9c1-ex-8c29-ex
0.65s total
```

Verified: returns both regular and ARO app object IDs, correctly returns empty for already-deleted apps.