### PR TITLE
fix: assign S3 driver versioning according to the OCP version

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/defaults/main.yml
@@ -18,3 +18,13 @@ ocp4_workload_create_rwx_volume_helm_s3_driver_repo_url: https://awslabs.github.
 
 ocp4_workload_create_rwx_volume_pv_storage: 1200Gi
 ocp4_workload_create_rwx_volume_pv_name: s3-volume-pv
+ocp4_workload_create_rwx_volume_pvc_name: s3-volume-pvc
+
+# Scoped IAM user for S3 CSI driver authentication.
+# Creates a dedicated IAM user with access limited to the S3 bucket only,
+# stores those credentials as a K8s Secret, and references it in the PV
+# via nodePublishSecretRef. Even if a customer reads the Secret (they have
+# cluster-admin), they can only access their own bucket.
+ocp4_workload_create_rwx_volume_iam_user_name: "s3-rwx-{{ guid }}-user"
+ocp4_workload_create_rwx_volume_iam_policy_name: "s3-rwx-{{ guid }}-policy"
+ocp4_workload_create_rwx_volume_k8s_secret_name: "s3-csi-{{ guid }}-credentials"

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/meta/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   role_name: ocp4_workload_create_rwx_volume
   author: Red Hat, Cluster Platform (ITCP) (itcp-team@redhat.com)
   description: |
-    Creates a S3 bucket and the PersistentVolume for it, accessing it as ReadWriteMany
+    Creates a S3 bucket, the PersistentVolume and the PersistentVolumeClaim for it, accessing it as ReadWriteMany
   license: MIT
   min_ansible_version: "2.9"
   platforms: []

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/remove_workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/remove_workload.yml
@@ -5,6 +5,91 @@
     - ocp4_workload_create_rwx_volume_enable | bool
   block:
     #############################################################################
+    # Remove PersistentVolume
+    #############################################################################
+
+    - name: Remove PersistentVolume
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: PersistentVolume
+        name: "{{ ocp4_workload_create_rwx_volume_pv_name }}"
+      ignore_errors: true
+
+    #############################################################################
+    # Remove Kubernetes Secret
+    #############################################################################
+
+    - name: Remove S3 CSI credentials secret
+      kubernetes.core.k8s:
+        state: absent
+        api_version: v1
+        kind: Secret
+        name: "{{ ocp4_workload_create_rwx_volume_k8s_secret_name }}"
+        namespace: kube-system
+      ignore_errors: true
+
+    #############################################################################
+    # Remove IAM resources (order: keys → detach policy → user → policy)
+    #############################################################################
+
+    - name: List access keys for scoped IAM user
+      ansible.builtin.command:
+        cmd: >-
+          aws iam list-access-keys
+          --user-name {{ ocp4_workload_create_rwx_volume_iam_user_name }}
+          --query 'AccessKeyMetadata[].AccessKeyId'
+          --output json
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+        AWS_DEFAULT_REGION: "{{ ocp4_workload_create_rwx_volume_region }}"
+      register: r_list_keys
+      ignore_errors: true
+
+    - name: Delete all access keys for scoped IAM user
+      when:
+        - r_list_keys is succeeded
+        - r_list_keys.stdout | default('') | length > 2
+      ansible.builtin.command:
+        cmd: >-
+          aws iam delete-access-key
+          --user-name {{ ocp4_workload_create_rwx_volume_iam_user_name }}
+          --access-key-id {{ item }}
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+        AWS_DEFAULT_REGION: "{{ ocp4_workload_create_rwx_volume_region }}"
+      loop: "{{ r_list_keys.stdout | default('[]') | from_json | default([]) }}"
+      ignore_errors: true
+
+    - name: Detach policy from IAM user
+      amazon.aws.iam_user:
+        name: "{{ ocp4_workload_create_rwx_volume_iam_user_name }}"
+        state: present
+        managed_policies: []
+        purge_policies: true
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+      ignore_errors: true
+
+    - name: Remove IAM user
+      amazon.aws.iam_user:
+        name: "{{ ocp4_workload_create_rwx_volume_iam_user_name }}"
+        state: absent
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+      ignore_errors: true
+
+    - name: Remove S3-only IAM policy
+      amazon.aws.iam_managed_policy:
+        policy_name: "{{ ocp4_workload_create_rwx_volume_iam_policy_name }}"
+        state: absent
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+      ignore_errors: true
+
+    #############################################################################
     # Clean up S3 bucket
     #############################################################################
     - name: Remove AWS S3 bucket

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/tasks/workload.yml
@@ -69,7 +69,7 @@
           ansible.builtin.shell: /usr/bin/helm completion bash >/etc/bash_completion.d/helm
 
     #############################################################################
-    # Setup S3 bucket and drivers
+    # Setup S3 bucket
     #############################################################################
 
     - name: Create AWS S3 bucket
@@ -80,12 +80,102 @@
         aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
         aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
 
+    #############################################################################
+    # Create scoped IAM user with access limited to this S3 bucket only
+    #############################################################################
+
+    - name: Create S3-only IAM policy
+      amazon.aws.iam_managed_policy:
+        policy_name: "{{ ocp4_workload_create_rwx_volume_iam_policy_name }}"
+        state: present
+        policy:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:PutObject
+                - s3:DeleteObject
+                - s3:ListBucket
+                - s3:GetBucketLocation
+              Resource:
+                - "arn:aws:s3:::{{ ocp4_workload_create_rwx_volume_s3_bucket_name }}"
+                - "arn:aws:s3:::{{ ocp4_workload_create_rwx_volume_s3_bucket_name }}/*"
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+      register: r_iam_policy
+
+    - name: Create dedicated IAM user for S3 CSI
+      amazon.aws.iam_user:
+        name: "{{ ocp4_workload_create_rwx_volume_iam_user_name }}"
+        state: present
+        managed_policies:
+          - "{{ r_iam_policy.policy.arn }}"
+        aws_access_key: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        aws_secret_key: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+
+    - name: Generate access keys for scoped IAM user
+      ansible.builtin.command:
+        cmd: >-
+          aws iam create-access-key
+          --user-name {{ ocp4_workload_create_rwx_volume_iam_user_name }}
+          --query 'AccessKey.{AccessKeyId: AccessKeyId, SecretAccessKey: SecretAccessKey}'
+          --output json
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ ocp4_workload_create_rwx_volume_access_key_id }}"
+        AWS_SECRET_ACCESS_KEY: "{{ ocp4_workload_create_rwx_volume_secret_access_key }}"
+        AWS_DEFAULT_REGION: "{{ ocp4_workload_create_rwx_volume_region }}"
+      register: r_scoped_key
+      no_log: true
+
+    - name: Parse scoped access key
+      ansible.builtin.set_fact:
+        _rwx_scoped_key: "{{ r_scoped_key.stdout | from_json }}"
+      no_log: true
+
+    - name: Store scoped credentials as Kubernetes Secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ ocp4_workload_create_rwx_volume_k8s_secret_name }}"
+            namespace: kube-system
+            labels:
+              app: s3-csi-rwx
+              guid: "{{ guid }}"
+          type: Opaque
+          stringData:
+            key_id: "{{ _rwx_scoped_key.AccessKeyId }}"
+            access_key: "{{ _rwx_scoped_key.SecretAccessKey }}"
+      no_log: true
+
+    #############################################################################
+    # Install S3 CSI driver
+    # The driver reads credentials from a fixed Secret at startup (not per-PV).
+    # We tell it to use our scoped secret via Helm awsAccessSecret.name.
+    #############################################################################
+
     - name: Install Amazon S3 CSI Driver
       block:
         - name: Add AWS helm repository
           kubernetes.core.helm_repository:
             name: aws-mountpoint-s3-csi-driver
             repo_url: "{{ ocp4_workload_create_rwx_volume_helm_s3_driver_repo_url }}"
+
+        - name: Set driver version
+          ansible.builtin.set_fact:
+            ocp4_workload_create_rwx_volume_helm_s3_driver_version: >-
+              {% if ocp4_installer_version is version_compare('4.18', '<') -%}
+              {{ '2.2.2' }}
+              {%- else -%}
+              {{ '' }}
+              {%- endif %}
+
+        - name: Debug driver version
+          ansible.builtin.debug:
+            msg: "Driver version: {{ ocp4_workload_create_rwx_volume_helm_s3_driver_version }}"
 
         - name: Deploy AWS Mountpoint S3 CSI Driver
           kubernetes.core.helm:
@@ -94,6 +184,12 @@
             release_namespace: kube-system
             create_namespace: true
             update_repo_cache: true
+            chart_version: >-
+              {{ ocp4_workload_create_rwx_volume_helm_s3_driver_version
+              | default(omit, true) }}
+            values:
+              awsAccessSecret:
+                name: "{{ ocp4_workload_create_rwx_volume_k8s_secret_name }}"
 
     #############################################################################
     # Setup PersistentVolume
@@ -103,6 +199,42 @@
       kubernetes.core.k8s:
         state: present
         resource_definition: "{{ lookup('template', 'persistent_volume.yaml.j2') }}"
+
+    #############################################################################
+    # Publish RWX volume info (visible in Babylon/ITCP portal)
+    #############################################################################
+
+    - name: Publish RWX volume user info
+      agnosticd_user_info:
+        msg: |
+          RWX Volume (S3-backed shared storage) is available.
+
+          S3 Bucket: {{ ocp4_workload_create_rwx_volume_s3_bucket_name }}
+          PV Name: {{ ocp4_workload_create_rwx_volume_pv_name }}
+          PVC Name: {{ ocp4_workload_create_rwx_volume_pvc_name }}
+
+          To use it, just use the created PVC or create your own similar to:
+
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: my-shared-storage
+          spec:
+            accessModes: [ReadWriteMany]
+            storageClassName: ""
+            resources:
+              requests:
+                storage: {{ ocp4_workload_create_rwx_volume_pv_storage }}
+            volumeName: {{ ocp4_workload_create_rwx_volume_pv_name }}
+
+    - name: Publish RWX volume data
+      agnosticd_user_info:
+        data:
+          rwx_volume_enabled: true
+          rwx_s3_bucket: "{{ ocp4_workload_create_rwx_volume_s3_bucket_name }}"
+          rwx_pv_name: "{{ ocp4_workload_create_rwx_volume_pv_name }}"
+          rwx_pvc_name: "{{ ocp4_workload_create_rwx_volume_pvc_name }}"
+          rwx_pv_storage: "{{ ocp4_workload_create_rwx_volume_pv_storage }}"
 
 # Leave this as the last task in the playbook.
 # --------------------------------------------

--- a/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/templates/persistent_volume.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4_workload_create_rwx_volume/templates/persistent_volume.yaml.j2
@@ -3,15 +3,35 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ ocp4_workload_create_rwx_volume_pv_name }}
+  namespace: default
 spec:
   capacity:
     storage: {{ ocp4_workload_create_rwx_volume_pv_storage }}
   accessModes:
     - ReadWriteMany
+  storageClassName: ""
+  claimRef:
+    namespace: default
+    name: {{ ocp4_workload_create_rwx_volume_pvc_name }}
   mountOptions:
     - allow-delete
+    - region {{ ocp4_workload_create_rwx_volume_region }}
   csi:
     driver: s3.csi.aws.com
-    volumeHandle: s3-csi-volume-marker
+    volumeHandle: s3-csi-{{ guid }}-handle
     volumeAttributes:
       bucketName: {{ ocp4_workload_create_rwx_volume_s3_bucket_name }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ ocp4_workload_create_rwx_volume_pvc_name }}
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: {{ ocp4_workload_create_rwx_volume_pv_storage }}
+  volumeName: {{ ocp4_workload_create_rwx_volume_pv_name }}


### PR DESCRIPTION
##### SUMMARY
Older versions of OCP can't install newer versions of `aws-mountpoint-s3-csi-driver`.
This PR fixes it by assigning the S3 driver version according to the OCP version.

This PR also creates scoped IAM user for S3 CSI driver authentication.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_create_rwx_volume

##### ADDITIONAL INFORMATION
- Testing done with multiple versions