### PR TITLE
Add Limitador Operator dependency to ocp4-workload-app-connect-ai

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_cl_kuadrant.yaml
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/tasks/provision_cl_kuadrant.yaml
@@ -11,6 +11,21 @@
     state: present
     resource_definition: "{{ lookup('template', 'kuadrant-operatorgroup.yaml.j2') }}"
 
+- name: Evaluate Limitador Operator Subscription
+  k8s:
+    state: present
+    resource_definition: "{{ lookup('template', 'limitador-subscription.yaml.j2') }}"
+
+- name: Wait for Limitador operator CRD to be present
+  k8s_info:
+    api_version: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    name: limitadors.limitador.kuadrant.io
+  register: crd_limitador
+  retries: 60
+  delay: 30
+  until: crd_limitador.resources | list | length == 1
+
 - name: Evaluate Kuadrant Subscription
   k8s:
     state: present

--- a/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/limitador-subscription.yaml.j2
+++ b/ansible/roles_ocp_workloads/ocp4-workload-app-connect-ai/templates/limitador-subscription.yaml.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: limitador-operator
+  namespace: kuadrant-system
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: limitador-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Problem
The `ocp4-workload-app-connect-ai` workload fails during provisioning because Kuadrant requires the Limitador Operator, which is not installed by the workload.

**Error:**
```
status.conditions[]:
  type: Ready
  status: False
  reason: MissingDependency
  message: [Limitador Operator] is not installed, please restart Kuadrant Operator pod once dependency has been installed
```

## Changes
This PR adds Limitador Operator installation to the workload:

1. **New template**: `limitador-subscription.yaml.j2` - Installs Limitador Operator from redhat-operators catalog
2. **Updated task flow** in `provision_cl_kuadrant.yaml`:
   - Install Limitador Operator subscription after OperatorGroup creation
   - Wait for Limitador CRD to be available
   - Proceed with Kuadrant installation

## Testing
- [ ] Test deployment in dev environment (summit-2026/lb2131-ai-data-flows)
- [ ] Verify Limitador Operator installs successfully
- [ ] Verify Kuadrant becomes Ready without MissingDependency error
- [ ] Create new tag once validated

## Affected Catalog Items
- `published/ai-data-flows` (Build fast and secure AI data flows with Red Hat Application Foundations and Connectivity Link)

## Related Tickets
- GPTEINFRA-17654
- RHDPSPPT-843