### PR TITLE
fix: aap-configuration dispatcher recovery for transient AAP outages

### DIFF
--- a/ansible/roles/ansible_automation_platform_configuration/tasks/aap-configuration.yml
+++ b/ansible/roles/ansible_automation_platform_configuration/tasks/aap-configuration.yml
@@ -25,30 +25,26 @@
             data:
               aap_controller_token: "{{ r_aap_token.ansible_facts.controller_token.token }}"
 
-    # - name: Run AAP Configuration dispatcher
-    #   ansible.builtin.import_role:
-    #     name: infra.aap_configuration.dispatch
+    - name: Run AAP configuration dispatcher
+      block:
+        - name: Include dispatcher
+          ansible.builtin.import_role:
+            name: infra.aap_configuration.dispatch
+      rescue:
+        - name: Wait for AAP to recover after transient failure
+          ansible.builtin.uri:
+            url: "{{ ansible_automation_platform_configuration_host }}/api/controller/v2/ping/"
+            method: GET
+            user: "{{ ansible_automation_platform_configuration_username }}"
+            password: "{{ ansible_automation_platform_configuration_password }}"
+            force_basic_auth: true
+            validate_certs: "{{ ansible_automation_platform_configuration_verify_ssl }}"
+            status_code: 200
+          register: _recovery_ping
+          until: _recovery_ping.status == 200
+          retries: 30
+          delay: 30
 
-  - name: Run AAP configuration dispatcher
-    block:
-      - name: Include dispatcher
-        ansible.builtin.import_role:
-          name: infra.aap_configuration.dispatch
-    rescue:
-      - name: Wait for AAP to recover after transient failure
-        ansible.builtin.uri:
-          url: "{{ ansible_automation_platform_configuration_host }}/api/controller/v2/ping/"
-          method: GET
-          user: "{{ ansible_automation_platform_configuration_username }}"
-          password: "{{ ansible_automation_platform_configuration_password }}"
-          force_basic_auth: true
-          validate_certs: "{{ ansible_automation_platform_configuration_verify_ssl }}"
-          status_code: 200
-        register: _recovery_ping
-        until: _recovery_ping.status == 200
-        retries: 30
-        delay: 30
-
-      - name: Re-run dispatcher after recovery
-        ansible.builtin.include_role:
-          name: infra.aap_configuration.dispatch
+        - name: Re-run dispatcher after recovery
+          ansible.builtin.include_role:
+            name: infra.aap_configuration.dispatch


### PR DESCRIPTION
## Summary

Fixes GPTEINFRA-17671 — high failure rate on MIG_FACTORY_DEMO.

**Root cause:** The AAP controller pod briefly crashes during the first project sync (git clone of `rhpds/ocp-virt.git` creates memory pressure from the manifest-triggered rolling restart). This causes `Connection refused` on `project_updates/1/` polling. The existing retry variables (`controller_configuration_projects_async_retries`, `controller_configuration_projects_async_delay`) don't help because `Connection refused` sets `finished: 1` on the async job immediately, satisfying `until: finished` and halting all retries.

**Changes:**

- Fixed YAML indentation: the `block/rescue` for the dispatcher was at 2-space indentation (task attribute level) instead of 4-space (inside `block:`), causing a parse error
- Removed the dead commented-out dispatcher task
- Added `rescue` block: on dispatcher failure, polls `/api/controller/v2/ping/` until AAP recovers (up to 15 min), then re-runs the dispatcher
- Re-run is safe because all `infra.aap_configuration` roles are idempotent

## Test plan

- [ ] Provision MIG_FACTORY_DEMO and confirm dispatcher completes without connection refused errors
- [ ] Verify idempotent re-run: manually kill the AAP controller pod mid-configuration and confirm rescue recovers and completes successfully