### PR TITLE
fix(ocp4_workload_showroom): fail fast when setup container crash-loops

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/defaults/main.yaml
@@ -114,6 +114,15 @@ ocp4_workload_showroom_automation_disable: false
 ocp4_workload_showroom_cloud_image: quay.io/rhpds/showroom-cloud:v1
 ocp4_workload_showroom_wait_retries: 300
 
+# Container waiting-state reasons that may mean the pod will not recover on its own.
+ocp4_workload_showroom_fatal_container_reasons:
+  - CrashLoopBackOff
+
+# Number of restarts to tolerate before treating a container stuck in one of
+# ocp4_workload_showroom_fatal_container_reasons as unrecoverable and failing fast,
+# instead of waiting out the full ocp4_workload_showroom_wait_retries budget.
+ocp4_workload_showroom_fatal_container_restart_threshold: 3
+
 
 # defaults for _showroom_user_data so env destroys don't fail
 _showroom_user_data:

--- a/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml
@@ -178,12 +178,26 @@
   register: r_pod_status
   retries: "{{ ocp4_workload_showroom_wait_retries | int }}"
   delay: 5
-  until:
-    - r_pod_status.resources | length > 0
-    - r_pod_status.resources[0].status.phase == 'Running'
-    - r_pod_status.resources[0].status.containerStatuses is defined
-    - r_pod_status.resources[0].status.containerStatuses | selectattr('ready', 'equalto', true) | list |
-      length == r_pod_status.resources[0].status.containerStatuses | length
+  until: >-
+    (r_pod_status.resources | length > 0) and
+    (
+      (
+        r_pod_status.resources[0].status.phase == 'Running' and
+        r_pod_status.resources[0].status.containerStatuses is defined and
+        r_pod_status.resources[0].status.containerStatuses | selectattr('ready', 'equalto', true) | list |
+          length == r_pod_status.resources[0].status.containerStatuses | length
+      )
+      or
+      (
+        (r_pod_status.resources[0].status.initContainerStatuses | default([])
+         + r_pod_status.resources[0].status.containerStatuses | default([]))
+        | selectattr('state.waiting', 'defined')
+        | selectattr('state.waiting.reason', 'in', ocp4_workload_showroom_fatal_container_reasons)
+        | map(attribute='restartCount', default=0) | map('int') | list
+        | select('ge', ocp4_workload_showroom_fatal_container_restart_threshold | int)
+        | list | length > 0
+      )
+    )
   ignore_errors: true
 
 - name: Get logs from all containers using k8s_log module


### PR DESCRIPTION
##### SUMMARY

The showroom pod readiness wait (`ansible/roles_ocp_workloads/ocp4_workload_showroom/tasks/deploy-showroom-helm-zerotouch.yaml`) would poll for the full `ocp4_workload_showroom_wait_retries` budget (default 300 retries x 5s delay = 25 min, worse if `ocp4_workload_showroom_wait_retries` is raised, e.g. to 600+) even when an init container (e.g. the `setup` container running the setup-automation scripts) is stuck in `CrashLoopBackOff` and will never recover on its own without intervention.

Confirmed via `oc get pod -o json` on a real failing pod:

```json
{
  "name": "setup",
  "restartCount": 9,
  "state": {
    "waiting": {
      "reason": "CrashLoopBackOff",
      "message": "back-off 5m0s restarting failed container=setup ..."
    }
  }
}
```

This change updates the `until:` condition on the "Check if showroom pod is running and ready" task to stop waiting early once any init or main container has been in a fatal waiting state (currently just `CrashLoopBackOff`) for at least `ocp4_workload_showroom_fatal_container_restart_threshold` restarts (default `3`), in addition to the existing success condition. The threshold tolerates a container that fails once or twice due to a transient issue and then recovers on a later restart, rather than failing on the very first crash.

Two new configurable defaults were added:
- `ocp4_workload_showroom_fatal_container_reasons` (default `[CrashLoopBackOff]`)
- `ocp4_workload_showroom_fatal_container_restart_threshold` (default `3`)

No changes were needed to the downstream failure-reporting tasks ("Get logs...", "Report pod failure with describe and logs") - they already key off `phase != Running or containerStatuses not ready` and already surface the `CrashLoopBackOff` reason and container logs in their report; they now just fire much sooner.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ocp4_workload_showroom

##### ADDITIONAL INFORMATION

Validated by rendering the exact `until:` Jinja expression (extracted from the edited YAML via PyYAML) against several pod-status payloads, including the real captured failure:

- Real failing pod, `restartCount: 9`, `CrashLoopBackOff` -> fails fast (as expected)
- Early crash-loop, `restartCount: 1`, `CrashLoopBackOff` -> keeps waiting/retrying
- Container recovers after 2 restarts, pod ends up `Running` and fully ready -> succeeds normally
- Normal init still in progress, no crash-loop -> keeps waiting, unaffected
- Exactly at threshold, `restartCount: 3`, `CrashLoopBackOff` -> fails fast right at the configured threshold
- `restartCount` returned as a string instead of int, or missing entirely -> handled correctly, no templating error

`yamllint` and `ansible-lint` pass on both edited files with no new violations (pre-existing warnings in unrelated lines/files are unchanged).

Made with [Cursor](https://cursor.com)