### PR TITLE
Fix wrong way to pull the image in coco module

### DIFF
--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/defaults/main.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/defaults/main.yml
@@ -22,7 +22,7 @@ ocp4_workload_coco_on_aro_image: ""
 ocp4_workload_coco_on_aro_authfile: "cluster-pull-secret.json"
 
 # CoCo tools image (set in agnosticv catalog)
-ocp4_workload_coco_on_aro_coco_tools_image: "quay.io/confidential-devhub/coco-tools:0.5.1"
+ocp4_workload_coco_on_aro_coco_tools_image: "quay.io/openshift_sandboxed_containers/coco-tools:0.5.1"
 
 # Workshop users (devel / uadmin), OAuth, RBAC, kubeconfigs, tmux — see tasks/workshop_users.yml
 ocp4_workload_coco_on_aro_setup_workshop_users: true

--- a/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
+++ b/ansible/roles_ocp_workloads/ocp4_workload_coco_on_aro/tasks/workload.yml
@@ -66,7 +66,8 @@
 
 - name: Pull coco-tools image to default podman location
   containers.podman.podman_image:
-    name: "{{ ocp4_workload_coco_on_aro_coco_tools_image }}"
+    name: "{{ ocp4_workload_coco_on_aro_coco_tools_image | regex_replace(':[^:]*$', '') }}"
+    tag: "{{ ocp4_workload_coco_on_aro_coco_tools_image | regex_replace('^.*:', '') }}"
     pull: true
   retries: 3
   delay: 10


### PR DESCRIPTION
<!--- Please read first:

https://github.com/redhat-cop/agnosticd/blob/development/docs/Contributing.adoc

-->
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions.
The approvers and mergers shouldn't have to interpret and guess by jumping right to the code. Context helps. -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the config, roles, task or feature below -->
ocp4_workload_coco_on_aro

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!-- ansible --version -->
<!-- pip freeze -->
```paste below

```
